### PR TITLE
Allow formatting of DatePicker chosen date text

### DIFF
--- a/__tests__/basic/DatePicker.android.js
+++ b/__tests__/basic/DatePicker.android.js
@@ -1,0 +1,88 @@
+import "react-native";
+import React from "react";
+import renderer from "react-test-renderer";
+import { Content } from "./../../src/basic/Content";
+import { DatePicker } from "./../../src/basic/DatePicker";
+
+// Note: test renderer must be required after react-native.
+
+jest.mock("Platform", () => {
+  const Platform = require.requireActual("Platform");
+  Platform.OS = "android";
+  return Platform;
+});
+
+it("renders with placeholder", () => {
+  let tree = renderer
+    .create(
+      <Content>
+        <DatePicker
+          defaultDate={new Date(2018, 1, 1)}
+          minimumDate={new Date(2018, 1, 1)}
+          maximumDate={new Date(2019, 1, 1)}
+          locale={"en"}
+          modalTransparent={false}
+          animationType={"fade"}
+          androidMode={"default"}
+          placeHolderText={"Select Date"}
+        />
+      </Content>
+    );
+
+  expect(tree.toJSON()).toMatchSnapshot();
+});
+
+it("renders with default formatted chosen date", () => {
+  // Default format is D/M/YYYY
+  let tree = renderer
+    .create(
+      <Content>
+        <DatePicker
+          defaultDate={new Date(2018, 1, 1)}
+          minimumDate={new Date(2018, 1, 1)}
+          maximumDate={new Date(2019, 1, 1)}
+          locale={"en"}
+          modalTransparent={false}
+          animationType={"fade"}
+          androidMode={"default"}
+          placeHolderText={"Select Date"}
+        />
+      </Content>
+    );
+
+  const picker = tree.root.findByType(DatePicker);
+  picker.instance.setDate(new Date(2018, 1, 2));
+
+  expect(tree.toJSON()).toMatchSnapshot();
+});
+
+it("renders with custom formatted chosen date", () => {
+  // Custom format is YYYY-M-D
+  let customDateFormatter = date => [
+    date.getFullYear(),
+    date.getMonth() + 1,
+    date.getDate(),
+  ].join('-')
+
+  let tree = renderer
+    .create(
+      <Content>
+        <DatePicker
+          defaultDate={new Date(2018, 1, 1)}
+          formatChosenDate={customDateFormatter}
+          minimumDate={new Date(2018, 1, 1)}
+          maximumDate={new Date(2019, 1, 1)}
+          locale={"en"}
+          modalTransparent={false}
+          animationType={"fade"}
+          androidMode={"default"}
+          placeHolderText={"Select Date"}
+        />
+      </Content>
+    );
+
+  const picker = tree.root.findByType(DatePicker);
+  picker.instance.setDate(new Date(2018, 1, 2));
+
+  expect(tree.toJSON()).toMatchSnapshot();
+});

--- a/__tests__/basic/DatePicker.ios.js
+++ b/__tests__/basic/DatePicker.ios.js
@@ -1,0 +1,88 @@
+import "react-native";
+import React from "react";
+import renderer from "react-test-renderer";
+import { Content } from "./../../src/basic/Content";
+import { DatePicker } from "./../../src/basic/DatePicker";
+
+// Note: test renderer must be required after react-native.
+
+jest.mock("Platform", () => {
+  const Platform = require.requireActual("Platform");
+  Platform.OS = "ios";
+  return Platform;
+});
+
+it("renders with placeholder", () => {
+  let tree = renderer
+    .create(
+      <Content>
+        <DatePicker
+          defaultDate={new Date(2018, 1, 1)}
+          minimumDate={new Date(2018, 1, 1)}
+          maximumDate={new Date(2019, 1, 1)}
+          locale={"en"}
+          modalTransparent={false}
+          animationType={"fade"}
+          androidMode={"default"}
+          placeHolderText={"Select Date"}
+        />
+      </Content>
+    );
+
+  expect(tree.toJSON()).toMatchSnapshot();
+});
+
+it("renders with default formatted chosen date", () => {
+  // Default format is D/M/YYYY
+  let tree = renderer
+    .create(
+      <Content>
+        <DatePicker
+          defaultDate={new Date(2018, 1, 1)}
+          minimumDate={new Date(2018, 1, 1)}
+          maximumDate={new Date(2019, 1, 1)}
+          locale={"en"}
+          modalTransparent={false}
+          animationType={"fade"}
+          androidMode={"default"}
+          placeHolderText={"Select Date"}
+        />
+      </Content>
+    );
+
+  const picker = tree.root.findByType(DatePicker);
+  picker.instance.setDate(new Date(2018, 1, 2));
+
+  expect(tree.toJSON()).toMatchSnapshot();
+});
+
+it("renders with custom formatted chosen date", () => {
+  // Custom format is YYYY-M-D
+  let customDateFormatter = date => [
+    date.getFullYear(),
+    date.getMonth() + 1,
+    date.getDate(),
+  ].join('-')
+
+  let tree = renderer
+    .create(
+      <Content>
+        <DatePicker
+          defaultDate={new Date(2018, 1, 1)}
+          formatChosenDate={customDateFormatter}
+          minimumDate={new Date(2018, 1, 1)}
+          maximumDate={new Date(2019, 1, 1)}
+          locale={"en"}
+          modalTransparent={false}
+          animationType={"fade"}
+          androidMode={"default"}
+          placeHolderText={"Select Date"}
+        />
+      </Content>
+    );
+
+  const picker = tree.root.findByType(DatePicker);
+  picker.instance.setDate(new Date(2018, 1, 2));
+
+  expect(tree.toJSON()).toMatchSnapshot();
+});

--- a/__tests__/basic/__snapshots__/DatePicker.android.js.snap
+++ b/__tests__/basic/__snapshots__/DatePicker.android.js.snap
@@ -1,0 +1,406 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders with custom formatted chosen date 1`] = `
+<RCTScrollView
+  automaticallyAdjustContentInsets={false}
+  contentContainerStyle={
+    Array [
+      Object {
+        "padding": undefined,
+      },
+      undefined,
+    ]
+  }
+  contentInset={
+    Object {
+      "bottom": 0,
+    }
+  }
+  enableAutomaticScroll={true}
+  enableResetScrollToCoords={true}
+  extraHeight={75}
+  extraScrollHeight={0}
+  getScrollResponder={[Function]}
+  handleOnScroll={[Function]}
+  keyboardDismissMode="interactive"
+  keyboardOpeningTime={250}
+  keyboardShouldPersistTaps="handled"
+  keyboardSpace={0}
+  onScroll={[Function]}
+  resetKeyboardSpace={[Function]}
+  resetScrollToCoords={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
+  scrollEventThrottle={1}
+  scrollForExtraHeightOnAndroid={[Function]}
+  scrollToEnd={[Function]}
+  scrollToFocusedInput={[Function]}
+  scrollToPosition={[Function]}
+  showsVerticalScrollIndicator={true}
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "flex": 1,
+    }
+  }
+  viewIsInsideTabBar={false}
+  virtual={undefined}
+>
+  <View>
+    <View>
+      <View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          disabled={false}
+          ellipsizeMode="tail"
+          onPress={[Function]}
+          style={
+            Array [
+              Object {
+                "color": "#000",
+                "fontFamily": "Roboto",
+                "fontSize": 16,
+              },
+              Object {
+                "color": "#000",
+                "padding": 10,
+              },
+              undefined,
+            ]
+          }
+          uppercase={false}
+          virtual={undefined}
+        >
+          2018-2-2
+        </Text>
+        <View>
+          <Modal
+            animationType="fade"
+            hardwareAccelerated={false}
+            onRequestClose={[Function]}
+            transparent={false}
+            visible={false}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              disabled={false}
+              ellipsizeMode="tail"
+              onPress={[Function]}
+              style={
+                Array [
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "Roboto",
+                    "fontSize": 16,
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                    "flex": 1,
+                  },
+                ]
+              }
+              uppercase={false}
+              virtual={undefined}
+            />
+            <View
+              style={undefined}
+            >
+              <RCTDatePicker
+                date={1517558400000}
+                maximumDate={1549008000000}
+                minimumDate={1517472000000}
+                minuteInterval={undefined}
+                mode="date"
+                onChange={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "height": 216,
+                  }
+                }
+                timeZoneOffsetInMinutes={undefined}
+              />
+            </View>
+          </Modal>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`renders with default formatted chosen date 1`] = `
+<RCTScrollView
+  automaticallyAdjustContentInsets={false}
+  contentContainerStyle={
+    Array [
+      Object {
+        "padding": undefined,
+      },
+      undefined,
+    ]
+  }
+  contentInset={
+    Object {
+      "bottom": 0,
+    }
+  }
+  enableAutomaticScroll={true}
+  enableResetScrollToCoords={true}
+  extraHeight={75}
+  extraScrollHeight={0}
+  getScrollResponder={[Function]}
+  handleOnScroll={[Function]}
+  keyboardDismissMode="interactive"
+  keyboardOpeningTime={250}
+  keyboardShouldPersistTaps="handled"
+  keyboardSpace={0}
+  onScroll={[Function]}
+  resetKeyboardSpace={[Function]}
+  resetScrollToCoords={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
+  scrollEventThrottle={1}
+  scrollForExtraHeightOnAndroid={[Function]}
+  scrollToEnd={[Function]}
+  scrollToFocusedInput={[Function]}
+  scrollToPosition={[Function]}
+  showsVerticalScrollIndicator={true}
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "flex": 1,
+    }
+  }
+  viewIsInsideTabBar={false}
+  virtual={undefined}
+>
+  <View>
+    <View>
+      <View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          disabled={false}
+          ellipsizeMode="tail"
+          onPress={[Function]}
+          style={
+            Array [
+              Object {
+                "color": "#000",
+                "fontFamily": "Roboto",
+                "fontSize": 16,
+              },
+              Object {
+                "color": "#000",
+                "padding": 10,
+              },
+              undefined,
+            ]
+          }
+          uppercase={false}
+          virtual={undefined}
+        >
+          2/2/2018
+        </Text>
+        <View>
+          <Modal
+            animationType="fade"
+            hardwareAccelerated={false}
+            onRequestClose={[Function]}
+            transparent={false}
+            visible={false}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              disabled={false}
+              ellipsizeMode="tail"
+              onPress={[Function]}
+              style={
+                Array [
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "Roboto",
+                    "fontSize": 16,
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                    "flex": 1,
+                  },
+                ]
+              }
+              uppercase={false}
+              virtual={undefined}
+            />
+            <View
+              style={undefined}
+            >
+              <RCTDatePicker
+                date={1517558400000}
+                maximumDate={1549008000000}
+                minimumDate={1517472000000}
+                minuteInterval={undefined}
+                mode="date"
+                onChange={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "height": 216,
+                  }
+                }
+                timeZoneOffsetInMinutes={undefined}
+              />
+            </View>
+          </Modal>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`renders with placeholder 1`] = `
+<RCTScrollView
+  automaticallyAdjustContentInsets={false}
+  contentContainerStyle={
+    Array [
+      Object {
+        "padding": undefined,
+      },
+      undefined,
+    ]
+  }
+  contentInset={
+    Object {
+      "bottom": 0,
+    }
+  }
+  enableAutomaticScroll={true}
+  enableResetScrollToCoords={true}
+  extraHeight={75}
+  extraScrollHeight={0}
+  getScrollResponder={[Function]}
+  handleOnScroll={[Function]}
+  keyboardDismissMode="interactive"
+  keyboardOpeningTime={250}
+  keyboardShouldPersistTaps="handled"
+  keyboardSpace={0}
+  onScroll={[Function]}
+  resetKeyboardSpace={[Function]}
+  resetScrollToCoords={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
+  scrollEventThrottle={1}
+  scrollForExtraHeightOnAndroid={[Function]}
+  scrollToEnd={[Function]}
+  scrollToFocusedInput={[Function]}
+  scrollToPosition={[Function]}
+  showsVerticalScrollIndicator={true}
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "flex": 1,
+    }
+  }
+  viewIsInsideTabBar={false}
+  virtual={undefined}
+>
+  <View>
+    <View>
+      <View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          disabled={false}
+          ellipsizeMode="tail"
+          onPress={[Function]}
+          style={
+            Array [
+              Object {
+                "color": "#000",
+                "fontFamily": "Roboto",
+                "fontSize": 16,
+              },
+              Object {
+                "color": "#000",
+                "padding": 10,
+              },
+              undefined,
+            ]
+          }
+          uppercase={false}
+          virtual={undefined}
+        >
+          Select Date
+        </Text>
+        <View>
+          <Modal
+            animationType="fade"
+            hardwareAccelerated={false}
+            onRequestClose={[Function]}
+            transparent={false}
+            visible={false}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              disabled={false}
+              ellipsizeMode="tail"
+              onPress={[Function]}
+              style={
+                Array [
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "Roboto",
+                    "fontSize": 16,
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                    "flex": 1,
+                  },
+                ]
+              }
+              uppercase={false}
+              virtual={undefined}
+            />
+            <View
+              style={undefined}
+            >
+              <RCTDatePicker
+                date={1517472000000}
+                maximumDate={1549008000000}
+                minimumDate={1517472000000}
+                minuteInterval={undefined}
+                mode="date"
+                onChange={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "height": 216,
+                  }
+                }
+                timeZoneOffsetInMinutes={undefined}
+              />
+            </View>
+          </Modal>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;

--- a/__tests__/basic/__snapshots__/DatePicker.ios.js.snap
+++ b/__tests__/basic/__snapshots__/DatePicker.ios.js.snap
@@ -1,0 +1,406 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders with custom formatted chosen date 1`] = `
+<RCTScrollView
+  automaticallyAdjustContentInsets={false}
+  contentContainerStyle={
+    Array [
+      Object {
+        "padding": undefined,
+      },
+      undefined,
+    ]
+  }
+  contentInset={
+    Object {
+      "bottom": 0,
+    }
+  }
+  enableAutomaticScroll={true}
+  enableResetScrollToCoords={true}
+  extraHeight={75}
+  extraScrollHeight={0}
+  getScrollResponder={[Function]}
+  handleOnScroll={[Function]}
+  keyboardDismissMode="interactive"
+  keyboardOpeningTime={250}
+  keyboardShouldPersistTaps="handled"
+  keyboardSpace={0}
+  onScroll={[Function]}
+  resetKeyboardSpace={[Function]}
+  resetScrollToCoords={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
+  scrollEventThrottle={1}
+  scrollForExtraHeightOnAndroid={[Function]}
+  scrollToEnd={[Function]}
+  scrollToFocusedInput={[Function]}
+  scrollToPosition={[Function]}
+  showsVerticalScrollIndicator={true}
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "flex": 1,
+    }
+  }
+  viewIsInsideTabBar={false}
+  virtual={undefined}
+>
+  <View>
+    <View>
+      <View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          disabled={false}
+          ellipsizeMode="tail"
+          onPress={[Function]}
+          style={
+            Array [
+              Object {
+                "color": "#000",
+                "fontFamily": "System",
+                "fontSize": 16,
+              },
+              Object {
+                "color": "#000",
+                "padding": 10,
+              },
+              undefined,
+            ]
+          }
+          uppercase={false}
+          virtual={undefined}
+        >
+          2018-2-2
+        </Text>
+        <View>
+          <Modal
+            animationType="fade"
+            hardwareAccelerated={false}
+            onRequestClose={[Function]}
+            transparent={false}
+            visible={false}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              disabled={false}
+              ellipsizeMode="tail"
+              onPress={[Function]}
+              style={
+                Array [
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                    "flex": 1,
+                  },
+                ]
+              }
+              uppercase={false}
+              virtual={undefined}
+            />
+            <View
+              style={undefined}
+            >
+              <RCTDatePicker
+                date={1517558400000}
+                maximumDate={1549008000000}
+                minimumDate={1517472000000}
+                minuteInterval={undefined}
+                mode="date"
+                onChange={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "height": 216,
+                  }
+                }
+                timeZoneOffsetInMinutes={undefined}
+              />
+            </View>
+          </Modal>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`renders with default formatted chosen date 1`] = `
+<RCTScrollView
+  automaticallyAdjustContentInsets={false}
+  contentContainerStyle={
+    Array [
+      Object {
+        "padding": undefined,
+      },
+      undefined,
+    ]
+  }
+  contentInset={
+    Object {
+      "bottom": 0,
+    }
+  }
+  enableAutomaticScroll={true}
+  enableResetScrollToCoords={true}
+  extraHeight={75}
+  extraScrollHeight={0}
+  getScrollResponder={[Function]}
+  handleOnScroll={[Function]}
+  keyboardDismissMode="interactive"
+  keyboardOpeningTime={250}
+  keyboardShouldPersistTaps="handled"
+  keyboardSpace={0}
+  onScroll={[Function]}
+  resetKeyboardSpace={[Function]}
+  resetScrollToCoords={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
+  scrollEventThrottle={1}
+  scrollForExtraHeightOnAndroid={[Function]}
+  scrollToEnd={[Function]}
+  scrollToFocusedInput={[Function]}
+  scrollToPosition={[Function]}
+  showsVerticalScrollIndicator={true}
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "flex": 1,
+    }
+  }
+  viewIsInsideTabBar={false}
+  virtual={undefined}
+>
+  <View>
+    <View>
+      <View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          disabled={false}
+          ellipsizeMode="tail"
+          onPress={[Function]}
+          style={
+            Array [
+              Object {
+                "color": "#000",
+                "fontFamily": "System",
+                "fontSize": 16,
+              },
+              Object {
+                "color": "#000",
+                "padding": 10,
+              },
+              undefined,
+            ]
+          }
+          uppercase={false}
+          virtual={undefined}
+        >
+          2/2/2018
+        </Text>
+        <View>
+          <Modal
+            animationType="fade"
+            hardwareAccelerated={false}
+            onRequestClose={[Function]}
+            transparent={false}
+            visible={false}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              disabled={false}
+              ellipsizeMode="tail"
+              onPress={[Function]}
+              style={
+                Array [
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                    "flex": 1,
+                  },
+                ]
+              }
+              uppercase={false}
+              virtual={undefined}
+            />
+            <View
+              style={undefined}
+            >
+              <RCTDatePicker
+                date={1517558400000}
+                maximumDate={1549008000000}
+                minimumDate={1517472000000}
+                minuteInterval={undefined}
+                mode="date"
+                onChange={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "height": 216,
+                  }
+                }
+                timeZoneOffsetInMinutes={undefined}
+              />
+            </View>
+          </Modal>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`renders with placeholder 1`] = `
+<RCTScrollView
+  automaticallyAdjustContentInsets={false}
+  contentContainerStyle={
+    Array [
+      Object {
+        "padding": undefined,
+      },
+      undefined,
+    ]
+  }
+  contentInset={
+    Object {
+      "bottom": 0,
+    }
+  }
+  enableAutomaticScroll={true}
+  enableResetScrollToCoords={true}
+  extraHeight={75}
+  extraScrollHeight={0}
+  getScrollResponder={[Function]}
+  handleOnScroll={[Function]}
+  keyboardDismissMode="interactive"
+  keyboardOpeningTime={250}
+  keyboardShouldPersistTaps="handled"
+  keyboardSpace={0}
+  onScroll={[Function]}
+  resetKeyboardSpace={[Function]}
+  resetScrollToCoords={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
+  scrollEventThrottle={1}
+  scrollForExtraHeightOnAndroid={[Function]}
+  scrollToEnd={[Function]}
+  scrollToFocusedInput={[Function]}
+  scrollToPosition={[Function]}
+  showsVerticalScrollIndicator={true}
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "flex": 1,
+    }
+  }
+  viewIsInsideTabBar={false}
+  virtual={undefined}
+>
+  <View>
+    <View>
+      <View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          disabled={false}
+          ellipsizeMode="tail"
+          onPress={[Function]}
+          style={
+            Array [
+              Object {
+                "color": "#000",
+                "fontFamily": "System",
+                "fontSize": 16,
+              },
+              Object {
+                "color": "#000",
+                "padding": 10,
+              },
+              undefined,
+            ]
+          }
+          uppercase={false}
+          virtual={undefined}
+        >
+          Select Date
+        </Text>
+        <View>
+          <Modal
+            animationType="fade"
+            hardwareAccelerated={false}
+            onRequestClose={[Function]}
+            transparent={false}
+            visible={false}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              disabled={false}
+              ellipsizeMode="tail"
+              onPress={[Function]}
+              style={
+                Array [
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                    "flex": 1,
+                  },
+                ]
+              }
+              uppercase={false}
+              virtual={undefined}
+            />
+            <View
+              style={undefined}
+            >
+              <RCTDatePicker
+                date={1517472000000}
+                maximumDate={1549008000000}
+                minimumDate={1517472000000}
+                minuteInterval={undefined}
+                mode="date"
+                onChange={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "height": 216,
+                  }
+                }
+                timeZoneOffsetInMinutes={undefined}
+              />
+            </View>
+          </Modal>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "compile": "rm -rf dist/* && babel . --out-dir dist --ignore node_modules,dist --source-maps ",
     "transpile": "npm run compile && cp src/basic/Icon/NBIcons.json dist/src/basic/Icon",
+    "test": "jest",
     "prepublish": "npm run transpile",
     "postinstall": "node addEjectScript.js",
     "flow": "flow"

--- a/src/basic/DatePicker.js
+++ b/src/basic/DatePicker.js
@@ -74,14 +74,10 @@ export class DatePicker extends React.Component {
             ]}
           >
             {this.state.chosenDate
-              ? this.state.chosenDate.getDate() +
-                "/" +
-                (this.state.chosenDate.getMonth() + 1) +
-                "/" +
-                +this.state.chosenDate.getFullYear()
-                : this.props.placeHolderText
-                  ? this.props.placeHolderText
-                  : "Select Date"}
+              ? this.formatChosenDate(this.state.chosenDate)
+              : this.props.placeHolderText
+                ? this.props.placeHolderText
+                : "Select Date"}
           </Text>
           <View>
             <Modal
@@ -112,5 +108,17 @@ export class DatePicker extends React.Component {
         </View>
       </View>
     );
+  }
+
+  formatChosenDate(date) {
+    if (this.props.formatChosenDate) {
+      return this.props.formatChosenDate(date);
+    }
+
+    return [
+      date.getDate(),
+      date.getMonth() + 1,
+      date.getFullYear(),
+    ].join('/');
   }
 }


### PR DESCRIPTION
This commit adds an optional `formatChosenDate` prop to the DatePicker component. If the prop is not supplied this will fall back to the original chosen date text format. Feedback welcome on the name of the prop, other options could be `chosenDateFormatter` or maybe `chosenDateFormat`.

I also included some basic IOS and Android jest tests for the placeholder text, default chosen date format and custom chosen date format. This is my first time adding jest tests so feedback welcome if I've messed anything up.

Test Plan:

- Ran `eslint` on my changes to `DatePicker.js`
- Ran `yarn run jest DatePicker` and inspected the snapshots to ensure properly formatted placeholder text, default format text and custom format text.