### PR TITLE
Allow passing in custom rowHasChanged to List

### DIFF
--- a/src/basic/List.js
+++ b/src/basic/List.js
@@ -9,7 +9,8 @@ class List extends Component {
   constructor(props) {
     super(props);
     if (props.dataArray && props.renderRow) {
-      const ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 });
+      let rowHasChanged = props.rowHasChanged || ((r1, r2) => r1 !== r2);
+      const ds = new ListView.DataSource({ rowHasChanged: rowHasChanged });
       this.state = {
         dataSource: ds.cloneWithRows(props.dataArray)
       }


### PR DESCRIPTION
Currently the `List` is unusable if you have an array of objects because the default `rowHasChanged` function does not perform a deep comparison. This PR allows us to pass in a custom `rowHasChanged` method just like ListView. 

Fixes #719 and #698 
