### PR TITLE
DefaultTabBar and ScrollableTabBar use mapPropsToStyleNames without import

### DIFF
--- a/src/basic/Tabs/DefaultTabBar.js
+++ b/src/basic/Tabs/DefaultTabBar.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import createReactClass from "create-react-class";
 const ReactNative = require("react-native");
 import { connectStyle, StyleProvider } from "native-base-shoutem-theme";
+import mapPropsToStyleNames from "../../Utils/mapPropsToStyleNames";
 import variable from "./../../theme/variables/platform";
 import { TabHeading, Text, TabContainer } from "./../../index";
 import _ from "lodash";

--- a/src/basic/Tabs/ScrollableTabBar.js
+++ b/src/basic/Tabs/ScrollableTabBar.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import createReactClass from "create-react-class";
 const ReactNative = require("react-native");
 import { connectStyle, StyleProvider } from "native-base-shoutem-theme";
+import mapPropsToStyleNames from "../../Utils/mapPropsToStyleNames";
 import variable from "./../../theme/variables/platform";
 import { TabHeading, Text, TabContainer } from "./../../index";
 import _ from "lodash";


### PR DESCRIPTION
The variable `mapPropsToStyleNames` is undefined when it's later used. I assume the intention is to use the definition in `Utils`.