### PR TITLE
Add ES6 module entry point for webpack and rollup.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "gitHead": "5bbeacc403ba97622703699132c55d8359344004",
   "homepage": "https://github.com/GeekyAnts/NativeBase#readme",
   "main": "dist/src/index.js",
+  "module": "src/index.js",
   "typings": "./index.d.ts",
   "optionalDependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
This just adds a `module` field to the `package.json` to point to the uncompiled ES6 modules, enabling tree shaking.