### PR TITLE
Ensure that <Tabs /> props.children is an array

### DIFF
--- a/Components/Widgets/Tabs.js
+++ b/Components/Widgets/Tabs.js
@@ -31,11 +31,12 @@ export default class TabNB extends NativeBaseComponent {
     }
 
     render() {
-        return(
-            <ScrollableTabView {...this.prepareRootProps()} >
-            {this.props.children.filter(child => child)}
-            </ScrollableTabView>
-        );
+		var children = Array.isArray(this.props.children) ? this.props.children : [this.props.children];
+		return(
+			<ScrollableTabView {...this.prepareRootProps()} >
+				{children.filter(child => child)}
+			</ScrollableTabView>
+		);
     }
 
 }


### PR DESCRIPTION
If only one child is given, this.props.children is not an array of objects, just a single object, breaking both .filter() in this file, and .map() in the ScrollableTabView component.

This checks if this.props.children is an array, and creates a single item array if it's not, thus allowing .filter() and .map() calls.