### PR TITLE
Fix the mispelled variable from this.root to this._root

### DIFF
--- a/src/basic/List.js
+++ b/src/basic/List.js
@@ -36,7 +36,7 @@ class List extends Component {
       return (
         <ListView
           {...this.props}
-          ref={(ref) => this.root = ref}
+          ref={(ref) => this._root = ref}
           enableEmptySections
           dataSource={this.state.dataSource}
           renderRow={this.props.renderRow}


### PR DESCRIPTION
In order to link back from List to ListView, the variable name should be this._root.