### PR TITLE
Make looping property to work as intended

### DIFF
--- a/src/basic/DeckSwiper.js
+++ b/src/basic/DeckSwiper.js
@@ -18,7 +18,7 @@ class DeckSwiper extends Component {
       card1Top: true,
       card2Top: false,
       fadeAnim: new Animated.Value(0.8),
-      looping: this.props.looping || true,
+      looping: typeof this.props.looping === 'undefined' ? true : this.props.looping,
       disabled: this.props.dataSource.length === 0,
       lastCard: this.props.dataSource.length === 1
     };


### PR DESCRIPTION
## Problem

`this.props.looping || true` will always set the looping state to true (Not only undefined but also false)

## Solution

Set `this.state.looping` to true only if `this.props.looping` is undefined