### PR TITLE
Changed import of ReactNativePropRegistry to be not dependent on path.

### DIFF
--- a/Components/Widgets/Button.js
+++ b/Components/Widgets/Button.js
@@ -9,7 +9,7 @@ import IconNB from './Icon';
 import Icon from './Icon';
 import Text from './Text';
 import _ from 'lodash';
-import ReactNativePropRegistry from 'react/lib/ReactNativePropRegistry';
+import { ReactNativePropRegistry } from 'react-native';
 
 
 export default class Button extends NativeBaseComponent {

--- a/Utils/computeProps.js
+++ b/Utils/computeProps.js
@@ -1,6 +1,6 @@
 'use_strict';
 import _ from 'lodash';
-import ReactNativePropRegistry from 'react/lib/ReactNativePropRegistry';
+import { ReactNativePropRegistry } from 'react-native';
 // For compatibility with RN 0.25
 // import ReactNativePropRegistry from "react-native/Libraries/ReactNative/ReactNativePropRegistry";
 module.exports = function(incomingProps, defaultProps) {


### PR DESCRIPTION
This is to address issues #318 and #319. Import is now not using absolute path. 