### PR TITLE
Remove old 'capitalize' prop from Button, use 'uppercase' on Text instead

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,8 @@ declare module 'native-base' {
     namespace NativeBase {
 
         interface Text extends ReactNative.TextProperties {
-            note?: boolean
+            note?: boolean,
+            uppercase?: boolean
         }
 
         interface Switch extends ReactNative.SwitchProperties { }
@@ -592,6 +593,7 @@ declare module 'native-base' {
             stackedLabel?: boolean,
             placeholderLabel?: boolean,
             bordered?: boolean,
+            regular?: boolean,
             underline?: boolean,
             rounded?: boolean,
             disabled?: boolean,
@@ -602,11 +604,11 @@ declare module 'native-base' {
             last?: boolean,
         }
 
-        interface Form{
-
+        interface Form {
+            style?: ReactNative.ViewStyle
         }
 
-        interface Fab{
+        interface Fab {
             active?:boolean,
             direction?:"down"|"up"|"left"|"right",
             containerStyle?:ReactNative.ViewStyle,

--- a/src/basic/Button.js
+++ b/src/basic/Button.js
@@ -31,7 +31,7 @@ class Button extends Component {
   render() {
     const children = Platform.OS === 'ios'
         ? this.props.children
-        : React.Children.map(this.props.children, child => child.type === Text ? React.cloneElement(child, { capitalize: true, ...child.props }) : child);
+        : React.Children.map(this.props.children, child => child.type === Text ? React.cloneElement(child, { uppercase: true, ...child.props }) : child);
     if (Platform.OS==='ios' || variables.androidRipple===false || Platform['Version'] <= 21) {
       return (
         <TouchableOpacity
@@ -69,17 +69,12 @@ Button.propTypes = {
   warning: React.PropTypes.bool,
   info: React.PropTypes.bool,
   bordered: React.PropTypes.bool,
-  capitalize: React.PropTypes.bool,
   disabled: React.PropTypes.bool,
   rounded: React.PropTypes.bool,
   large: React.PropTypes.bool,
   small: React.PropTypes.bool,
   active: React.PropTypes.bool,
 };
-
-Button.defaultProps = {
-  capitalize: true
-}
 
 const StyledButton = connectStyle('NativeBase.Button', {}, mapPropsToStyleNames)(Button);
 export {

--- a/src/basic/Text.js
+++ b/src/basic/Text.js
@@ -12,7 +12,7 @@ class Text extends Component {
         ref={c => this._root = c}
         {...this.props}
       >
-        {this.props.capitalize ? this.props.children.toUpperCase() : this.props.children}
+        {this.props.uppercase ? this.props.children.toUpperCase() : this.props.children}
       </RNText>
     );
   }


### PR DESCRIPTION
This is a followup to my last PR which wasn't merged quite right. The TypeScript definitions I included weren't merged and the treatment of the new `uppercase` prop was a bit inconsistent.

This removes the old `capitalize` prop from `Button` that must have accidentally been included when the component was updated to 2.x. It has no functionality and isn't documented, so I removed it.

This properly names the new prop on `Text` to _uppercase_ [in accordance with the equivalent CSS text-transform property](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Syntax) along the the necessary TypeScript definitions (and a couple other missing ones I need).