### PR TITLE
Supports different Picker.Item generation.

### DIFF
--- a/src/basic/Picker.ios.js
+++ b/src/basic/Picker.ios.js
@@ -89,6 +89,7 @@ class PickerNB extends Component {
     if (children && !Array.isArray(children)) {
       return [].concat(children);
     }
+    children = [].concat.apply([], children)
     return children;
   }
 


### PR DESCRIPTION
Attempt to fix #983 (Picker : undefined is not an object :child.props.value)