### PR TITLE
Added support for disabled transparent buttons in theme.

### DIFF
--- a/src/theme/components/Button.js
+++ b/src/theme/components/Button.js
@@ -250,6 +250,20 @@ export default (variables = variable) => {
         ...lightCommon,
         backgroundColor: null,
       },
+      '.disabled': {
+        backgroundColor: 'transparent',
+        borderColor: variables.btnDisabledBg,
+        borderWidth: variables.borderWidth * 2,
+        'NativeBase.Text': {
+          color: variables.btnDisabledBg,
+        },
+        'NativeBase.Icon': {
+          color: variables.btnDisabledBg,
+        },
+        'NativeBase.IconNB': {
+          color: variables.btnDisabledBg,
+        }
+      }
     },
 
     '.small': {

--- a/src/theme/components/Button.js
+++ b/src/theme/components/Button.js
@@ -81,8 +81,14 @@ export default (variables = variable) => {
     }
   }
   const buttonTheme = {
-    '.disabled': {
-      backgroundColor: variables.btnDisabledBg,
+    ".disabled": {
+      ".transparent": {
+        backgroundColor: null,
+        "NativeBase.Text": {
+          color: variables.btnDisabledBg
+        }
+      },
+      backgroundColor: variables.btnDisabledBg
     },
     '.bordered': {
       '.dark': {


### PR DESCRIPTION
Attempt to fix issue #1742(Disabled transparent buttons should stay transparent and "disable" text inside)