### PR TITLE
Import react from react

### DIFF
--- a/Components/Base/NativeBaseComponent.js
+++ b/Components/Base/NativeBaseComponent.js
@@ -1,7 +1,7 @@
 /* @flow */
 'use strict';
 
-import React, {Component} from 'react-native';
+import React, {Component} from 'react';
 import lightTheme from '../Themes/light';
 
 export default class NativeBaseComponent extends Component {			

--- a/Components/Widgets/Badge.js
+++ b/Components/Widgets/Badge.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {Text} from 'react-native';
+import React from 'react';
+import {Text} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 

--- a/Components/Widgets/Button.js
+++ b/Components/Widgets/Button.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, { Text, TouchableOpacity } from 'react-native';
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 import Icon from './Icon';

--- a/Components/Widgets/Card.js
+++ b/Components/Widgets/Card.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {View} from 'react-native';
+import React from 'react';
+import {View} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 

--- a/Components/Widgets/CardItem.js
+++ b/Components/Widgets/CardItem.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {Image} from 'react-native';
+import React from 'react';
+import {Image} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 import Icon from './Icon';

--- a/Components/Widgets/CheckBox.js
+++ b/Components/Widgets/CheckBox.js
@@ -1,7 +1,7 @@
 /* @flow */
 'use strict';
 
-import React from 'react-native';
+import React from 'react';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 import Checkbox from 'react-native-checkbox';

--- a/Components/Widgets/Container.js
+++ b/Components/Widgets/Container.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {View } from 'react-native';
+import React from 'react';
+import {View} from 'react-native';
 import Header from './Header';
 import Content from './Content';
 import Footer from './Footer';

--- a/Components/Widgets/Content.js
+++ b/Components/Widgets/Content.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {ScrollView } from 'react-native';
+import React from 'react';
+import {ScrollView} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 

--- a/Components/Widgets/Footer.js
+++ b/Components/Widgets/Footer.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {View} from 'react-native';
+import React from 'react';
+import {View} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 

--- a/Components/Widgets/H1.js
+++ b/Components/Widgets/H1.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {Text } from 'react-native';
+import React from 'react';
+import {Text} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 

--- a/Components/Widgets/H2.js
+++ b/Components/Widgets/H2.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {Text } from 'react-native';
+import React from 'react';
+import {Text} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 

--- a/Components/Widgets/H3.js
+++ b/Components/Widgets/H3.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {Text } from 'react-native';
+import React from 'react';
+import {Text} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 

--- a/Components/Widgets/Header.js
+++ b/Components/Widgets/Header.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {View} from 'react-native';
+import React from 'react';
+import {View} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 

--- a/Components/Widgets/Icon.js
+++ b/Components/Widgets/Icon.js
@@ -1,7 +1,7 @@
 /* @flow */
 'use strict';
 
-import React from 'react-native';
+import React from 'react';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 import Icon from 'react-native-vector-icons/Ionicons';

--- a/Components/Widgets/Input.js
+++ b/Components/Widgets/Input.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {View, TextInput} from 'react-native';
+import React from 'react';
+import {View, TextInput} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 

--- a/Components/Widgets/InputGroup.js
+++ b/Components/Widgets/InputGroup.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {Text, View, PixelRatio } from 'react-native';
+import React from 'react';
+import {Text, View, PixelRatio} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import Icon from './Icon';
 import computeProps from '../../Utils/computeProps';

--- a/Components/Widgets/List.js
+++ b/Components/Widgets/List.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {View} from 'react-native';
+import React from 'react';
+import {View} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 import _ from 'lodash';

--- a/Components/Widgets/ListItem.js
+++ b/Components/Widgets/ListItem.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {Image} from 'react-native';
+import React from 'react';
+import {Image} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 import Icon from './Icon';

--- a/Components/Widgets/Picker.js
+++ b/Components/Widgets/Picker.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {Picker} from 'react-native';
+import React from 'react';
+import {Picker} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 

--- a/Components/Widgets/Switch.js
+++ b/Components/Widgets/Switch.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {Switch} from 'react-native';
+import React from 'react';
+import {Switch} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 

--- a/Components/Widgets/Text.js
+++ b/Components/Widgets/Text.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {Text } from 'react-native';
+import React from 'react';
+import {Text} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 

--- a/Components/Widgets/Thumbnail.js
+++ b/Components/Widgets/Thumbnail.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {Image} from 'react-native';
+import React from 'react';
+import {Image} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 import _ from 'lodash';

--- a/Components/Widgets/Title.js
+++ b/Components/Widgets/Title.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {Text, View } from 'react-native';
+import React from 'react';
+import {Text, View } from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 
 

--- a/Components/Widgets/View.js
+++ b/Components/Widgets/View.js
@@ -1,7 +1,8 @@
 /* @flow */
 'use strict';
 
-import React, {View } from 'react-native';
+import React from 'react';
+import {View} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 
 

--- a/Utils/computeProps.js
+++ b/Utils/computeProps.js
@@ -1,5 +1,3 @@
-var React = require('react-native');
-
 var StyleSheetRegistry = require('react-native/Libraries/ReactNative/ReactNativePropRegistry');
 
 module.exports = function(incomingProps, defaultProps) {

--- a/Utils/computeProps.js
+++ b/Utils/computeProps.js
@@ -1,11 +1,11 @@
-var StyleSheetRegistry = require('react-native/Libraries/ReactNative/ReactNativePropRegistry');
+import _ from 'lodash';
+import StyleSheetRegistry from 'react-native/Libraries/ReactNative/ReactNativePropRegistry';
 
 module.exports = function(incomingProps, defaultProps) {
 
-
     // External props has a higher precedence
     var computedProps = {};
-    
+
     incomingProps = _.clone(incomingProps);
     delete incomingProps.children;
 
@@ -13,26 +13,24 @@ module.exports = function(incomingProps, defaultProps) {
 
     if(incomingProps)
         _.merge(computedProps, defaultProps, incomingProps);
-    else 
+    else
         computedProps = defaultProps;
 
     // Pass the merged Style Object instead
     if(incomingProps.style) {
-
+        var incomingPropsStyle;
         if(typeof incomingProps.style == 'number') {
-            var incomingPropsStyle = StyleSheetRegistry.getStyleByID(incomingProps.style);
+            incomingPropsStyle = StyleSheetRegistry.getStyleByID(incomingProps.style);
             computedProps.style = {};
         } else {
-            var incomingPropsStyle = incomingProps.style;
+            incomingPropsStyle = incomingProps.style;
         }
 
-        _.merge(computedProps.style, defaultProps.style, incomingPropsStyle); 
+        _.merge(computedProps.style, defaultProps.style, incomingPropsStyle);
 
     }
 
     // console.log("computedProps ", computedProps);
-    
+
     return computedProps;
-
-
 }


### PR DESCRIPTION
in order to remove deprecation warnings introduced with react-native [0.25.1](https://github.com/facebook/react-native/releases/tag/v0.25.1)

Todo:
 * [ ] replace `import React from 'react-native'` with `import React from 'react'` in Components
 * [ ] do the same in the packages that are included in the vendor folder
  * [ ] react-native-calendar-picker
  * [ ] react-native-gifted-messenger
  * [ ] react-native-scrollable-tab-view

<img width="753" alt="bildschirmfoto 2016-05-05 um 12 12 12" src="https://cloud.githubusercontent.com/assets/596578/15041223/acd6daba-12ba-11e6-9f0f-3ffa219dbfbe.png">