### PR TITLE
Max height on actionsheet modal

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parser": "babel-eslint",
-  "rules":{
+  {
     "indent": [
       "error",
       2

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,11 @@
 {
   "parser": "babel-eslint",
-  "indent": [
-    "error",
-    2
-  ],
+  "rules":{
+    "indent": [
+      "error",
+      2
+    ]
+  },
   "plugins": [
     "react",
     "jsx-a11y",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,9 @@
 {
   "parser": "babel-eslint",
-  {
-    "indent": [
-      "error",
-      2
-    ]
-  },
+  "indent": [
+    "error",
+    2
+  ],
   "plugins": [
     "react",
     "jsx-a11y",

--- a/src/basic/Actionsheet.js
+++ b/src/basic/Actionsheet.js
@@ -89,6 +89,7 @@ class ActionSheetContainer extends Component {
             style={{
               backgroundColor: "#fff",
               height: this.state.length * 80,
+              maxHeight: "100%",
               padding: 15,
               elevation: 4
             }}


### PR DESCRIPTION
Resolves #1595. This will make sure that a large modal created for android action sheet stays inside the bounds of the root container.

Before:
![screen shot 2018-02-15 at 5 45 38 pm](https://user-images.githubusercontent.com/3289501/36290789-6e1f45fc-1284-11e8-8497-3a9bd931e747.png)

After:
![screen shot 2018-02-15 at 7 20 48 pm](https://user-images.githubusercontent.com/3289501/36290958-88568178-1285-11e8-8232-cc99f168a2da.png)

Extra change:  Eslint was unable to read the rc file as it was written. I updated to insure this change would be within the parameters of the eslint guidelines for the project.