### PR TITLE
Added checks for null children to CardItem

### DIFF
--- a/Components/Widgets/Card.js
+++ b/Components/Widgets/Card.js
@@ -37,9 +37,13 @@ export default class CardNB extends NativeBaseComponent {
 
     }
 
+    setNativeProps(nativeProps) {
+      this._root.setNativeProps(nativeProps);
+    }
+
     render() {
         return(
-            <View {...this.prepareRootProps()} >
+            <View ref={component => this._root = component} {...this.prepareRootProps()} >
                 {this.props.children}
             </View>
         );

--- a/Components/Widgets/CardItem.js
+++ b/Components/Widgets/CardItem.js
@@ -95,6 +95,7 @@ export default class ListItemNB extends NativeBaseComponent {
     thumbnailPresent() {
         var thumbnailComponentPresent = false;
         React.Children.forEach(this.props.children, function (child) {
+            if (!child) return;
             if(child.type == Thumbnail)
                 thumbnailComponentPresent = true;
         })
@@ -105,6 +106,7 @@ export default class ListItemNB extends NativeBaseComponent {
     imagePresent() {
         var imagePresent = false;
         React.Children.forEach(this.props.children, function (child) {
+            if (!child) return;
             if(child.type == Image)
                 imagePresent = true;
         })
@@ -115,6 +117,7 @@ export default class ListItemNB extends NativeBaseComponent {
     iconPresent() {
         var iconComponentPresent = false;
         React.Children.forEach(this.props.children, function (child) {
+            if (!child) return;
             if(child.type == Icon)
                 iconComponentPresent = true;
         })
@@ -125,6 +128,7 @@ export default class ListItemNB extends NativeBaseComponent {
     buttonPresent() {
         var buttonComponentPresent = false;
         React.Children.forEach(this.props.children, function (child) {
+            if (!child) return;
             if(child.type == Button)
                 buttonComponentPresent = true;
         })
@@ -147,6 +151,7 @@ export default class ListItemNB extends NativeBaseComponent {
         var notePresent = false;
 
         React.Children.forEach(this.props.children, function (child) {
+            if (!child) return;
             if(child.type == Text && child.props.note)
                 notePresent = true;
         });
@@ -158,6 +163,7 @@ export default class ListItemNB extends NativeBaseComponent {
         var squareThumbs = false;
         if (this.thumbnailPresent()) {
             React.Children.forEach(this.props.children, function (child) {
+                if (!child) return;
                 if(child.props.square)
                     squareThumbs = true;
             });
@@ -254,8 +260,9 @@ export default class ListItemNB extends NativeBaseComponent {
         var newChildren = [];
 
         if(!this.thumbnailPresent() && !this.iconPresent()) {
-            
+
             newChildren = React.Children.map(this.props.children, (child) => {
+                if (!child) return;
                 return React.cloneElement(child, this.getChildProps(child));
             });
         }


### PR DESCRIPTION
I've added some checks to make sure children are defined before accessing their props. Otherwise, when you add conditional children to `CardItem` components, it throws an exception, e.g.:

```
<CardItem>
    <Text>A heading</Text>
    {someVar && <Text>Conditional test</Text>}
</CardItem>
```
