### PR TITLE
Fix Missing Character "r" in md-arrow-down android

### DIFF
--- a/dist/src/basic/Icon/NBIcons.json
+++ b/dist/src/basic/Icon/NBIcons.json
@@ -121,7 +121,7 @@
   },
   "arrow-down": {
     "android": {
-      "default": "md-arro-down",
+      "default": "md-arrow-down",
       "active": "md-arrow-down"
     },
     "ios": {

--- a/src/basic/Icon/NBIcons.json
+++ b/src/basic/Icon/NBIcons.json
@@ -121,7 +121,7 @@
   },
   "arrow-down": {
     "android": {
-      "default": "md-arro-down",
+      "default": "md-arrow-down",
       "active": "md-arrow-down"
     },
     "ios": {


### PR DESCRIPTION
Add missing character 'r' in android 'md-arrow-down' at `NBIcons.json` files from issue #594 
please review it :)