### PR TITLE
Add missing function in Drawer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -718,7 +718,10 @@ declare module 'native-base' {
     /**
      * NativeBase.Drawer
      */
-    export class Drawer extends React.Component<NativeBase.Drawer, any> { }
+    export class Drawer extends React.Component<NativeBase.Drawer, any> { 
+        close: Function;
+        open: Function;
+    }
     /**
      * NativeBase.Tabs
      *


### PR DESCRIPTION
If you have custom Navigator in react native TypeScript app, sometimes we need to call
`this.drawer.open();`
`this.drawer.close();`

Therefore, I add them into index.d.ts file