### PR TITLE
Update typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-declare module 'native-base2' {
+declare module 'native-base' {
     namespace NativeBase {
 
         interface Text extends React.TextProperties {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
-declare module 'native-base' {
+import * as React from 'react';
+
+declare module 'native-base2' {
     namespace NativeBase {
 
         interface Text extends React.TextProperties {
@@ -71,7 +73,7 @@ declare module 'native-base' {
             rounded?: boolean,
             style?: React.ViewStyle
         }
-            
+
         interface Left{
 
         }
@@ -82,8 +84,8 @@ declare module 'native-base' {
 
         interface Right{
 
-        }    
-            
+        }
+
         /**
          * see Widget FooterTab.js
          */
@@ -216,12 +218,11 @@ declare module 'native-base' {
              * Aligns icon to the right of ListItem.
              * Default: false
              */
-            iconRight?: boolean,
             /**
              * Aligns icon to the left of ListItem.
              * Default: true
              */
-            iconLeft?: boolean,
+            icon?: boolean,
             button?: boolean,
             /**
              * Helps to organize and group the list items.
@@ -440,7 +441,8 @@ declare module 'native-base' {
          */
         interface Icon {
             name: string,
-            style?: React.TextStyle
+            style?: React.TextStyle,
+            active?:boolean
         }
         /**
          * see Widget Icon.js
@@ -537,6 +539,23 @@ declare module 'native-base' {
             springTension?: number,
             springFriction?: number
         }
+
+        interface Item {
+            fixedLabel?:boolean,
+            floatingLabel?:boolean,
+            inlineLabel?:boolean,
+            stackedLabel?:boolean,
+            placeholderLabel?:boolean,
+            bordered?:boolean,
+            underline?:boolean,
+            rounded?:boolean,
+            disabled?: boolean,
+            error?: boolean,
+            placeholder?:string,
+            secureTextEntry?:boolean,
+            success?: boolean,
+            last?:boolean,
+        }
     }
 
     // Export definitions
@@ -587,7 +606,7 @@ declare module 'native-base' {
      * NativeBase.Body
      */
     export class Body extends React.Component<NativeBase.Body, any> { }
-            
+
     export class Content extends React.Component<NativeBase.Content, any> { }
     /**
      * NativeBase.FooterTab
@@ -753,7 +772,16 @@ declare module 'native-base' {
     /**
      * NativeBase.Drawer
      */
-    export class Drawer extends React.Component<NativeBase.Drawer, any> { }
+    export class Drawer extends React.Component<NativeBase.Drawer, any> {
+        _root:{
+            open:()=>void,
+            close:()=>void
+        }
+    }
+
+    export class Item extends React.Component<NativeBase.Item, any> { }
+
+
     /**
      * NativeBase.Tabs
      *


### PR DESCRIPTION
The typing definitions of React can no longer be installed as a global module. It throws the `cannot find name space React`, so I think it'd be better to add `import * as React from react` at the top.

I also added the definition of `<Item/>`  and updated `<ListItem/>`,`<Icon/>`