### PR TITLE
get correct icon name when using custom Icon type

### DIFF
--- a/src/basic/Icon/index.js
+++ b/src/basic/Icon/index.js
@@ -21,7 +21,7 @@ class Icon extends Component {
 		const platformStyle = variables.platformStyle;
 		const platform = variables.platform;
 
-		if (variables.iconFamily === "Ionicons") {
+		if (!this.props.type && variables.iconFamily === "Ionicons") {
 			if (typeof ic[this.props.name] !== "object") {
 				return this.props.name;
 			} else if (typeof ic[this.props.name] === "object") {


### PR DESCRIPTION
when using <Icon> and provide with custom `type` props, we shouldn't auto prefix `md-` and `ios-`
related issue: 
https://github.com/GeekyAnts/NativeBase/issues/1640