### PR TITLE
Picker Header Customizations

### DIFF
--- a/src/basic/Picker.ios.js
+++ b/src/basic/Picker.ios.js
@@ -109,12 +109,12 @@ class PickerNB extends Component {
   }
 
   renderHeader() {
-    return (this.props.headerComponent) ? this.modifyHeader() : (<Header >
+    return (this.props.headerComponent) ? this.modifyHeader() : (<Header style={this.props.headerStyle}>
       <Left><Button
-        style={{ shadowOffset: null, shadowColor: null, shadowRadius: null, shadowOpacity: null }}
+        style={[{ shadowOffset: null, shadowColor: null, shadowRadius: null, shadowOpacity: null }, this.props.headerBackButtonStyle]}
         transparent onPress={() => { this._setModalVisible(false); }}
-      ><Text>Back</Text></Button></Left>
-    <Body><Title>{(this.props.iosHeader) ? this.props.iosHeader : 'Select One'}</Title></Body>
+      ><Text>{this.props.headerBackButtonText || 'Back'}</Text></Button></Left>
+    <Body><Title style={this.props.headerTextStyle}>{this.props.iosHeader || 'Select One'}</Title></Body>
       <Right />
     </Header>);
   }
@@ -175,6 +175,9 @@ PickerNB.Item = React.createClass({
 
 PickerNB.propTypes = {
   ...View.propTypes,
+  headerStyle: React.PropTypes.object,
+  headerBackButtonStyle: React.PropTypes.object,
+  headerBackButtonText: React.PropTypes.string,
 };
 
 const StyledPickerNB = connectStyle('NativeBase.PickerNB', {}, mapPropsToStyleNames)(PickerNB);


### PR DESCRIPTION
Hi, we had a need to customize the Picker (ios only) header's background, Back button color and text.  This was done with the addition of 3 props:

1. headerStyle - style applied to <Header>
2. headerBackButtonStyle - style applied to <Button> inside <Header>
3. headerBackButtonText - text shown instead of hardcoded 'Back'

These are backwards compatible and optional props.  Included in propTypes.  

Like I did with `renderButton`, how do you feel about a `renderHeader()` prop?  This makes it a bit easier to customize the entire header and isn't as tricky as supporting `headerComponent`.  In fact `headerComponent` could be deprecated with a very simple upgrade path. 