### PR TITLE
Complete customization of Picker button

### DIFF
--- a/src/basic/Picker.ios.js
+++ b/src/basic/Picker.ios.js
@@ -90,6 +90,23 @@ class PickerNB extends Component {
     return React.cloneElement(this.props.iosIcon, { style: { fontSize: 22, lineHeight: 26, color: '#7a7a7a' } });
   }
 
+  renderButton() {
+    const onPress = () => { this._setModalVisible(true); };
+    if (this.props.renderButton) {
+      return this.props.renderButton(onPress);
+    }
+    return <Button
+      style={this.props.style}
+      dark
+      picker
+      transparent
+      onPress={onPress}
+    >
+      <Text note={(this.props.note)} style={this.props.textStyle}>{this.state.currentLabel ? this.state.currentLabel : this.props.defaultLabel}</Text>
+      {(this.props.iosIcon === undefined) ? null : this.renderIcon()}
+    </Button>;
+  }
+
   renderHeader() {
     return (this.props.headerComponent) ? this.modifyHeader() : (<Header >
       <Left><Button
@@ -104,16 +121,7 @@ class PickerNB extends Component {
   render() {
     return (
       <View ref={c => this._root = c}>
-        <Button
-          style={this.props.style}
-          dark
-          picker
-          transparent
-          onPress={() => { this._setModalVisible(true); }}
-        >
-          <Text note={(this.props.note)} style={this.props.textStyle}>{this.state.currentLabel ? this.state.currentLabel : this.props.defaultLabel}</Text>
-          {(this.props.iosIcon === undefined) ? null : this.renderIcon()}
-        </Button>
+        {this.renderButton()}
         <Modal
           animationType="slide"
           transparent={false}

--- a/src/basic/Picker.ios.js
+++ b/src/basic/Picker.ios.js
@@ -92,8 +92,9 @@ class PickerNB extends Component {
 
   renderButton() {
     const onPress = () => { this._setModalVisible(true); };
+    const text = this.state.currentLabel ? this.state.currentLabel : this.props.defaultLabel;
     if (this.props.renderButton) {
-      return this.props.renderButton(this, onPress);
+      return this.props.renderButton(onPress, text, this);
     }
     return <Button
       style={this.props.style}
@@ -102,7 +103,7 @@ class PickerNB extends Component {
       transparent
       onPress={onPress}
     >
-      <Text note={(this.props.note)} style={this.props.textStyle}>{this.state.currentLabel ? this.state.currentLabel : this.props.defaultLabel}</Text>
+      <Text note={(this.props.note)} style={this.props.textStyle}>{text}</Text>
       {(this.props.iosIcon === undefined) ? null : this.renderIcon()}
     </Button>;
   }

--- a/src/basic/Picker.ios.js
+++ b/src/basic/Picker.ios.js
@@ -93,7 +93,7 @@ class PickerNB extends Component {
   renderButton() {
     const onPress = () => { this._setModalVisible(true); };
     if (this.props.renderButton) {
-      return this.props.renderButton(onPress);
+      return this.props.renderButton(this, onPress);
     }
     return <Button
       style={this.props.style}


### PR DESCRIPTION
The stock Picker didn't allow me to sufficiently customize the button that gets rendered in the form.  This PR lets you customize the rendering of it with a property called renderButton.

Ex:
`
renderButton(onPress) {
return <Button onPress={onPress}>....
}

render() {
  return <Picker renderButton={this.renderButton} ...
}
`

I'd like to see this pattern more and more in NativeBase.  I've found the components are flexible enough most of the time, but when you really need to customize, they lack the appropriate hooks.  The good news it's easy to do.