### PR TITLE
Fix error when adding props with components to NativeBase widgets

### DIFF
--- a/Utils/computeProps.js
+++ b/Utils/computeProps.js
@@ -14,9 +14,14 @@ module.exports = function(incomingProps, defaultProps) {
     delete incomingProps.style;
 
     // console.log(defaultProps, incomingProps);
-    if(incomingProps)
-        _.merge(computedProps, defaultProps, incomingProps);
-    else
+    if(incomingProps) {
+        try {
+            _.merge(computedProps, defaultProps, incomingProps);
+        } catch (exception) {
+            console.log('Warning: Call stack size exceeded when merging props, falling back to shallow merge.');
+            _.assign(computedProps, defaultProps, incomingProps);
+        }
+    } else
         computedProps = defaultProps;
     // Pass the merged Style Object instead
     if(incomingPropsStyle) {


### PR DESCRIPTION
When I tried to add a `refreshControl` prop to `<Content>` to enable pull-to-refresh feature, a `Maximum call stack size exceeded` error was thrown and app crashed.
```
<Content refreshControl={
    <RefreshControl
	  refreshing={this.props.isFetching}
	  onRefresh={() => this.props.dispatch(fetchData())}
    />
}>
```
Actually, I found that passing a prop with a component as value to any components from NativeBase, such as `<Card myCustomProp={<Text>hello</Text>} />`, results in the same error.

The problem is, in the `computeProps()` function which is called by every NativeBase widget in `NativeBaseComponent` class, styled default props and incoming props are recursively merged with `_.merge()`. When the incoming props contain a React component, the merge is too deep to finish and crash occurs. 

My workaround is to add a try catch clause and use shallow merge as fallback. That's gonna work and we can finally add `refreshControl` prop to `<Content>`.