### PR TITLE
Fix for issue #1521

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "native-base-shoutem-theme": "0.2.2",
     "print-message": "^2.1.0",
     "prop-types": "^15.5.10",
-    "react-native-drawer": "https://github.com/GeekyAnts/react-native-drawer",
+    "react-native-drawer": "2.5.0",
     "react-native-easy-grid": "0.1.15",
-    "react-native-keyboard-aware-scroll-view": "https://github.com/GeekyAnts/react-native-keyboard-aware-scroll-view",
+    "react-native-keyboard-aware-scroll-view": "0.4.2",
     "react-native-vector-icons": "~4.4.2",
     "react-tween-state": "^0.1.5",
     "tween-functions": "^1.0.1"


### PR DESCRIPTION
This change guarantees the use of the npm repository in the stable versions of the repositories: react-native-drawer@2.5.0 and react-native-keyboard-aware-scroll-view@0.4.2.