### PR TITLE
create new object instead of setting the padding directly on props in Content component

### DIFF
--- a/Components/Widgets/Content.js
+++ b/Components/Widgets/Content.js
@@ -34,8 +34,8 @@ export default class Content extends NativeBaseComponent {
   }
 
   render() {
-    const contentContainerStyle = this.props.contentContainerStyle || {};
-    contentContainerStyle.padding = (this.props.padder) ? this.getTheme().contentPadding : 0;
+    const padding = (this.props.padder) ? this.getTheme().contentPadding : 0;
+    const contentContainerStyle = {padding, ...this.props.contentContainerStyle};
     return(
       <KeyboardAwareScrollView automaticallyAdjustContentInsets={false} ref={c => this._scrollview = c} {...this.prepareRootProps()} contentContainerStyle={contentContainerStyle}>{this.props.children}</KeyboardAwareScrollView>
     );


### PR DESCRIPTION
Hey,

I ran into crashes as my props were somehow converted into immutable objects. Maybe there are some performance things happening in newer versions of react-native and thus this error hasn't surfaced before.

Anyways, here's a pull request that doesn't directly modify the props object and allows overwriting of the padding by the user :)
