### PR TITLE
Header: show dark theme by default just like the documentation samples

### DIFF
--- a/Components/Base/NativeBaseComponent.js
+++ b/Components/Base/NativeBaseComponent.js
@@ -2,7 +2,7 @@
 'use strict';
 
 import React, {Component} from 'react';
-import lightTheme from '../Themes/light';
+import darkTheme from '../Themes/dark';
 
 export default class NativeBaseComponent extends Component {			
 	static contextTypes = {
@@ -32,6 +32,6 @@ export default class NativeBaseComponent extends Component {
 	}
 
 	getTheme() {
-		return this.props.theme ? this.props.theme : this.context.theme || lightTheme
+		return this.props.theme ? this.props.theme : this.context.theme || darkTheme
 	}
 }


### PR DESCRIPTION
New peps will be confused just like me that the theme is different from what the docs is using.