### PR TITLE
Support use of Picker inside an InputGroup in a form

### DIFF
--- a/Components/Widgets/InputGroup.js
+++ b/Components/Widgets/InputGroup.js
@@ -8,6 +8,7 @@ import Icon from './Icon';
 import Button from './Button';
 import computeProps from '../../Utils/computeProps';
 import Input from './Input';
+import Picker from './Picker';
 import _ from 'lodash';
 
 export default class InputGroup extends NativeBaseComponent {
@@ -145,7 +146,7 @@ export default class InputGroup extends NativeBaseComponent {
     });
 
     var inp = _.find(childrenArray, function(item) {
-      if(item && item.type == Input) {
+      if(item && (item.type == Input || item.type == Picker)) {
         return true;
       }
     });

--- a/Components/Widgets/Picker.ios.js
+++ b/Components/Widgets/Picker.ios.js
@@ -95,16 +95,20 @@ export default class PickerNB extends NativeBaseComponent {
     }
 
     render() {
+        let additionalProps = {marginLeft: -35};
+        if(this.props.inlineLabel) {
+          additionalProps = {paddingHorizontal: 4};
+        }
         return (
         <View ref={c => this._root = c}>
             <Button
                 iconRight={(this.props.iosIcon== undefined) ? false : true}
                 transparent
                 textStyle={this.props.textStyle}
-                style={[this.props.style,{marginLeft: -35}]}
+                style={[this.props.style,additionalProps]}
                 onPress={() => {this._setModalVisible(true)}}>
                 {this.state.currentLabel}
-                {(this.props.iosIcon == undefined) ? <Icon name="ios-home" style={{opacity: 0}} /> : this.renderIcon()}
+                {(this.props.iosIcon == undefined) ? '' : this.renderIcon()}
             </Button>
             <Modal animationType='slide'
                 transparent={false}

--- a/Components/Widgets/Picker.ios.js
+++ b/Components/Widgets/Picker.ios.js
@@ -97,7 +97,7 @@ export default class PickerNB extends NativeBaseComponent {
     render() {
         let additionalProps = {marginLeft: -35};
         if(this.props.inlineLabel) {
-          additionalProps = {paddingHorizontal: 4};
+          additionalProps = {paddingHorizontal: 4, justifyContent: 'flex-start', alignSelf: 'stretch'};
         }
         return (
         <View ref={c => this._root = c}>

--- a/Components/Widgets/Picker.js
+++ b/Components/Widgets/Picker.js
@@ -30,8 +30,13 @@ export default class PickerNB extends NativeBaseComponent {
     }
 
     render() {
+        const {style, itemStyle, inlineLabel, iosHeader, children, ...otherProps } = this.prepareRootProps(); //eslint-disable-line
+        let additionalProps = {};
+        if(inlineLabel) {
+          additionalProps = { flex: 1};
+        }
         return(
-            <Picker ref={c => this._root = c} {...this.prepareRootProps()}>
+            <Picker ref={c => this._root = c} style={[style, additionalProps]} itemStyle={[itemStyle]} {...otherProps}>
                 {this.props.children}
             </Picker>
         );


### PR DESCRIPTION
Present implementation does not work well with a Picker inside a form. The styling does not match with the styling of other form elements containing Input. This PR also resolves issues [Issue 1](https://github.com/GeekyAnts/NativeBase/issues/295) and [Issue 2](https://github.com/GeekyAnts/NativeBase/issues/89)