### PR TITLE
TS: Add all valid props to Content interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -155,21 +155,25 @@ declare module "native-base" {
 		/**
          * see Widget Content.js
          */
-		interface Content {
-			/**
-             * The theme prop can be applied to any component of NativeBase.
-             */
-			refreshing?: boolean;
-			refreshControl?: object;
+		interface Content extends ReactNative.ScrollViewProperties {
+      /**
+       * The theme prop can be applied to any component of NativeBase.
+       */
 			theme?: Object;
 			padder?: boolean;
 			disableKBDismissScroll?: boolean;
+			viewIsInsideTabBar?: boolean;
+			resetScrollToCoords?: {
+				x: number;
+				y: number;
+			};
 			enableResetScrollToCoords?: boolean;
-			contentOffset?: Object;
-			scrollEnabled?: boolean;
-			style?: ReactNative.ViewStyle | Array<ReactNative.ViewStyle>;
-			contentContainerStyle?: ReactNative.ViewStyle | Array<ReactNative.ViewStyle>;
-		}
+			enableAutomaticScroll?: boolean;
+			enableOnAndroid?: boolean;
+			extraHeight?: number;
+			extraScrollHeight?: number;
+			keyboardOpeningTime?: number;
+    }
 		/**
          * see Widget Button.js
          */


### PR DESCRIPTION
Based on the [react-native-keyboard-aware-scroll-view docs](https://github.com/APSL/react-native-keyboard-aware-scroll-view) (which the Content component wraps), this component should be able to accept all ScrollView props, as well some additional props to control the keyboard-aware-scroll-view (which have been directly copied from [that project's d.ts](https://github.com/APSL/react-native-keyboard-aware-scroll-view/blob/master/index.d.ts), as it does not export it's props). All redundant props have been removed from the interface.