### PR TITLE
adjusted for new StaticContainer.react.js filename

### DIFF
--- a/dist/src/basic/react-native-scrollable-tab-view/SceneComponent.js
+++ b/dist/src/basic/react-native-scrollable-tab-view/SceneComponent.js
@@ -3,7 +3,7 @@ var ReactNative=require('react-native');var
 Component=React.Component;var
 View=ReactNative.View,StyleSheet=ReactNative.StyleSheet;
 
-var StaticContainer=require('react-native/Libraries/Components/StaticContainer');
+var StaticContainer=require('react-native/Libraries/Components/StaticContainer.react');
 
 var SceneComponent=function SceneComponent(Props){var
 shouldUpdated=Props.shouldUpdated,props=_objectWithoutProperties(Props,['shouldUpdated']);

--- a/src/basic/react-native-scrollable-tab-view/SceneComponent.js
+++ b/src/basic/react-native-scrollable-tab-view/SceneComponent.js
@@ -3,7 +3,7 @@ const ReactNative = require('react-native');
 const {Component, } = React;
 const {View, StyleSheet, } = ReactNative;
 
-const StaticContainer = require('react-native/Libraries/Components/StaticContainer');
+const StaticContainer = require('react-native/Libraries/Components/StaticContainer.react');
 
 const SceneComponent = (Props) => {
   const {shouldUpdated, ...props, } = Props;


### PR DESCRIPTION
react-native master has changed the filename for this internal component to StaticContainer.react.js , so this pull request updates the import statements.