### PR TITLE
missing import `prop-types` package

### DIFF
--- a/src/basic/Gravatar.js
+++ b/src/basic/Gravatar.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { Image } from "react-native";
 import { connectStyle } from "native-base-shoutem-theme";
 import _ from "lodash";


### PR DESCRIPTION
The import `prop-types` package line was missed when migrating from `React.PropTypes` to `prop-types` package in the Gravatar component.