### PR TITLE
Fix date picker props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -826,8 +826,9 @@ declare module "native-base" {
 			timeZoneOffsetInMinutes?: number;
 			modalTransparent?: boolean;
 			animationType?: "slide" | "fade" | "none";
-			disabled:? boolean;
+			disabled?: boolean;
 			onDateChange?: (date: any) => void;
+			
 		}
 	}
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -828,7 +828,7 @@ declare module "native-base" {
 			animationType?: "slide" | "fade" | "none";
 			disabled?: boolean;
 			onDateChange?: (date: any) => void;
-			
+			formatChosenDate?: (date: any) => void;
 		}
 	}
 


### PR DESCRIPTION
refs #2126
disabled property on DatePicker Props have wrong syntax definition and is causing the error I mention in #2126 also formatChosenDate was added to DatePicker but the definition was not added in the DatePicker Props definition I added it.