### PR TITLE
removes unused and broken var declaration

### DIFF
--- a/src/basic/Item.js
+++ b/src/basic/Item.js
@@ -32,7 +32,7 @@ class Item extends Component {
 	componentWillReceiveProps(nextProps) {
 		const childrenArray = React.Children.toArray(nextProps.children);
 		let inputProps = {};
-		input = _.remove(childrenArray, item => {
+		_.remove(childrenArray, item => {
 			if (item.type.displayName === "Styled(Input)") {
 				inputProps = item.props;
 				this.inputProps = item.props;


### PR DESCRIPTION
`input` was not defined anything, so the code would break. I realised that the var is not used at all, so I removed it.