### PR TITLE
(typescript) Add missing tabBarUnderlineStyle property to Tabs 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -640,6 +640,7 @@ declare module "native-base" {
 			onChangeTab?: Function;
 			locked?: boolean;
 			initialPage?: number;
+			tabBarUnderlineStyle?: ReactNative.ViewStyle;
 		}
 
 		interface Tab {


### PR DESCRIPTION
Added the tabBarUnderlineStyle property as it was missing from the typescript definitions.