### PR TITLE
Set layout handler on button when tab has no name

### DIFF
--- a/src/basic/Tabs/ScrollableTabBar.js
+++ b/src/basic/Tabs/ScrollableTabBar.js
@@ -152,7 +152,7 @@ const ScrollableTabBar = createReactClass({
 			);
 		} else {
 			return (
-				<Button key={_.random(1.2, 5.2)} onPress={() => onPressHandler(page)}>
+				<Button key={_.random(1.2, 5.2)} onPress={() => onPressHandler(page)} onLayout={onLayoutHandler}>
 					<TabHeading scrollable style={tabHeaderStyle} active={isTabActive}>
 						{headerContent}
 					</TabHeading>


### PR DESCRIPTION
This was causing the tabs to not be measured, and breaking the indicator layout on scrollable tabs.