### PR TITLE
Resolve ReactNativePropRegistry issue Fixes #328.

### DIFF
--- a/Utils/computeProps.js
+++ b/Utils/computeProps.js
@@ -1,6 +1,6 @@
 'use_strict';
 import _ from 'lodash';
-import ReactNativePropRegistry from 'react-native/Libraries/Renderer/src/renderers/native/ReactNativePropRegistry';
+import { ReactNativePropRegistry } from 'react-native';
 // For compatibility with RN 0.25
 // import ReactNativePropRegistry from "react-native/Libraries/ReactNative/ReactNativePropRegistry";
 module.exports = function(incomingProps, defaultProps) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "color": "~0.11.1",
     "lodash": "~4.11.1",
     "react-native-checkbox": "~1.0.8",
-    "react-native-easy-grid": "0.1.5",
+    "react-native-easy-grid": "0.1.7",
     "react-native-keyboard-aware-scroll-view": "0.2.0",
     "react-native-vector-icons": "2.x.x"
   },


### PR DESCRIPTION
Resolved this issue by bumping the version number of react-native-easy-grid, which has a fix in place as of 0.1.7, and by modifying the import statement to take advantage of the fact that it can be imported directly from react-native.