### PR TITLE
Add default width to Spinner

### DIFF
--- a/Components/Widgets/Spinner.js
+++ b/Components/Widgets/Spinner.js
@@ -12,7 +12,8 @@ export default class SpinnerNB extends NativeBaseComponent {
     prepareRootProps() {
 
         var type = {
-            height: 80
+            height: 80,
+            width: 80
         }
 
         var defaultProps = {


### PR DESCRIPTION
This enables the spinner container to be squared, like in this screenshot: https://www.dropbox.com/s/oo7osg9lpfjhcbx/Screenshot%202016-11-23%2020.02.43.png?dl=0