### PR TITLE
Fix: Single right-aligned header button margin

### DIFF
--- a/Components/Widgets/Header.js
+++ b/Components/Widgets/Header.js
@@ -111,7 +111,7 @@ export default class Header extends NativeBaseComponent {
                     {[title[0],subtitle[0]]}
                     </View>)
                     newChildren.push(<View key='title2' style={{flex: 3, alignSelf: 'stretch'}} />)
-                    newChildren.push(<View key='btn1' style={{alignItems: 'center', justifyContent: 'flex-start', flexDirection: 'row', marginLeft: -14}}>
+                    newChildren.push(<View key='btn1' style={{alignItems: 'center', justifyContent: 'flex-start', flexDirection: 'row', marginRight: -14}}>
                     {React.cloneElement(buttons[0], {color: this.getTheme().iosToolbarBtnColor, style: this.getInitialStyle().toolbarButton})}
                     </View>)
                 }


### PR DESCRIPTION
**Issue:**
![image](https://cloud.githubusercontent.com/assets/5214462/20228379/ea934f06-a81e-11e6-9e01-2becd3e601cd.png)
When using the `iconRight` attribute on `Header` with a single button, a negative margin is applied to pull it flush with the edge of the screen, but it is incorrectly placed on the left side. (This is more obvious with an opaque button, but even with a transparent button seen here, it leaves a large gap between the icon and right side of the screen.

**Fix:**
![image](https://cloud.githubusercontent.com/assets/5214462/20228408/007eb378-a81f-11e6-9f48-2374843e5428.png)
The negative margin is moved to the right side so the button is flush.

_Note that you can compare this fix with the other layout conditions in the same file, where identical properties are applied. It appears to have simply been copied incorrectly when the "single-button/iconRight" logic was added._
