### PR TITLE
Fix incorrect use of androidRippleColor when android version <= 21

### DIFF
--- a/src/basic/ListItem.js
+++ b/src/basic/ListItem.js
@@ -7,7 +7,7 @@ import variable from '../theme/variables/platform';
 
 class ListItem extends Component {
   render() {
-    if (Platform.OS==='ios' || variable.androidRipple===false || !this.props.onPress) {
+    if (Platform.OS==='ios' || variable.androidRipple===false || Platform['Version'] <= 21 || !this.props.onPress) {
       return (
         <TouchableOpacity
           ref={c => this._root = c}


### PR DESCRIPTION
Use the same logic of [`Button.js`](https://github.com/GeekyAnts/NativeBase/blob/77334aa2528b937af3dc5a9fbcfd7d4ea5d03f54/src/basic/Button.js#L56)  to avoid the problem of androidRippleColor which background type is available on Android API level 21+.