### PR TITLE
Fix button display error

### DIFF
--- a/Components/Widgets/InputGroup.js
+++ b/Components/Widgets/InputGroup.js
@@ -172,13 +172,16 @@ export default class InputGroup extends NativeBaseComponent {
         newChildren.push(React.cloneElement(iconElement[0],this.getIconProps(iconElement[0])));
       }
       else if(buttonElement.length>0) {
-        newChildren.push(React.cloneElement(
-          iconElement[0],
-          {
-            ...this.getIconProps(iconElement[0]),
-            key: 'icon0'
-          }
-        ));
+        if (iconElement.length > 0) {
+          newChildren.push(React.cloneElement(
+            iconElement[0],
+            {
+              ...this.getIconProps(iconElement[0]),
+              key: 'icon0'
+            }
+          ));
+        }
+
         if(clonedInp) {
            newChildren.push(clonedInp);
          }


### PR DESCRIPTION
Hi, @sankhadeeproy007 

When I use a Button inside a InputGroup without Icon, an error occurs:

```
<InputGroup>
<Input placeholder="PASSWORD" secureTextEntry/>
<Button>
<Icon name="ios-eye-off"/>
</Button>
</InputGroup>
```

![simulator screen shot 2016 12 6 16 00 06](https://cloud.githubusercontent.com/assets/716511/20917723/2ebfb6d4-bbce-11e6-8320-68e921d1bf32.png)

I modify the InputGroup to make it work.