### PR TITLE
Add uppercase prop to Text, make button text uppercase by default on Android

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,8 @@ declare module 'native-base' {
     namespace NativeBase {
 
         interface Text extends ReactNative.TextProperties {
-            note?: boolean
+            note?: boolean,
+            uppercase?: boolean
         }
 
         interface Switch extends ReactNative.SwitchProperties { }
@@ -592,6 +593,7 @@ declare module 'native-base' {
             stackedLabel?: boolean,
             placeholderLabel?: boolean,
             bordered?: boolean,
+            regular?: boolean,
             underline?: boolean,
             rounded?: boolean,
             disabled?: boolean,
@@ -602,11 +604,11 @@ declare module 'native-base' {
             last?: boolean,
         }
 
-        interface Form{
-
+        interface Form {
+            style?: ReactNative.ViewStyle
         }
 
-        interface Fab{
+        interface Fab {
             active?:boolean,
             direction?:"down"|"up"|"left"|"right",
             containerStyle?:ReactNative.ViewStyle,

--- a/src/basic/Button.js
+++ b/src/basic/Button.js
@@ -31,7 +31,7 @@ class Button extends Component {
   render() {
     const children = Platform.OS === 'ios'
         ? this.props.children
-        : React.Children.map(this.props.children, child => child.type === Text ? React.cloneElement(child, { capitalize: true, ...child.props }) : child);
+        : React.Children.map(this.props.children, child => child.type === Text ? React.cloneElement(child, { uppercase: true, ...child.props }) : child);
     if (Platform.OS==='ios' || variables.androidRipple===false || Platform['Version'] <= 21) {
       return (
         <TouchableOpacity
@@ -69,17 +69,12 @@ Button.propTypes = {
   warning: React.PropTypes.bool,
   info: React.PropTypes.bool,
   bordered: React.PropTypes.bool,
-  capitalize: React.PropTypes.bool,
   disabled: React.PropTypes.bool,
   rounded: React.PropTypes.bool,
   large: React.PropTypes.bool,
   small: React.PropTypes.bool,
   active: React.PropTypes.bool,
 };
-
-Button.defaultProps = {
-  capitalize: true
-}
 
 const StyledButton = connectStyle('NativeBase.Button', {}, mapPropsToStyleNames)(Button);
 export {

--- a/src/basic/Text.js
+++ b/src/basic/Text.js
@@ -12,7 +12,7 @@ class Text extends Component {
         ref={c => this._root = c}
         {...this.props}
       >
-        {this.props.capitalize ? this.props.children.toUpperCase() : this.props.children}
+        {this.props.uppercase ? this.props.children.toUpperCase() : this.props.children}
       </RNText>
     );
   }


### PR DESCRIPTION
This reimplements the behavior available in previous versions of NB. I chose `uppercase` over `capitalize` since it better corresponds to the `text-transform` CSS property value.

To force lowercase text in buttons on Android, the component is used like
```jsx
<Button>
  <Text uppercase={false}>Tap here</Text>
</Button>
```

This also includes some updated TypeScript definitions.