### PR TITLE
Add missing props in TypeScript definitions file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -631,7 +631,7 @@ declare module "native-base" {
 		}
 
 		interface Tab {
-			heading: TabHeading;
+			heading: _TabHeading;
 		}
 		interface TabHeading {
 			activeTabStyle?: ReactNative.ViewStyle;
@@ -909,6 +909,7 @@ declare module "native-base" {
 	export class Tab extends React.Component<NativeBase.Tab, any> {}
 
 	export class TabHeading extends React.Component<NativeBase.TabHeading, any> {}
+	type _TabHeading = TabHeading;
 	/**
      * NativeBase.Item
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -87,6 +87,7 @@ declare module "native-base" {
              */
 			hasTabs?: boolean;
 			noShadow?: boolean;
+			androidStatusBarColor?: string;
 		}
 
 		interface Left {
@@ -560,6 +561,7 @@ declare module "native-base" {
          */
 		interface CheckBox {
 			checked?: boolean;
+			color?: string;
 		}
 		/**
          * see Widget CheckBox.js


### PR DESCRIPTION
This PR adds two props which were missing from index.d.ts: `androidStatusBarColor` (on `Header`) and `color` (on `CheckBox`). It also points the `header` prop on `Tab` to the right type (previously it was referencing the property type definition, and not the actual component class. Since the names clash, I used an underscored alias.