### PR TITLE
Tabs initial setup change

### DIFF
--- a/src/basic/Tabs/index.js
+++ b/src/basic/Tabs/index.js
@@ -66,9 +66,8 @@ const ScrollableTabView = createReactClass({
 
   componentDidMount() {
     const scrollFn = () => {
-      if (this.scrollView && Platform.OS === "android") {
-        const x = this.props.initialPage * this.state.containerWidth;
-        this.scrollView.scrollTo({ x, animated: false });
+      if (this.scrollView) {
+        this.state.scrollValue.setValue(this.props.initialPage);
       }
     };
     this.setTimeout(() => {


### PR DESCRIPTION
<Tabs /> underline is not properly positioned when there is a lot of stuff to render.
This fix eliminates issue in my case, but simply putting around hundred <Text /> children breaks it 100% on iOS.
Further investigation required