### PR TITLE
Add type to proptypes

### DIFF
--- a/src/basic/Icon/index.js
+++ b/src/basic/Icon/index.js
@@ -76,6 +76,7 @@ Icon.propTypes = {
 	ios: PropTypes.string,
 	android: PropTypes.string,
 	active: PropTypes.bool,
+	type: PropTypes.string,
 };
 
 const StyledIcon = connectStyle("NativeBase.Icon", {}, mapPropsToStyleNames)(Icon);


### PR DESCRIPTION
Add missing property `type` to Icon.PropTypes