### PR TITLE
Fix Header when a `null` child is being passed

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react-native"]
+}

--- a/Components/Widgets/Header.js
+++ b/Components/Widgets/Header.js
@@ -1,8 +1,8 @@
 /* @flow */
 'use strict';
 
-import React from 'react';
-import { Platform} from 'react-native';
+import React, { cloneElement } from 'react';
+import { Platform } from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
 import Button from './Button';
@@ -10,7 +10,58 @@ import View from './View';
 import Title from './Title';
 import InputGroup from './InputGroup';
 import Subtitle from './Subtitle';
-import _ from 'lodash';
+
+const baseButtonStyle = {
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    flexDirection: 'row',
+};
+const iOSButtonStyle = Object.assign({}, baseButtonStyle, {
+    marginLeft: -14
+});
+const iOSHeaderBtnListStyle = Object.assign({}, baseButtonStyle, {
+    marginRight: -14
+});
+const iOSSearchBarSearchBtnStyle = Object.assign({}, baseButtonStyle, {
+    justifyContent: 'center',
+    marginRight: -14
+});
+const androidHeaderBtnStyle = Object.assign({}, baseButtonStyle, {
+    marginLeft: -10,
+    marginRight: 12
+});
+const androidHeaderBtnListStyle = Object.assign({}, baseButtonStyle, {
+    marginRight: -7
+});
+
+
+const iOSSingleButtonTitleStyle = {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 13,
+    bottom: 0,
+    alignSelf: 'center',
+    justifyContent: 'center'
+};
+const baseTitleStyle = {
+    flex: 3,
+    alignSelf: 'stretch'
+};
+const androidHeaderTitleStyle = Object.assign({}, baseTitleStyle, {
+    justifyContent: 'center'
+});
+const baseSearchBarStyle = {
+    flex: 1,
+    alignSelf: 'center',
+    justifyContent: 'flex-start',
+    flexDirection: 'row',
+    marginLeft: -7
+};
+const androidSearchBarStyle = Object.assign({}, baseSearchBarStyle, {
+    marginLeft: -8,
+    marginRight: -8
+});
 
 export default class Header extends NativeBaseComponent {
 
@@ -19,9 +70,9 @@ export default class Header extends NativeBaseComponent {
         rounded : React.PropTypes.bool,
         style : React.PropTypes.object,
         iconRight: React.PropTypes.bool
-    }
+    };
 
-    getInitialStyle() {
+    getInitialStyle () {
         return {
             navbar: {
                 backgroundColor: this.getTheme().toolbarDefaultBg,
@@ -32,7 +83,7 @@ export default class Header extends NativeBaseComponent {
                 paddingHorizontal: 15,
                 paddingTop: (Platform.OS === 'ios' ) ? 15 : 0,
                 shadowColor: '#000',
-                shadowOffset: {width: 0, height: 2},
+                shadowOffset: { width: 0, height: 2 },
                 shadowOpacity: 0.1,
                 shadowRadius: 1.5,
                 height: this.getTheme().toolbarHeight,
@@ -44,14 +95,14 @@ export default class Header extends NativeBaseComponent {
                 borderRadius: this.props.rounded ? 25 : 2,
                 height: 30,
                 borderColor: 'transparent',
-                flex:1
+                flex: 1
             },
             androidToolbarSearch: {
                 backgroundColor: '#fff',
                 borderRadius: 2,
                 borderColor: 'transparent',
                 elevation: 2,
-                flex:1
+                flex: 1
             },
             toolbarButton: {
                 paddingHorizontal: 15
@@ -59,126 +110,174 @@ export default class Header extends NativeBaseComponent {
         }
     }
 
-    prepareRootProps() {
-
-        var defaultProps = {
-            style: this.getInitialStyle().navbar
-        };
-
-        return computeProps(this.props, defaultProps);
-
-    }
-    renderChildren() {
-        if(!Array.isArray(this.props.children)) {
+    renderChildren () {
+        if (!Array.isArray(this.props.children)) {
             return this.props.children;
         }
 
-        else if (Array.isArray(this.props.children)) {
-            var newChildren = [];
-            var childrenArray = React.Children.toArray(this.props.children);
+        const children = React.Children.toArray(this.props.children);
 
-            var buttons = [];
-            buttons = _.remove(childrenArray, function(item) {
-                if(item.type == Button) {
-                    return true;
-                }
-            });
+        const buttons = children.filter((item) => item.type == Button);
+        const title = children.filter((item) => item.type == Title);
+        const subtitle = children.filter((item) => item.type == Subtitle);
+        const input = children.filter((item) => item.type == InputGroup);
 
-            var title = [];
-            title = _.remove(childrenArray, function(item) {
-                if(item.type == Title) {
-                    return true;
-                }
-            });
-
-            var subtitle = [];
-            subtitle = _.remove(childrenArray, function(item) {
-                if(item.type == Subtitle) {
-                    return true;
-                }
-            });
-
-            var input = [];
-            input = _.remove(childrenArray, function(item) {
-                if(item.type == InputGroup) {
-                    return true;
-                }
-            });
-
-            if (buttons.length == 1 && this.props.iconRight) {
-                if (Platform.OS === 'ios') {
-                    newChildren.push(<View key='title' style={{position: 'absolute', left: 0, right: 0, top: 13, bottom: 0, alignSelf: 'center', justifyContent: 'center'}}>
-                    {[title[0],subtitle[0]]}
-                    </View>)
-                    newChildren.push(<View key='title2' style={{flex: 3, alignSelf: 'stretch'}} />)
-                    newChildren.push(<View key='btn1' style={{alignItems: 'center', justifyContent: 'flex-start', flexDirection: 'row', marginLeft: -14}}>
-                    {React.cloneElement(buttons[0], {color: this.getTheme().iosToolbarBtnColor, style: this.getInitialStyle().toolbarButton})}
-                    </View>)
-                }
-                else {
-                    newChildren.push(<View key='title' style={{flex: 3, alignSelf: 'stretch', justifyContent: 'center'}}>
-                    {[title[0]]}
-                    </View>)
-                    newChildren.push(<View key='btn1' style={{alignItems: 'center', justifyContent: 'flex-start', flexDirection: 'row', marginLeft: -10, marginRight: 12}}>
-                    {React.cloneElement(buttons[0], {style: this.getInitialStyle().toolbarButton, header : true, textStyle: {color: this.getTheme().toolbarTextColor}})}
-                    </View>)
-                }
+        if (buttons.length == 1 && this.props.iconRight) {
+            if (Platform.OS === 'ios') {
+                return this.renderIOSSingleButton(title, subtitle, buttons)
             }
+            return this.renderAndroidSingleButton(title, buttons)
+        }
 
-            else if (this.props.searchBar) {
-                if (Platform.OS === 'ios') {
-                    newChildren.push(<View key='search' style={{flex: 1, alignSelf: 'center', justifyContent: 'flex-start', flexDirection: 'row', marginLeft: -7}}>
-                        {React.cloneElement(input[0],{style: this.getInitialStyle().iosToolbarSearch, toolbar : true, key : 'inp'})}
-                        </View>)
-                        newChildren.push(<View key='searchBtn' style={{alignItems: 'center', justifyContent: 'center', flexDirection: 'row', marginRight: -14}}>
-                        {React.cloneElement(buttons[0], {color: this.getTheme().iosToolbarBtnColor, style: this.getInitialStyle().toolbarButton})}
-                        </View>)
-                    } else {
-                        newChildren.push(<View key='search' style={{flex: 1,alignSelf: 'center', justifyContent: 'flex-start', flexDirection: 'row', marginLeft: -8, marginRight: -8}}>
-                        {React.cloneElement(input[0],{style: this.getInitialStyle().androidToolbarSearch, atoolbar : true})}
-                        </View>)
-                    }
-                }
-                else {
-                    if (Platform.OS === 'ios') {
-                        newChildren.push(<View key='title' style={{position: 'absolute', left: 0, right: 0, top: 13, bottom: 0, alignSelf: 'center', justifyContent: 'center'}}>
-                        {[title[0],subtitle[0]]}
-                        </View>)
-                        newChildren.push(<View key='btn1' style={{alignItems: 'center', justifyContent: 'flex-start', flexDirection: 'row', marginLeft: -14}}>
-                        {React.cloneElement(buttons[0], {color: this.getTheme().iosToolbarBtnColor, style: this.getInitialStyle().toolbarButton})}
-                        </View>)
-                        newChildren.push(<View key='title2' style={{flex: 3, alignSelf: 'stretch'}} />)
-                        if (buttons.length>1) {
-                            for (let i = 1; i < buttons.length; i++) {
-                                newChildren.push(<View key={'btn' + (i+1)} style={{alignItems: 'center', justifyContent: 'flex-start', flexDirection: 'row', marginRight: -14}}>
-                                {React.cloneElement(buttons[i], {color: this.getTheme().iosToolbarBtnColor, style: this.getInitialStyle().toolbarButton})}
-                                </View>)
-                            }
-                        }
-                    }
-                    else {
-                        newChildren.push(<View key='btn1' style={{alignItems: 'center', justifyContent: 'flex-start', flexDirection: 'row', marginLeft: -10, marginRight: 12}}>
-                        {React.cloneElement(buttons[0], {style: this.getInitialStyle().toolbarButton, header : true, textStyle: {color: this.getTheme().toolbarTextColor}})}
-                        </View>)
-                        newChildren.push(<View key='title' style={{flex: 3, alignSelf: 'stretch', justifyContent: 'center'}}>
-                        {[title[0]]}
-                        </View>)
-                        for (let i = 1; i < buttons.length; i++) {
-                            newChildren.push(<View key={'btn' + (i+1)} style={{alignItems: 'center', justifyContent: 'flex-start', flexDirection: 'row', marginRight: -7}}>
-                            {React.cloneElement(buttons[i], {style: this.getInitialStyle().toolbarButton, header : true, textStyle: {color: this.getTheme().toolbarTextColor}})}
-                            </View>)
-                        }
-                    }
+        if (this.props.searchBar) {
+            if (Platform.OS === 'ios') {
+                return this.renderIOSSearchBar(input, buttons)
+            }
+            return this.renderAndroidSearchBar(input)
+        }
 
-                }
-                return newChildren;
+        if (Platform.OS === 'ios') {
+            return this.renderIOSHeader(title, subtitle, buttons)
+        }
+        return this.renderAndroidHeader(buttons, title)
+    }
+
+    renderAndroidHeader (buttons, title) {
+        const elements = [];
+        elements.push(
+            <View key='btn1' style={androidHeaderBtnStyle}>
+                {cloneElement(buttons[0], {
+                    style: this.getInitialStyle().toolbarButton,
+                    header: true,
+                    textStyle: { color: this.getTheme().toolbarTextColor }
+                })}
+            </View>
+        );
+        elements.push(<View key='title' style={androidHeaderTitleStyle}>{title[0]}</View>);
+
+        for (let i = 1; i < buttons.length; i++) {
+            elements.push(
+                <View key={'btn' + (i + 1)} style={androidHeaderBtnListStyle}>
+                    {cloneElement(buttons[i], {
+                        style: this.getInitialStyle().toolbarButton,
+                        header: true,
+                        textStyle: { color: this.getTheme().toolbarTextColor }
+                    })}
+                </View>
+            );
+        }
+        return elements;
+    }
+
+    renderIOSHeader (title, subtitle, buttons) {
+        const elements = [];
+        elements.push(<View key='title' style={iOSSingleButtonTitleStyle}>{[ title[0], subtitle[0] ]}</View>);
+        elements.push(
+            <View key='btn1' style={iOSButtonStyle}>
+                {cloneElement(buttons[0], {
+                    color: this.getTheme().iosToolbarBtnColor,
+                    style: this.getInitialStyle().toolbarButton
+                })}
+            </View>
+        );
+
+        elements.push(<View key='title2' style={baseTitleStyle}/>);
+
+        if (buttons.length > 1) {
+            for (let i = 1; i < buttons.length; i++) {
+                elements.push(
+                    <View key={'btn' + (i + 1)} style={iOSHeaderBtnListStyle}>
+                        {cloneElement(buttons[i], {
+                            color: this.getTheme().iosToolbarBtnColor,
+                            style: this.getInitialStyle().toolbarButton
+                        })}
+                    </View>
+                );
             }
         }
 
-        render() {
-            return(
-            <View {...this.prepareRootProps()} >
-            {this.renderChildren()}
+        return elements;
+    }
+
+    renderAndroidSearchBar (input) {
+        return (
+            <View key='search' style={androidSearchBarStyle}>
+                {cloneElement(input[0], {
+                    style: this.getInitialStyle().androidToolbarSearch,
+                    atoolbar: true
+                })}
+            </View>
+        );
+    }
+
+    renderIOSSearchBar (input, buttons) {
+        const elements = [];
+
+        elements.push(
+            <View key='search' style={baseSearchBarStyle}>
+                {cloneElement(input[0], {
+                    style: this.getInitialStyle().iosToolbarSearch,
+                    toolbar: true,
+                    key: 'inp'
+                })}
+            </View>
+        );
+        elements.push(
+            <View key='searchBtn' style={iOSSearchBarSearchBtnStyle}>
+                {cloneElement(buttons[0], {
+                    color: this.getTheme().iosToolbarBtnColor,
+                    style: this.getInitialStyle().toolbarButton
+                })}
+            </View>
+        );
+
+        return elements;
+    }
+
+    renderAndroidSingleButton (title, buttons) {
+        const elements = [];
+
+        elements.push(
+            <View key='title' style={androidHeaderTitleStyle}>
+                {[ title[0] ]}
+            </View>
+        );
+        elements.push(
+            <View key='btn1' style={androidHeaderBtnStyle}>
+                {cloneElement(buttons[0], {
+                    style: this.getInitialStyle().toolbarButton,
+                    header: true,
+                    textStyle: { color: this.getTheme().toolbarTextColor }
+                })}
+            </View>
+        );
+
+        return elements;
+    }
+
+    renderIOSSingleButton (title, subtitle, buttons) {
+        const elements = [];
+        elements.push(<View key='title' style={iOSSingleButtonTitleStyle}>{[ title[0], subtitle[0] ]}</View>);
+        elements.push(<View key='title2' style={baseTitleStyle}/>);
+        elements.push(
+            <View key='btn1' style={iOSButtonStyle}>
+                {cloneElement(buttons[0], {
+                    color: this.getTheme().iosToolbarBtnColor,
+                    style: this.getInitialStyle().toolbarButton
+                })}
+            </View>
+        );
+
+        return elements;
+    }
+
+    render () {
+        const rootProps = computeProps(this.props, {
+            style: this.getInitialStyle().navbar
+        });
+        return (
+            <View {...rootProps}>
+                {this.renderChildren()}
             </View>
         );
     }

--- a/Components/Widgets/Header.js
+++ b/Components/Widgets/Header.js
@@ -116,6 +116,9 @@ export default class Header extends NativeBaseComponent {
         }
 
         const children = React.Children.toArray(this.props.children);
+        if(children.length === 1) {
+            return children;
+        }
 
         const buttons = children.filter((item) => item.type == Button);
         const title = children.filter((item) => item.type == Title);

--- a/__tests__/Components/Widgets/Header.android.js
+++ b/__tests__/Components/Widgets/Header.android.js
@@ -40,6 +40,16 @@ it('renders header with buttons', () => {
     expect(tree).toMatchSnapshot();
 });
 
+it('renders header with a null button', () => {
+    const tree = renderer.create(
+        <Header>
+            {null}
+            <Title>Header</Title>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
 it('renders header with buttons and subtitle', () => {
     const tree = renderer.create(
         <Header>

--- a/__tests__/Components/Widgets/Header.android.js
+++ b/__tests__/Components/Widgets/Header.android.js
@@ -1,0 +1,132 @@
+import 'react-native';
+import React from 'react';
+import Header from '../../../Components/Widgets/Header';
+import Button from '../../../Components/Widgets/Button';
+import Icon from '../../../Components/Widgets/Icon';
+import Title from '../../../Components/Widgets/Title';
+import Subtitle from '../../../Components/Widgets/Subtitle';
+
+// Note: test renderer must be required after react-native.
+import renderer from 'react-test-renderer';
+
+jest.mock('Platform', () => {
+    const Platform = require.requireActual('Platform');
+    Platform.OS = 'android';
+    return Platform;
+});
+jest.mock('ScrollView', () => 'ScrollView');
+
+it('renders correctly', () => {
+    const tree = renderer.create(
+        <Header />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with buttons', () => {
+    const tree = renderer.create(
+        <Header>
+            <Button transparent>
+                <Icon name='ios-arrow-back' />
+            </Button>
+
+            <Title>Header</Title>
+
+            <Button transparent>
+                <Icon name='ios-menu' />
+            </Button>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with buttons and subtitle', () => {
+    const tree = renderer.create(
+        <Header>
+            <Button transparent>
+                <Icon name='ios-arrow-back' />
+            </Button>
+
+            <Title>Header</Title>
+            <Subtitle>Subtitle</Subtitle>
+
+            <Button transparent>
+                <Icon name='ios-menu' />
+            </Button>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with just one button', () => {
+    const tree = renderer.create(
+        <Header>
+            <Button transparent>
+                <Icon name='ios-arrow-back' />
+            </Button>
+
+            <Title>Header</Title>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with just one button and subtitle', () => {
+    const tree = renderer.create(
+        <Header>
+            <Button transparent>
+                <Icon name='ios-arrow-back' />
+            </Button>
+
+            <Title>Header</Title>
+            <Subtitle>Subtitle</Subtitle>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with just one button and iconRight', () => {
+    const tree = renderer.create(
+        <Header iconRight>
+            <Button transparent>
+                <Icon name='ios-arrow-back' />
+            </Button>
+
+            <Title>Header</Title>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with just one button, iconRight and a subtitle', () => {
+    const tree = renderer.create(
+        <Header iconRight>
+            <Button transparent>
+                <Icon name='ios-arrow-back' />
+            </Button>
+
+            <Title>Header</Title>
+            <Subtitle>SubTitle</Subtitle>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+// jest-react-native doesn't work yet with that and mocking didn't work either.
+/*
+it('renders header with searchbar', () => {
+    const tree = renderer.create(
+        <Header searchBar rounded>
+            <InputGroup>
+                <Icon name='ios-search' />
+                <Input placeholder='Search' />
+                <Icon name='ios-people' />
+            </InputGroup>
+            <Button transparent>
+                Search
+            </Button>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+*/

--- a/__tests__/Components/Widgets/Header.ios.js
+++ b/__tests__/Components/Widgets/Header.ios.js
@@ -1,0 +1,130 @@
+import 'react-native';
+import React from 'react';
+import Header from '../../../Components/Widgets/Header';
+import Button from '../../../Components/Widgets/Button';
+import Icon from '../../../Components/Widgets/Icon';
+import Title from '../../../Components/Widgets/Title';
+import InputGroup from '../../../Components/Widgets/InputGroup';
+import Input from '../../../Components/Widgets/Input';
+import Subtitle from '../../../Components/Widgets/Subtitle';
+
+// Note: test renderer must be required after react-native.
+import renderer from 'react-test-renderer';
+
+jest.mock('Platform', () => {
+    const Platform = require.requireActual('Platform');
+    Platform.OS = 'ios';
+    return Platform;
+});
+
+it('renders correctly', () => {
+    const tree = renderer.create(
+        <Header />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with buttons', () => {
+   const tree = renderer.create(
+       <Header>
+           <Button transparent>
+               <Icon name='ios-arrow-back' />
+           </Button>
+
+           <Title>Header</Title>
+
+           <Button transparent>
+               <Icon name='ios-menu' />
+           </Button>
+       </Header>
+   ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with buttons and subtitle', () => {
+    const tree = renderer.create(
+        <Header>
+            <Button transparent>
+                <Icon name='ios-arrow-back' />
+            </Button>
+
+            <Title>Header</Title>
+            <Subtitle>Subtitle</Subtitle>
+
+            <Button transparent>
+                <Icon name='ios-menu' />
+            </Button>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with just one button', () => {
+    const tree = renderer.create(
+        <Header>
+            <Button transparent>
+                <Icon name='ios-arrow-back' />
+            </Button>
+
+            <Title>Header</Title>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with just one button and subtitle', () => {
+    const tree = renderer.create(
+        <Header>
+            <Button transparent>
+                <Icon name='ios-arrow-back' />
+            </Button>
+
+            <Title>Header</Title>
+            <Subtitle>Subtitle</Subtitle>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with just one button and iconRight', () => {
+    const tree = renderer.create(
+        <Header iconRight>
+            <Button transparent>
+                <Icon name='ios-arrow-back' />
+            </Button>
+
+            <Title>Header</Title>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with just one button, iconRight and a subtitle', () => {
+    const tree = renderer.create(
+        <Header iconRight>
+            <Button transparent>
+                <Icon name='ios-arrow-back' />
+            </Button>
+
+            <Title>Header</Title>
+            <Subtitle>SubTitle</Subtitle>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders header with searchbar', () => {
+    const tree = renderer.create(
+        <Header searchBar rounded>
+            <InputGroup>
+                <Icon name='ios-search' />
+                <Input placeholder='Search' />
+                <Icon name='ios-people' />
+            </InputGroup>
+            <Button transparent>
+                Search
+            </Button>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/__tests__/Components/Widgets/Header.ios.js
+++ b/__tests__/Components/Widgets/Header.ios.js
@@ -41,6 +41,16 @@ it('renders header with buttons', () => {
     expect(tree).toMatchSnapshot();
 });
 
+it('renders header with a null button', () => {
+    const tree = renderer.create(
+        <Header>
+            {null}
+            <Title>Header</Title>
+        </Header>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
 it('renders header with buttons and subtitle', () => {
     const tree = renderer.create(
         <Header>

--- a/__tests__/Components/Widgets/__snapshots__/Header.android.js.snap
+++ b/__tests__/Components/Widgets/__snapshots__/Header.android.js.snap
@@ -23,6 +23,54 @@ exports[`test renders correctly 1`] = `
   } />
 `;
 
+exports[`test renders header with a null button 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#4179F7",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 56,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 0,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "justifyContent": "center",
+      }
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "alignSelf": "flex-start",
+          "color": "#fff",
+          "fontFamily": "Roboto_medium",
+          "fontSize": 19,
+          "lineHeight": 24,
+        }
+      }>
+      Header
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`test renders header with buttons 1`] = `
 <View
   style={

--- a/__tests__/Components/Widgets/__snapshots__/Header.android.js.snap
+++ b/__tests__/Components/Widgets/__snapshots__/Header.android.js.snap
@@ -1,0 +1,886 @@
+exports[`test renders correctly 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#4179F7",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 56,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": 30,
+      "paddingTop": 0,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  } />
+`;
+
+exports[`test renders header with buttons 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#4179F7",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 56,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 0,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -10,
+        "marginRight": 12,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 2,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#fff",
+              "fontSize": 28,
+              "lineHeight": 21,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "flex": 3,
+        "justifyContent": "center",
+      }
+    }>
+    <View
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "flex-start",
+            "color": "#fff",
+            "fontFamily": "Roboto_medium",
+            "fontSize": 19,
+            "lineHeight": 24,
+          }
+        }>
+        Header
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginRight": -7,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 2,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#fff",
+              "fontSize": 28,
+              "lineHeight": 21,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`test renders header with buttons and subtitle 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#4179F7",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 56,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 0,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -10,
+        "marginRight": 12,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 2,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#fff",
+              "fontSize": 28,
+              "lineHeight": 21,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "flex": 3,
+        "justifyContent": "center",
+      }
+    }>
+    <View
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "flex-start",
+            "color": "#fff",
+            "fontFamily": "Roboto_medium",
+            "fontSize": 19,
+            "lineHeight": 24,
+          }
+        }>
+        Header
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginRight": -7,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 2,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#fff",
+              "fontSize": 28,
+              "lineHeight": 21,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`test renders header with just one button 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#4179F7",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 56,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 0,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -10,
+        "marginRight": 12,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 2,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#fff",
+              "fontSize": 28,
+              "lineHeight": 21,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "flex": 3,
+        "justifyContent": "center",
+      }
+    }>
+    <View
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "flex-start",
+            "color": "#fff",
+            "fontFamily": "Roboto_medium",
+            "fontSize": 19,
+            "lineHeight": 24,
+          }
+        }>
+        Header
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`test renders header with just one button and iconRight 1`] = `
+<View
+  iconRight={true}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#4179F7",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 56,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 0,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "flex": 3,
+        "justifyContent": "center",
+      }
+    }>
+    <View
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "flex-start",
+            "color": "#fff",
+            "fontFamily": "Roboto_medium",
+            "fontSize": 19,
+            "lineHeight": 24,
+          }
+        }>
+        Header
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -10,
+        "marginRight": 12,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 2,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#fff",
+              "fontSize": 28,
+              "lineHeight": 21,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`test renders header with just one button and subtitle 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#4179F7",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 56,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 0,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -10,
+        "marginRight": 12,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 2,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#fff",
+              "fontSize": 28,
+              "lineHeight": 21,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "flex": 3,
+        "justifyContent": "center",
+      }
+    }>
+    <View
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "flex-start",
+            "color": "#fff",
+            "fontFamily": "Roboto_medium",
+            "fontSize": 19,
+            "lineHeight": 24,
+          }
+        }>
+        Header
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`test renders header with just one button, iconRight and a subtitle 1`] = `
+<View
+  iconRight={true}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#4179F7",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 56,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 0,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "flex": 3,
+        "justifyContent": "center",
+      }
+    }>
+    <View
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "flex-start",
+            "color": "#fff",
+            "fontFamily": "Roboto_medium",
+            "fontSize": 19,
+            "lineHeight": 24,
+          }
+        }>
+        Header
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -10,
+        "marginRight": 12,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 2,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#fff",
+              "fontSize": 28,
+              "lineHeight": 21,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/__tests__/Components/Widgets/__snapshots__/Header.ios.js.snap
+++ b/__tests__/Components/Widgets/__snapshots__/Header.ios.js.snap
@@ -1,0 +1,1189 @@
+exports[`test renders correctly 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#F8F8F8",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 64,
+      "justifyContent": "center",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 15,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  } />
+`;
+
+exports[`test renders header with buttons 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#F8F8F8",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 64,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 15,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "bottom": 0,
+        "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 13,
+      }
+    }>
+    <View
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "center",
+            "color": "#000",
+            "fontFamily": "HelveticaNeue",
+            "fontSize": 17,
+            "fontWeight": "500",
+            "lineHeight": 20,
+          }
+        }>
+        Header
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -14,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 5,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#007aff",
+              "fontSize": 25,
+              "lineHeight": 28,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "flex": 3,
+      }
+    } />
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginRight": -14,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 5,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#007aff",
+              "fontSize": 25,
+              "lineHeight": 28,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`test renders header with buttons and subtitle 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#F8F8F8",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 64,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 15,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "bottom": 0,
+        "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 13,
+      }
+    }>
+    <View
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "center",
+            "color": "#000",
+            "fontFamily": "HelveticaNeue",
+            "fontSize": 17,
+            "fontWeight": "500",
+            "lineHeight": 20,
+          }
+        }>
+        Header
+      </Text>
+    </View>
+    <View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "center",
+            "color": "#8e8e93",
+            "fontSize": 12,
+          }
+        }>
+        Subtitle
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -14,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 5,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#007aff",
+              "fontSize": 25,
+              "lineHeight": 28,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "flex": 3,
+      }
+    } />
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginRight": -14,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 5,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#007aff",
+              "fontSize": 25,
+              "lineHeight": 28,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`test renders header with just one button 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#F8F8F8",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 64,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 15,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "bottom": 0,
+        "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 13,
+      }
+    }>
+    <View
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "center",
+            "color": "#000",
+            "fontFamily": "HelveticaNeue",
+            "fontSize": 17,
+            "fontWeight": "500",
+            "lineHeight": 20,
+          }
+        }>
+        Header
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -14,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 5,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#007aff",
+              "fontSize": 25,
+              "lineHeight": 28,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "flex": 3,
+      }
+    } />
+</View>
+`;
+
+exports[`test renders header with just one button and iconRight 1`] = `
+<View
+  iconRight={true}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#F8F8F8",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 64,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 15,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "bottom": 0,
+        "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 13,
+      }
+    }>
+    <View
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "center",
+            "color": "#000",
+            "fontFamily": "HelveticaNeue",
+            "fontSize": 17,
+            "fontWeight": "500",
+            "lineHeight": 20,
+          }
+        }>
+        Header
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "flex": 3,
+      }
+    } />
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -14,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 5,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#007aff",
+              "fontSize": 25,
+              "lineHeight": 28,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`test renders header with just one button and subtitle 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#F8F8F8",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 64,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 15,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "bottom": 0,
+        "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 13,
+      }
+    }>
+    <View
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "center",
+            "color": "#000",
+            "fontFamily": "HelveticaNeue",
+            "fontSize": 17,
+            "fontWeight": "500",
+            "lineHeight": 20,
+          }
+        }>
+        Header
+      </Text>
+    </View>
+    <View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "center",
+            "color": "#8e8e93",
+            "fontSize": 12,
+          }
+        }>
+        Subtitle
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -14,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 5,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#007aff",
+              "fontSize": 25,
+              "lineHeight": 28,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "flex": 3,
+      }
+    } />
+</View>
+`;
+
+exports[`test renders header with just one button, iconRight and a subtitle 1`] = `
+<View
+  iconRight={true}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#F8F8F8",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 64,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 15,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "bottom": 0,
+        "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 13,
+      }
+    }>
+    <View
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "center",
+            "color": "#000",
+            "fontFamily": "HelveticaNeue",
+            "fontSize": 17,
+            "fontWeight": "500",
+            "lineHeight": 20,
+          }
+        }>
+        Header
+      </Text>
+    </View>
+    <View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "alignSelf": "center",
+            "color": "#8e8e93",
+            "fontSize": 12,
+          }
+        }>
+        SubTitle
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "flex": 3,
+      }
+    } />
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -14,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 5,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "color": "#007aff",
+              "fontSize": 25,
+              "lineHeight": 28,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`test renders header with searchbar 1`] = `
+<View
+  rounded={true}
+  searchBar={true}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#F8F8F8",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 64,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 15,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": -7,
+      }
+    }>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#CECDD2",
+          "borderColor": "transparent",
+          "borderLeftWidth": 0,
+          "borderRadius": 25,
+          "borderRightWidth": 0,
+          "borderTopWidth": 0,
+          "borderWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+          "height": 30,
+          "paddingLeft": 5,
+          "paddingRight": 5,
+          "position": "relative",
+        }
+      }
+      toolbar={true}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "alignSelf": "center",
+              "color": "#000",
+              "fontSize": 20,
+              "lineHeight": 20,
+              "marginLeft": 5,
+              "marginTop": 2,
+              "paddingRight": 5,
+            },
+          ]
+        }>
+        
+      </Text>
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }>
+        <TextInput
+          placeholder="Search"
+          placeholderTextColor="#575757"
+          style={
+            Object {
+              "color": "#000",
+              "fontSize": 15,
+              "height": 30,
+              "lineHeight": 24,
+              "paddingLeft": 5,
+              "paddingRight": 5,
+            }
+          }
+          toolbar={true}
+          underlineColorAndroid="rgba(0,0,0,0)" />
+      </View>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "Ionicons",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {
+              "alignSelf": "center",
+              "color": "#000",
+              "fontSize": 20,
+              "lineHeight": 20,
+              "marginLeft": 5,
+              "marginTop": 2,
+              "paddingRight": 5,
+            },
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "center",
+        "marginRight": -14,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "borderColor": "#5067FF",
+          "borderRadius": 5,
+          "borderWidth": 0,
+          "elevation": 0,
+          "flexDirection": "row",
+          "height": 38,
+          "justifyContent": "space-around",
+          "opacity": 1,
+          "paddingHorizontal": 15,
+          "paddingVertical": 6,
+        }
+      }
+      testID={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "color": "#007aff",
+            "fontFamily": "HelveticaNeue",
+            "fontSize": 16.5,
+            "lineHeight": 19,
+            "marginLeft": 0,
+            "marginRight": 0,
+          }
+        }>
+        Search
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/__tests__/Components/Widgets/__snapshots__/Header.ios.js.snap
+++ b/__tests__/Components/Widgets/__snapshots__/Header.ios.js.snap
@@ -23,6 +23,55 @@ exports[`test renders correctly 1`] = `
   } />
 `;
 
+exports[`test renders header with a null button 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#F8F8F8",
+      "elevation": 3,
+      "flexDirection": "row",
+      "height": 64,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 15,
+      "paddingLeft": undefined,
+      "paddingTop": 15,
+      "position": "relative",
+      "shadowColor": "#000",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 0.1,
+      "shadowRadius": 1.5,
+    }
+  }>
+  <View
+    style={
+      Object {
+        "justifyContent": "center",
+      }
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "alignSelf": "center",
+          "color": "#000",
+          "fontFamily": "HelveticaNeue",
+          "fontSize": 17,
+          "fontWeight": "500",
+          "lineHeight": 20,
+        }
+      }>
+      Header
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`test renders header with buttons 1`] = `
 <View
   style={

--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
     "packager",
     "rnpm"
   ],
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "preset": "jest-react-native"
+  },
   "version": "0.5.11",
   "private": false,
   "dependencies": {
@@ -30,12 +36,17 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",
+    "babel-jest": "^16.0.0",
+    "babel-preset-react-native": "^1.9.0",
     "eslint": "^3.5.0",
     "eslint-config-airbnb": "^11.1.0",
     "eslint-plugin-import": "^1.14.0",
     "eslint-plugin-jsx-a11y": "^2.2.1",
     "eslint-plugin-react": "^6.2.0",
-    "eslint-plugin-react-native": "^2.0.0"
+    "eslint-plugin-react-native": "^2.0.0",
+    "jest": "^16.0.2",
+    "jest-react-native": "^16.0.0",
+    "react-test-renderer": "^15.3.2"
   },
   "rnpm": {
     "assets": [


### PR DESCRIPTION
I had a bug when using the Header in the following way:

```
const someVar = false;
let someButton = null;
if (someVar === true) {
  someButton = <Button><Icon name='ios-arrow-back' /></Button>;
}

return (
  <Header>
    {someButton}
    <Title>Test</Title>
  </Header>
);
```

Issue is that the Component Header checks if the children is an array or not. If not it will just immediately return the children to be rendered. Otherwise it will try to layout the children accordingly to what is being passed. 

Before I started fixing the issue I however was not very comfortable with changing anything due to the code quality and no tests being around. 
Therefore I first added tests for the use cases I found in the documentation, using [Jest](https://facebook.github.io/jest/). This has been done in https://github.com/GeekyAnts/NativeBase/commit/c6491a7252f922b09611b119f25b6d65ed40a51b.

After adding the tests I started refactoring the code. Indentations were wrong (if else clauses where indentation was completely off), else clauses where no else clause was needed because you can return early instead. 
Also everything in one method is too hard to follow as well. 
I therefore refactored the existing component into what's visible in https://github.com/GeekyAnts/NativeBase/commit/4fefbb00147ce1291d3319180dac53034f3af791. 

After doing that, fixing the actual bug has been easy: https://github.com/GeekyAnts/NativeBase/commit/b62a0ae986c7ee203cb3253381e6c64201a6f6a8. 

The refactored code is much easier to read and to make changes. It is however not yet optimal. The styles which I added on top (instead of being in each rendered component directly) is reducing duplication but I think there's still a lot of optimizations one could do.

I do strongly suggest to add tests for all other components as well and then start to refactor it in a similar way. This will make future changes much easier.
Additionally I recommend using [Travis-CI](http://travis-ci.org/) for running the tests automatically for every change and pull request. 

Also I've removed lodash in this specific component. If you only use `_.remove` and other similar functions from lodash, I'd recommend using standard javascript functions (e.g. the ones in Array, like `Array.prototype.filter`) instead.
