### PR TITLE
Allow null block inside InputGroup Component

### DIFF
--- a/Components/Widgets/InputGroup.js
+++ b/Components/Widgets/InputGroup.js
@@ -127,7 +127,6 @@ export default class InputGroup extends NativeBaseComponent {
 		var inputProps = {};
 		var newChildren = [];
 		var childrenArray = React.Children.toArray(this.props.children);
-		console.log('childrenArray: ', this.props.children)
 
 		var iconElement = [];
 		iconElement = _.remove(childrenArray, function(item) {

--- a/Components/Widgets/InputGroup.js
+++ b/Components/Widgets/InputGroup.js
@@ -68,7 +68,6 @@ export default class InputGroup extends NativeBaseComponent {
 	}
 
 	prepareRootProps() {
-
 		var type = {
 			paddingLeft:  (this.props.borderType === 'rounded' && !this.props.children.type == Icon) ? 15 :
 			(this.props.children.type == Icon ) ? this.getTheme().inputPaddingLeftIcon : 5
@@ -89,7 +88,6 @@ export default class InputGroup extends NativeBaseComponent {
 	}
 
 	getIconProps(icon) {
-
 		var defaultStyle = {
 			fontSize: (this.props.toolbar || this.props.atoolbar) ? this.getTheme().toolbarIconSize : 27,
 			alignSelf: 'center',
@@ -126,10 +124,10 @@ export default class InputGroup extends NativeBaseComponent {
 
 
 	renderChildren() {
-
 		var inputProps = {};
 		var newChildren = [];
 		var childrenArray = React.Children.toArray(this.props.children);
+		console.log('childrenArray: ', this.props.children)
 
 		var iconElement = [];
 		iconElement = _.remove(childrenArray, function(item) {
@@ -166,7 +164,7 @@ export default class InputGroup extends NativeBaseComponent {
 
 		if(Array.isArray(this.props.children)) {
 
-			if(this.props.iconRight) {
+			if(this.props.iconRight && iconElement.length > 0) {
 				if(clonedInp) {
 					newChildren.push(clonedInp);
 				}
@@ -211,7 +209,9 @@ export default class InputGroup extends NativeBaseComponent {
 						}
 					));
 				} else {
-					newChildren.push(React.cloneElement(iconElement[0], this.getIconProps(iconElement[0])));
+					if(iconElement.length > 0){
+					  newChildren.push(React.cloneElement(iconElement[0], this.getIconProps(iconElement[0])));
+					}
 					if(clonedInp) {
 						newChildren.push(clonedInp);
 	 				}


### PR DESCRIPTION
Currently, the following snippet: 

```js
...
  <InputGroup>
    {null}
    <Input />
  </InputGroup>
...
```
Results in this error:
```sh
InputGroup.getIconProps
    InputGroup.js:105
InputGroup.renderChildren
    InputGroup.js:171
InputGroup.render
    InputGroup.js:236
<unknown>
    ReactCompositeComponent.js:793
measureLifeCyclePerf
    ReactCompositeComponent.js:74
ReactCompositeComponentWrapper._renderValidatedComponentWithoutOwnerOrContext
    ReactCompositeComponent.js:792
ReactCompositeComponentWrapper._renderValidatedComponent
    ReactCompositeComponent.js:819
ReactCompositeComponentWrapper.performInitialMount
    ReactCompositeComponent.js:361
ReactCompositeComponentWrapper.mountComponent
    ReactCompositeComponent.js:257
Object.mountComponent
    ReactReconciler.js:47
```

This update allows for inserting a null value inside the InputGroup block, making something like the following possible:

```js
...
  <InputGroup>
    { displayIcon ? myIcon : null }
    <Input />
  </InputGroup>
...
```

It appears that this update also addresses #137 

