### PR TITLE
If application root is reinitialized, update ActionSheet and Toast refs

### DIFF
--- a/dist/src/basic/Root.js
+++ b/dist/src/basic/Root.js
@@ -14,12 +14,12 @@ _react2.default.createElement(_reactNative.View,_extends({ref:function ref(c){re
 this.props.children,
 _react2.default.createElement(_ToastContainer.ToastContainer,{
 ref:function ref(c){
-if(!_ToastContainer.ToastContainer.toastInstance)_ToastContainer.ToastContainer.toastInstance=c;
+if(c)_ToastContainer.ToastContainer.toastInstance=c;
 },__source:{fileName:_jsxFileName,lineNumber:15}}),
 
 _react2.default.createElement(_Actionsheet.ActionSheetContainer,{
 ref:function ref(c){
-if(!_Actionsheet.ActionSheetContainer.actionsheetInstance)
+if(c)
 _Actionsheet.ActionSheetContainer.actionsheetInstance=c;
 },__source:{fileName:_jsxFileName,lineNumber:20}})));
 

--- a/src/basic/Root.js
+++ b/src/basic/Root.js
@@ -14,12 +14,12 @@ class Root extends Component {
         {this.props.children}
         <Toast
           ref={c => {
-            if (!Toast.toastInstance) Toast.toastInstance = c;
+            if (c) Toast.toastInstance = c;
           }}
         />
         <ActionSheet
           ref={c => {
-            if (!ActionSheet.actionsheetInstance)
+            if (c)
               ActionSheet.actionsheetInstance = c;
           }}
         />


### PR DESCRIPTION
This PR is related to issues #1397, #1315, #937.

There is potential that React Native may unmount and remount the root node of the application due to Android lifecycle events without clearing the JS execution environment.  (This is possible even if native-base's `Root` is the top level component.)  This results in `actionSheetInstance` being invalid as it pointed to the previously mounted application root's ActionSheet component that was unmounted.  

This pull request updates the static `actionSheetInstance` and `toastInstance` refs regardless of what state they are in such that stale refs will be overwritten appropriately.

According to the [React Ref documentation](https://reactjs.org/docs/refs-and-the-dom.html):
> React will call the ref callback with the DOM element when the component mounts, and call it with null when it unmounts.

Thus, there is a null check on `c` in the ref callbacks.