### PR TITLE
zero value check added for button's active opacity.

### DIFF
--- a/src/basic/Button.js
+++ b/src/basic/Button.js
@@ -55,7 +55,7 @@ class Button extends Component {
           {...this.prepareRootProps()}
           ref={c => (this._root = c)}
           activeOpacity={
-            this.props.activeOpacity ? this.props.activeOpacity : 0.5
+            this.props.activeOpacity > 0 ? this.props.activeOpacity : 0.5
           }
         >
           {children}


### PR DESCRIPTION
Current: If `props.activeOpacity` will be `0`, `activeOpacity` is being `0.5`

Fix for above issue.