### PR TITLE
Fix default export for computeProps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "gitHead": "5bbeacc403ba97622703699132c55d8359344004",
   "homepage": "https://github.com/GeekyAnts/NativeBase#readme",
   "main": "dist/src/index.js",
+  "module": "src/index.js",
   "typings": "./index.d.ts",
   "optionalDependencies": {},
   "peerDependencies": {

--- a/src/Utils/computeProps.js
+++ b/src/Utils/computeProps.js
@@ -3,7 +3,7 @@ import _ from "lodash";
 import ReactNativePropRegistry from "react-native/Libraries/Renderer/shims/ReactNativePropRegistry";
 // For compatibility with RN 0.25
 // import ReactNativePropRegistry from "react-native/Libraries/ReactNative/ReactNativePropRegistry";
-module.exports = function(incomingProps, defaultProps) {
+function computeProps(incomingProps, defaultProps) {
   // External props has a higher precedence
   let computedProps = {};
 
@@ -42,3 +42,5 @@ module.exports = function(incomingProps, defaultProps) {
   // console.log("computedProps ", computedProps);
   return computedProps;
 };
+
+export default computeProps;


### PR DESCRIPTION
Experimentally, I found there would be errors when using the `src` folder with
Webpack (see https://github.com/GeekyAnts/NativeBase/pull/1268):

```
WARNING in ./node_modules/native-base/src/basic/Fab.js
1:3390-3402 "export 'default' (imported as 'computeProps') was not found in
  '../Utils/computeProps'
```

The solution was to name the function and export it by default.