### PR TITLE
feat: added toast onButtonClick functionality (requires documentation update)

### DIFF
--- a/src/basic/ToastContainer.js
+++ b/src/basic/ToastContainer.js
@@ -58,7 +58,7 @@ class ToastContainer extends Component {
       buttonTextStyle: config.buttonTextStyle,
       buttonStyle: config.buttonStyle,
       textStyle: config.textStyle,
-      onClose: config.onClose
+      onClose: config.onClose,
       onButtonClick: config.onButtonClick
     });
     // If we have a toast already open, cut off its close timeout so that it won't affect *this* toast.

--- a/src/basic/ToastContainer.js
+++ b/src/basic/ToastContainer.js
@@ -59,6 +59,7 @@ class ToastContainer extends Component {
       buttonStyle: config.buttonStyle,
       textStyle: config.textStyle,
       onClose: config.onClose
+      onButtonClick: config.onButtonClick
     });
     // If we have a toast already open, cut off its close timeout so that it won't affect *this* toast.
     if (this.closeTimeout) {
@@ -68,7 +69,7 @@ class ToastContainer extends Component {
     if (config.duration !== 0) {
       const duration = (config.duration > 0) ? config.duration : 1500;
       this.closeTimeout = setTimeout(this.closeToast.bind(this, 'timeout'), duration);
-    }  
+    }
     // Fade the toast in now.
     Animated.timing(this.state.fadeAnim, {
       toValue: 1,
@@ -91,6 +92,13 @@ class ToastContainer extends Component {
       duration: 200
     }).start(this.closeModal.bind(this, reason));
   }
+  // Call the onButtonClick event and close the modal
+  onButtonClick(reason, func) {
+    if (func && typeof func === "function") {
+      func();
+    }
+    closeModal(reason)
+  }
   render() {
     if (this.state.modalVisible) {
       return (
@@ -105,7 +113,9 @@ class ToastContainer extends Component {
             {this.state.buttonText && (
               <Button
                 style={this.state.buttonStyle}
-                onPress={() => this.closeToast('user')}
+                onPress={() => this.state.onButtonClick ?
+                  this.onButtonClick('user', this.state.onButtonClick) :
+                  this.closeToast('user')}
               >
                 <Text style={this.state.buttonTextStyle}>
                   {this.state.buttonText}

--- a/src/basic/ToastContainer.js
+++ b/src/basic/ToastContainer.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
+import { array, number, object, oneOfType } from "prop-types";
 import { View, Modal, Platform, Animated, ViewPropTypes } from "react-native";
 import { connectStyle } from "native-base-shoutem-theme";
 import { Text } from "./Text";
@@ -9,17 +9,22 @@ import { Toast } from "./Toast";
 import mapPropsToStyleNames from "../utils/mapPropsToStyleNames";
 
 class ToastContainer extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      modalVisible: false,
-      fadeAnim: new Animated.Value(0)
-    };
-  }
+  static propTypes = {
+    ...ViewPropTypes,
+    style: oneOfType([object, number, array])
+  };
+
   static toastInstance;
+
   static show({ ...config }) {
     this.toastInstance._root.showToast({ config });
   }
+
+  state = {
+    modalVisible: false,
+    fadeAnim: new Animated.Value(0)
+  };
+
   getToastStyle() {
     return {
       position: "absolute",
@@ -31,21 +36,21 @@ class ToastContainer extends Component {
       bottom: this.state.position === "bottom" ? this.getTop() : undefined
     };
   }
+
   getTop() {
-    if (Platform.OS === "ios") {
-      return 30;
-    } else {
-      return 0;
-    }
+    return Platform.OS === "ios" ? 30 : 0;
   }
+
   getButtonText(buttonText) {
     if (buttonText) {
-      if (buttonText.trim().length === 0) {
-        return undefined;
-      } else return buttonText;
+      if (buttonText.trim().length > 0) {
+        return buttonText
+      }
     }
+
     return undefined;
   }
+
   showToast({ config }) {
     this.setState({
       modalVisible: true,
@@ -61,82 +66,87 @@ class ToastContainer extends Component {
       onClose: config.onClose,
       onButtonClick: config.onButtonClick
     });
+
     // If we have a toast already open, cut off its close timeout so that it won't affect *this* toast.
     if (this.closeTimeout) {
       clearTimeout(this.closeTimeout)
     }
+
     // Set the toast to close after the duration.
     if (config.duration !== 0) {
       const duration = (config.duration > 0) ? config.duration : 1500;
       this.closeTimeout = setTimeout(this.closeToast.bind(this, 'timeout'), duration);
     }
+
     // Fade the toast in now.
     Animated.timing(this.state.fadeAnim, {
       toValue: 1,
       duration: 200
     }).start();
   }
+
   closeModal(reason) {
-    this.setState({
-      modalVisible: false
-    });
+    this.setState({ modalVisible: false });
     const { onClose } = this.state;
+
     if(onClose && typeof onClose === "function") {
       onClose(reason);
     }
   }
+
   closeToast(reason) {
     clearTimeout(this.closeTimeout);
+
     Animated.timing(this.state.fadeAnim, {
       toValue: 0,
       duration: 200
     }).start(this.closeModal.bind(this, reason));
   }
+
   // Call the onButtonClick event and close the modal
   onButtonClick(reason, func) {
-    if (func && typeof func === "function") {
-      func();
-    }
+    if (func && typeof func === "function") func();
     closeModal(reason)
   }
   render() {
-    if (this.state.modalVisible) {
-      return (
-        <Animated.View style={this.getToastStyle()}>
-          <Toast
-            style={this.state.style}
-            danger={this.state.type == "danger" ? true : false}
-            success={this.state.type == "success" ? true : false}
-            warning={this.state.type == "warning" ? true : false}
-          >
-            <Text style={this.state.textStyle}>{this.state.text}</Text>
-            {this.state.buttonText && (
-              <Button
-                style={this.state.buttonStyle}
-                onPress={() => this.state.onButtonClick ?
-                  this.onButtonClick('user', this.state.onButtonClick) :
-                  this.closeToast('user')}
-              >
-                <Text style={this.state.buttonTextStyle}>
-                  {this.state.buttonText}
-                </Text>
-              </Button>
-            )}
-          </Toast>
-        </Animated.View>
-      );
-    } else return null;
+    const {
+      buttonStyle,
+      buttonText,
+      buttonTextStyle,
+      modalVisible,
+      onButtonClick,
+      style,
+      text,
+      textStyle,
+      type,
+    } this.state;
+
+    return modalVisible ? (
+      <Animated.View style={this.getToastStyle()}>
+        <Toast
+          style={style}
+          danger={type == "danger"}
+          success={type == "success"}
+          warning={type == "warning"}
+        >
+          <Text style={textStyle}>{text}</Text>
+          {buttonText && (
+            <Button
+              style={buttonStyle}
+              onPress={() => onButtonClick ?
+                this.onButtonClick('user', onButtonClick) :
+                this.closeToast('user')}
+            >
+              <Text style={buttonTextStyle}>
+                {buttonText}
+              </Text>
+            </Button>
+          )}
+        </Toast>
+      </Animated.View>
+    ) : null;
   }
 }
-
-ToastContainer.propTypes = {
-  ...ViewPropTypes,
-  style: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.number,
-    PropTypes.array
-  ])
-};
 
 const StyledToastContainer = connectStyle(
   "NativeBase.ToastContainer",


### PR DESCRIPTION
I'm not sure how to updated the documentation. But basically this new feature allows the toast config to take an additional config key called `onButtonClick` which accepts any function that runs when the button is clicked, but not when the toast closes (it does however also close the toast upon clicking it after running the function).