### PR TITLE
Enable androidRipple with either onPress or onLongPress

### DIFF
--- a/src/basic/ListItem.js
+++ b/src/basic/ListItem.js
@@ -12,7 +12,7 @@ class ListItem extends Component {
   render() {
     const variables = (this.context.theme) ? this.context.theme['@@shoutem.theme/themeStyle'].variables : variable;
 
-    if (Platform.OS === 'ios' || variable.androidRipple === false || !this.props.onPress || !this.props.onLongPress || Platform.Version <= 21) {
+    if (Platform.OS === 'ios' || variable.androidRipple === false || (!this.props.onPress && !this.props.onLongPress) || Platform.Version <= 21) {
       return (
         <TouchableHighlight
           onPress={this.props.onPress}


### PR DESCRIPTION
If I am not mistaken, you currently have to supply both `onPress` *and* `onLongPress` to `ListItem` in order to enable android ripples. In my app I would like to enable them, but only by using `onPress` as I have no use for `onLongPress`.

With this change either prop will enable ripples.