### PR TITLE
Consider Icon type prop when fetching names

### DIFF
--- a/src/basic/Icon/index.js
+++ b/src/basic/Icon/index.js
@@ -21,7 +21,7 @@ class Icon extends Component {
 		const platformStyle = variables.platformStyle;
 		const platform = variables.platform;
 
-		if (variables.iconFamily === "Ionicons") {
+		if ((this.props.type || variables.iconFamily) === "Ionicons") {
 			if (typeof ic[this.props.name] !== "object") {
 				return this.props.name;
 			} else if (typeof ic[this.props.name] === "object") {


### PR DESCRIPTION
This prevents icon names from being mapped via `NBIcons.json` when prop `type` is configured as something other than `"Ionicons"`.

Without this fix the following name is incorrectly mapped to `"md-send"` which fails to load for type `"MaterialIcons"`:
``` javascript
<Icon name="send" type="MaterialIcons" />
```