### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -616,6 +616,7 @@ declare module "native-base" {
          * see Widget Textarea.js
          */
 		interface Textarea extends ReactNative.TextInputProperties {
+			bordered: boolean;
 			rowSpan: number;
 		}
 


### PR DESCRIPTION
`bordered` jsx attribute missing in type for `<Textarea />` but renders as expected when used anyway (2.8.1).