### PR TITLE
Added page attribute on Tabs component typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -754,6 +754,7 @@ declare module "native-base" {
 			onChangeTab?: Function;
 			locked?: boolean;
 			initialPage?: number;
+			page?: number;
 			tabBarUnderlineStyle?: ReactNative.ViewStyle | Array<ReactNative.ViewStyle>;
 			tabBarBackgroundColor?: string;
 			tabBarActiveTextColor?: string;


### PR DESCRIPTION
Fixed TypeScript definition inconsistency on Tabs component.

[JavaScript has `page` props](https://github.com/GeekyAnts/NativeBase/blob/e594c43e79fe5c173c06d945757b0c72c9458eac/src/basic/Tabs/index.js#L37) but [TypeScrpit does not](https://github.com/GeekyAnts/NativeBase/blob/master/index.d.ts#L748).

We're building a functional component and the `page` props seems essential to let Tabs component to render Tab from outer context, such as FooterTab buttons.