### PR TITLE
remove flex:1

### DIFF
--- a/Components/Widgets/Card.js
+++ b/Components/Widgets/Card.js
@@ -16,7 +16,6 @@ export default class CardNB extends NativeBaseComponent {
         return {
             card: {
                 marginVertical: 5,
-                flex: 1,
                 borderWidth: this.getTheme().borderWidth,
                 borderRadius: 2,
                 borderColor: this.getTheme().listBorderColor,


### PR DESCRIPTION
 changing state make card collapsed in rn 39. maybe due to this breaking change: https://github.com/facebook/react-native/commit/d63ba47b59e3261403800c1f741d979a089efb48