### PR TITLE
Add transpilation step to ensure native-base works with Jest out of the box

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "sourceMaps": true,
   "presets": [
+    "es2015",
     "react"
   ],
   "plugins": [

--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "sourceMaps": true,
+  "presets": [
+    "react"
+  ],
+  "plugins": [
+    "transform-class-properties",
+    "transform-object-rest-spread"
+  ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,6 @@
 {
   "sourceMaps": true,
   "presets": [
-    "es2015",
-    "react"
-  ],
-  "plugins": [
-    "transform-class-properties",
-    "transform-object-rest-spread"
+    "react-native"
   ]
 }

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 vendor/
 Components/Styles/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -30,6 +31,7 @@ Temporary Items
 logs
 *.log
 npm-debug.log*
+dist
 
 # Runtime data
 pids

--- a/.npmignore
+++ b/.npmignore
@@ -11,7 +11,6 @@ index.js
 _config.yml
 
 # Documents
-CHANGELOG.md
 CONTRIBUTING.md
 ISSUE_TEMPLATE.txt
 img

--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ _config.yml
 CHANGELOG.md
 CONTRIBUTING.md
 ISSUE_TEMPLATE.txt
+img

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+# Source file
+Components
+Utils
+index.js
+
+# Dotfiles
+.babelrc
+.eslintignore
+.eslintrc.json
+.gitattributes
+_config.yml
+
+# Documents
+CHANGELOG.md
+CONTRIBUTING.md
+ISSUE_TEMPLATE.txt

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     ]
   },
   "scripts": {
-    "build": "rm -rf dist/* && babel . --out-dir dist --ignore node_modules,dist"
+    "build": "rm -rf dist/* && babel . --out-dir dist --ignore node_modules,dist --source-maps"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "files": [
     "dist",
-    "index.d.ts"
+    "index.d.ts",
+    "Fonts"
   ],
   "gitHead": "a8504267642c8bafe763ce292bcf0e97737fd0e4",
   "homepage": "https://github.com/GeekyAnts/NativeBase#readme",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,11 @@
     "react-native-vector-icons": "~3.0.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.18.0",
     "babel-eslint": "^6.1.2",
+    "babel-plugin-transform-class-properties": "^6.19.0",
+    "babel-plugin-transform-object-rest-spread": "^6.20.2",
+    "babel-preset-react": "^6.16.0",
     "eslint": "^3.5.0",
     "eslint-config-airbnb": "^11.1.0",
     "eslint-plugin-import": "^1.14.0",
@@ -42,7 +46,7 @@
   },
   "gitHead": "a8504267642c8bafe763ce292bcf0e97737fd0e4",
   "homepage": "https://github.com/GeekyAnts/NativeBase#readme",
-  "main": "index.js",
+  "main": "dist/index.js",
   "maintainers": [
     {
       "name": "himanshu-sahusoft",
@@ -72,5 +76,7 @@
       "Fonts"
     ]
   },
-  "scripts": {}
+  "scripts": {
+    "build": "babel . --out-dir dist --ignore node_modules,dist"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,7 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-eslint": "^6.1.2",
-    "babel-plugin-transform-class-properties": "^6.19.0",
-    "babel-plugin-transform-object-rest-spread": "^6.20.2",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
+    "babel-preset-react-native": "^1.9.1",
     "eslint": "^3.5.0",
     "eslint-config-airbnb": "^11.1.0",
     "eslint-plugin-import": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "tarball": "https://registry.npmjs.org/native-base/-/native-base-0.5.19.tgz"
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "gitHead": "a8504267642c8bafe763ce292bcf0e97737fd0e4",
   "homepage": "https://github.com/GeekyAnts/NativeBase#readme",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "shasum": "fb3677a4f6e732b4fe60e569e04222399011661f",
     "tarball": "https://registry.npmjs.org/native-base/-/native-base-0.5.19.tgz"
   },
+  "files": [
+    "dist"
+  ],
   "gitHead": "a8504267642c8bafe763ce292bcf0e97737fd0e4",
   "homepage": "https://github.com/GeekyAnts/NativeBase#readme",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-eslint": "^6.1.2",
     "babel-plugin-transform-class-properties": "^6.19.0",
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
+    "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "eslint": "^3.5.0",
     "eslint-config-airbnb": "^11.1.0",
@@ -77,6 +78,6 @@
     ]
   },
   "scripts": {
-    "build": "babel . --out-dir dist --ignore node_modules,dist"
+    "build": "rm -rf dist/* && babel . --out-dir dist --ignore node_modules,dist"
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     ]
   },
   "scripts": {
-    "build": "rm -rf dist/* && babel . --out-dir dist --ignore node_modules,dist --source-maps"
+    "compile": "rm -rf dist/* && babel . --out-dir dist --ignore node_modules,dist --source-maps"
   }
 }


### PR DESCRIPTION
**Changes**

- Add `npm run compile` command to transpile source into `dist` directory
- `npm publish` publishes the `dist` directory, the `Fonts` directory, and `index.d.ts`
- Ignore extraneous files on publish (images, config files, dotfiles)

Fixes the following issues: #396, #400

**Testing**

- Published as [native-base-transpiled](https://www.npmjs.com/package/native-base-transpiled) and used locally on a React Native project
- Verify via [unpkg](https://unpkg.com/native-base-transpiled@0.5.25/) that correct files are published