### PR TITLE
types: fixed Picker extends PickerProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,8 +14,7 @@ declare module "native-base" {
 			padder?: boolean;
 		}
 
-		interface Picker extends ReactNative.PickerProperties {
-			mode?: "dialog" | "dropdown";
+		interface Picker extends ReactNative.PickerProps {
 			iosHeader?: string;
 			inlineLabel?: boolean;
 			headerBackButtonText?: string;


### PR DESCRIPTION
Renamed `PickerProperties` to `PickerProps`, that is correct name. And property `mode` was removed because it is part of react-native and not native-base.
References: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/index.d.ts#L2890
