### PR TITLE
H1/H2/H3 should not check children types.

### DIFF
--- a/src/basic/H1.js
+++ b/src/basic/H1.js
@@ -12,20 +12,9 @@ class H1 extends Component {
   }
 }
 
-const childrenType = function (props, propName, component) {
-  let error;
-  const prop = props[propName];
-  React.Children.forEach(prop, (child) => {
-    if (typeof child !== 'string') {
-      error = new Error(`${component} should have only string`);
-    }
-  });
-  return error;
-};
-
 H1.propTypes = {
   ...Text.propTypes,
-  children: childrenType,
+  children: React.PropTypes.oneOfType[React.PropTypes.node, React.PropTypes.string],
   style: React.PropTypes.object,
 };
 

--- a/src/basic/H2.js
+++ b/src/basic/H2.js
@@ -12,20 +12,9 @@ class H2 extends Component {
   }
 }
 
-const childrenType = function (props, propName, component) {
-  let error;
-  const prop = props[propName];
-  React.Children.forEach(prop, (child) => {
-    if (typeof child !== 'string') {
-      error = new Error(`${component} should have only string`);
-    }
-  });
-  return error;
-};
-
 H2.propTypes = {
   ...Text.propTypes,
-  children: childrenType,
+  children: React.PropTypes.oneOfType[React.PropTypes.node, React.PropTypes.string],
   style: React.PropTypes.object,
 };
 

--- a/src/basic/H3.js
+++ b/src/basic/H3.js
@@ -12,20 +12,9 @@ class H3 extends Component {
   }
 }
 
-const childrenType = function (props, propName, component) {
-  let error;
-  const prop = props[propName];
-  React.Children.forEach(prop, (child) => {
-    if (typeof child !== 'string') {
-      error = new Error(`${component} should have only string`);
-    }
-  });
-  return error;
-};
-
 H3.propTypes = {
   ...Text.propTypes,
-  children: childrenType,
+  children: React.PropTypes.oneOfType[React.PropTypes.node, React.PropTypes.string],
   style: React.PropTypes.object,
 };
 


### PR DESCRIPTION
H1, H2, H3 should not check children types. The Text component is already handling type checking for child nodes. This will allow us to use `Text` inside `H1/H2/H3` tags.