### PR TITLE
fix bug - Type 'Element' is not assignable to type 'TabHeading' #1301

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -643,7 +643,7 @@ declare module "native-base" {
 		}
 
 		interface Tab {
-			heading: _TabHeading;
+			heading: _TabHeading | string;
 		}
 		interface TabHeading {
 			activeTabStyle?: ReactNative.ViewStyle;


### PR DESCRIPTION
fix this bug : 
https://github.com/GeekyAnts/NativeBase/issues/1301

modify the index.d.ts file.