### PR TITLE
check children in Children.map

### DIFF
--- a/src/basic/Button.js
+++ b/src/basic/Button.js
@@ -31,7 +31,7 @@ class Button extends Component {
   render() {
     const children = Platform.OS === 'ios'
         ? this.props.children
-        : React.Children.map(this.props.children, child => child.type === Text ? React.cloneElement(child, { uppercase: true, ...child.props }) : child);
+        : React.Children.map(this.props.children, child => child && child.type === Text ? React.cloneElement(child, { uppercase: true, ...child.props }) : child);
     if (Platform.OS==='ios' || variables.androidRipple===false || Platform['Version'] <= 21) {
       return (
         <TouchableOpacity

--- a/src/smart/STabs/index.js
+++ b/src/smart/STabs/index.js
@@ -137,8 +137,8 @@ class STabs extends Component {
   render() {
     const tabBarProps = {
       goToPage: this.goToPage.bind(this),
-      tabs: this.props.children.map(child => child.props.tabLabel),
-      tabIcon: this.props.children.map(child => child.props.tabIcon),
+      tabs: this.props.children.map(child => child && child.props.tabLabel),
+      tabIcon: this.props.children.map(child => child && child.props.tabIcon),
       activeTab: this.state.currentPage,
       iconPresent: (this.props.children[0].props.tabIcon) ? true : false,
       tabBarTextStyle: this.props.tabBarTextStyle,


### PR DESCRIPTION
fix #264

Child can be `null` or `false` and `child.type` will throw error.

example:
```js
isLoading = false // or true
return <Button>
  {isLoading && <Spinner/>}
  {!isLoading && <Text>Send</Text>}
</Button>
```