### PR TITLE
RawText " " must be wrapped in an explicit <Text> component

### DIFF
--- a/src/basic/Picker.ios.js
+++ b/src/basic/Picker.ios.js
@@ -83,7 +83,7 @@ class PickerNB extends Component {
         newChildren.push(child);
       }
     });
-    return <Header {...this.props.headerComponent.props} > {newChildren}</Header>;
+    return <Header {...this.props.headerComponent.props} >{newChildren}</Header>;
   }
 
   renderIcon() {


### PR DESCRIPTION
Removed leading whitespace space to fix 'RawText " " must be wrapped in an explicit <Text> component'