### PR TITLE
Add .filter() call on this.props.children

### DIFF
--- a/Components/Widgets/Tabs.js
+++ b/Components/Widgets/Tabs.js
@@ -33,7 +33,7 @@ export default class TabNB extends NativeBaseComponent {
     render() {
         return(
             <ScrollableTabView {...this.prepareRootProps()} >
-            {this.props.children}
+            {this.props.children.filter(child => child)}
             </ScrollableTabView>
         );
     }


### PR DESCRIPTION
I was encountering a problem, where if a null value was passed as a child to Component, it threw a few errors.
This .filter() removes all falsey values from this.props.children, preventing the errors, and returning the correct result.