### PR TITLE
Fix readme not showing up on npmjs.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "react-native": ">=0.38.0",
     "react": ">=15.4.0"
   },
-  "readme": "ERROR: No README data found!",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GeekyAnts/NativeBase.git"


### PR DESCRIPTION
**Changes**

- Fixed empty readme page on npmjs.com (see image below)

Tested by publishing to [another package name](https://www.npmjs.com/package/native-base-transpiled)

**Before fix**
![screen shot 2017-01-04 at 2 13 59 am](https://cloud.githubusercontent.com/assets/15131271/21619793/ddac7edc-d223-11e6-9bf5-36b8bf8b3aef.png)

**After fix**
![screen shot 2017-01-04 at 2 13 53 am](https://cloud.githubusercontent.com/assets/15131271/21620015/de9bd756-d224-11e6-8634-3cd2b92415ee.png)
