### PR TITLE
Fix mixed ES6 imports with CommonJS exports.

### DIFF
--- a/src/Utils/mapPropsToStyleNames.js
+++ b/src/Utils/mapPropsToStyleNames.js
@@ -1,6 +1,6 @@
 import _ from "lodash";
 
-export default (mapPropsToStyleNames = (styleNames, props) => {
+const mapPropsToStyleNames = (styleNames, props) => {
   const keys = _.keys(props);
   const values = _.values(props);
 
@@ -11,4 +11,6 @@ export default (mapPropsToStyleNames = (styleNames, props) => {
   });
 
   return styleNames;
-});
+};
+
+export default mapPropsToStyleNames;

--- a/src/basic/Tabs/Button.android.js
+++ b/src/basic/Tabs/Button.android.js
@@ -14,4 +14,4 @@ const Button = props => {
   );
 };
 
-module.exports = Button;
+export default Button;

--- a/src/basic/Tabs/Button.ios.js
+++ b/src/basic/Tabs/Button.ios.js
@@ -10,4 +10,4 @@ const Button = props => {
   );
 };
 
-module.exports = Button;
+export default Button;

--- a/src/basic/Tabs/Button.windows.js
+++ b/src/basic/Tabs/Button.windows.js
@@ -10,4 +10,4 @@ const Button = props => {
   );
 };
 
-module.exports = Button;
+export default Button;

--- a/src/basic/Tabs/SceneComponent.js
+++ b/src/basic/Tabs/SceneComponent.js
@@ -16,4 +16,4 @@ const SceneComponent = Props => {
   );
 };
 
-module.exports = SceneComponent;
+export default SceneComponent;

--- a/src/basic/Tabs/StaticContainer.js
+++ b/src/basic/Tabs/StaticContainer.js
@@ -14,4 +14,4 @@ class StaticContainer extends React.Component {
   }
 }
 
-module.exports = StaticContainer;
+export default StaticContainer;

--- a/src/basic/Tabs/index.js
+++ b/src/basic/Tabs/index.js
@@ -287,7 +287,7 @@ const ScrollableTabView = createReactClass({
 	},
 });
 
-module.exports = ScrollableTabView;
+export default ScrollableTabView;
 
 const styles = StyleSheet.create({
 	container: {


### PR DESCRIPTION
When using Webpack/Rollup with ES6 modules, mixed module formats can cause errors.

This fixes that.

Also, I am a bit confused by the file `src/Utils/mapPropsToStyleNames.js`. It appears the authors intended it to be something like a default parameter? But assigning to `mapPropsToStyleNames` without a declaration is an error.