### PR TITLE
fix android drawer overlay

### DIFF
--- a/src/basic/Drawer/index.js
+++ b/src/basic/Drawer/index.js
@@ -27,7 +27,7 @@ Drawer.defaultProps = {
 		mainOverlay: {
 			opacity: 0,
 			backgroundColor: "rgba(0, 0, 0, 0.8)",
-			elevation: 8,
+			elevation: 0,
 		},
 	},
 	tweenHandler: ratio => ({


### PR DESCRIPTION
This should fix the dark drawer issue on android.

Please see [#2312](https://github.com/GeekyAnts/NativeBase/issues/2312) 