### PR TITLE
Added icon styles to transparent button in footer, fix #1576

### DIFF
--- a/src/theme/components/Footer.js
+++ b/src/theme/components/Footer.js
@@ -14,7 +14,13 @@ export default (variables = variable) => {
           shadowColor: null,
           shadowOffset: null,
           shadowRadius: null,
-          shadowOpacity: null
+          shadowOpacity: null,
+          "NativeBase.Icon": {
+            color: variables.topTabBarActiveTextColor
+          },
+          "NativeBase.IconNB": {
+            color: variables.topTabBarActiveTextColor
+          }
         },
         "NativeBase.Icon": {
           color: variables.topTabBarActiveTextColor
@@ -42,7 +48,13 @@ export default (variables = variable) => {
           shadowColor: null,
           shadowOffset: null,
           shadowRadius: null,
-          shadowOpacity: null
+          shadowOpacity: null,
+          "NativeBase.Icon": {
+            color: variables.topTabBarActiveTextColor
+          },
+          "NativeBase.IconNB": {
+            color: variables.topTabBarActiveTextColor
+          }
         },
         ".full": {
           height: variables.footerHeight,
@@ -66,7 +78,13 @@ export default (variables = variable) => {
           shadowColor: null,
           shadowOffset: null,
           shadowRadius: null,
-          shadowOpacity: null
+          shadowOpacity: null,
+          "NativeBase.Icon": {
+            color: variables.topTabBarActiveTextColor
+          },
+          "NativeBase.IconNB": {
+            color: variables.topTabBarActiveTextColor
+          }
         },
         "NativeBase.Icon": {
           color: variables.topTabBarActiveTextColor

--- a/src/theme/components/Footer.js
+++ b/src/theme/components/Footer.js
@@ -15,12 +15,18 @@ export default (variables = variable) => {
           shadowOffset: null,
           shadowRadius: null,
           shadowOpacity: null,
+          'NativeBase.Text': {
+            color: variables.topTabBarActiveTextColor
+          },
           "NativeBase.Icon": {
             color: variables.topTabBarActiveTextColor
           },
           "NativeBase.IconNB": {
             color: variables.topTabBarActiveTextColor
           }
+        },
+        'NativeBase.Text': {
+          color: variables.topTabBarActiveTextColor
         },
         "NativeBase.Icon": {
           color: variables.topTabBarActiveTextColor
@@ -49,6 +55,9 @@ export default (variables = variable) => {
           shadowOffset: null,
           shadowRadius: null,
           shadowOpacity: null,
+          'NativeBase.Text': {
+            color: variables.topTabBarActiveTextColor
+          },
           "NativeBase.Icon": {
             color: variables.topTabBarActiveTextColor
           },
@@ -60,6 +69,9 @@ export default (variables = variable) => {
           height: variables.footerHeight,
           paddingBottom:variables.footerPaddingBottom,
           flex: 1
+        },
+        'NativeBase.Text': {
+          color: variables.topTabBarActiveTextColor
         },
         "NativeBase.Icon": {
           color: variables.topTabBarActiveTextColor
@@ -79,12 +91,18 @@ export default (variables = variable) => {
           shadowOffset: null,
           shadowRadius: null,
           shadowOpacity: null,
+          'NativeBase.Text': {
+            color: variables.topTabBarActiveTextColor
+          },
           "NativeBase.Icon": {
             color: variables.topTabBarActiveTextColor
           },
           "NativeBase.IconNB": {
             color: variables.topTabBarActiveTextColor
           }
+        },
+        'NativeBase.Text': {
+          color: variables.topTabBarActiveTextColor
         },
         "NativeBase.Icon": {
           color: variables.topTabBarActiveTextColor


### PR DESCRIPTION
Fixes #1576

Icons in buttons in footers are not being styled by the global variables, causing them to always be black. To fix this, I basically copied what was done in Headers.js, to get the global color from commonColor.js to be used as the icon color. Additionally, I added styles for text colors in buttons as well (to match the icon color).