### PR TITLE
Fix for issue #1601 (React Native have to double click for onPress to…

### DIFF
--- a/src/basic/Tabs/index.js
+++ b/src/basic/Tabs/index.js
@@ -152,6 +152,7 @@ const ScrollableTabView = createReactClass({
         horizontal
         pagingEnabled
         automaticallyAdjustContentInsets={false}
+        keyboardShouldPersistTaps="handled"
         contentOffset={{
           x: this.props.initialPage * this.state.containerWidth,
         }}


### PR DESCRIPTION
… work inside Tab)