### PR TITLE
Fix for issue #1331.

### DIFF
--- a/src/basic/Icon/NBIcons.json
+++ b/src/basic/Icon/NBIcons.json
@@ -1401,7 +1401,7 @@
   },
   "happy": {
     "android": {
-      "default": "md-happy-outline",
+      "default": "md-happy",
       "active": "md-happy"
     },
     "ios": {


### PR DESCRIPTION
Issue - Icon "happy" maps to non-existent "md-happy-outline" on android