### PR TITLE
types: remove double semi-colon

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1120,7 +1120,7 @@ declare module "native-base" {
 			position?: "top" | "bottom" | "center";
 			type?: "danger" | "success" | "warning";
 			duration?: number;
-			onClose?: (reason: "user" | "timeout") => any;;
+			onClose?: (reason: "user" | "timeout") => any;
 			textStyle?: ReactNative.TextStyle;
 			buttonTextStyle?: ReactNative.TextStyle;
 			buttonStyle?: ReactNative.ViewStyle;


### PR DESCRIPTION
the double semi-colon caused the following error: `node_modules/native-base/index.d.ts(1123,50): error TS1131: Property or signature expected`