### PR TITLE
Fix #2461 Icons components broken on iOS

### DIFF
--- a/dist/src/basic/Icon/NBIcons.json
+++ b/dist/src/basic/Icon/NBIcons.json
@@ -5,7 +5,7 @@
       "active": "md-add"
     },
     "ios": {
-      "default": "ios-add-outline",
+      "default": "ios-add",
       "active": "ios-add"
     }
   },
@@ -15,7 +15,7 @@
       "active": "md-add-circle"
     },
     "ios": {
-      "default": "ios-add-circle-outline",
+      "default": "ios-add-circle",
       "active": "ios-add-circle"
     }
   },
@@ -25,7 +25,7 @@
       "active": "md-alarm"
     },
     "ios": {
-      "default": "ios-alarm-outline",
+      "default": "ios-alarm",
       "active": "ios-alarm"
     }
   },
@@ -35,7 +35,7 @@
       "active": "md-albums"
     },
     "ios": {
-      "default": "ios-albums-outline",
+      "default": "ios-albums",
       "active": "ios-albums"
     }
   },
@@ -45,7 +45,7 @@
       "active": "md-alert"
     },
     "ios": {
-      "default": "ios-alert-outline",
+      "default": "ios-alert",
       "active": "ios-alert"
     }
   },
@@ -55,7 +55,7 @@
       "active": "md-american-football"
     },
     "ios": {
-      "default": "ios-american-football-outline",
+      "default": "ios-american-football",
       "active": "ios-american-football"
     }
   },
@@ -65,7 +65,7 @@
       "active": "md-analytics"
     },
     "ios": {
-      "default": "ios-analytics-outline",
+      "default": "ios-analytics",
       "active": "ios-analytics"
     }
   },
@@ -75,7 +75,7 @@
       "active": "md-aperture"
     },
     "ios": {
-      "default": "ios-aperture-outline",
+      "default": "ios-aperture",
       "active": "ios-aperture"
     }
   },
@@ -85,7 +85,7 @@
       "active": "md-apps"
     },
     "ios": {
-      "default": "ios-apps-outline",
+      "default": "ios-apps",
       "active": "ios-apps"
     }
   },
@@ -95,7 +95,7 @@
       "active": "md-appstore"
     },
     "ios": {
-      "default": "ios-appstore-outline",
+      "default": "ios-appstore",
       "active": "ios-apps"
     }
   },
@@ -105,7 +105,7 @@
       "active": "md-archive"
     },
     "ios": {
-      "default": "ios-archive-outline",
+      "default": "ios-archive",
       "active": "ios-archive"
     }
   },
@@ -115,7 +115,7 @@
       "active": "md-arrow-back"
     },
     "ios": {
-      "default": "ios-arrow-back-outline",
+      "default": "ios-arrow-back",
       "active": "ios-arrow-back"
     }
   },
@@ -125,7 +125,7 @@
       "active": "md-arrow-down"
     },
     "ios": {
-      "default": "ios-arrow-down-outline",
+      "default": "ios-arrow-down",
       "active": "ios-arrow-down"
     }
   },
@@ -135,7 +135,7 @@
       "active": "md-arrow-dropdown"
     },
     "ios": {
-      "default": "ios-arrow-dropdown-outline",
+      "default": "ios-arrow-dropdown",
       "active": "ios-arrow-dropdown"
     }
   },
@@ -145,7 +145,7 @@
       "active": "md-arrow-dropdown-circle"
     },
     "ios": {
-      "default": "ios-arrow-dropdown-circle-outline",
+      "default": "ios-arrow-dropdown-circle",
       "active": "ios-arrow-dropdown-circle"
     }
   },
@@ -155,7 +155,7 @@
       "active": "md-arrow-dropleft"
     },
     "ios": {
-      "default": "ios-arrow-dropleft-outline",
+      "default": "ios-arrow-dropleft",
       "active": "ios-arrow-dropleft"
     }
   },
@@ -165,7 +165,7 @@
       "active": "md-arrow-dropleft-circle"
     },
     "ios": {
-      "default": "ios-arrow-dropleft-circle-outline",
+      "default": "ios-arrow-dropleft-circle",
       "active": "ios-arrow-dropleft-circle"
     }
   },
@@ -175,7 +175,7 @@
       "active": "md-arrow-dropright"
     },
     "ios": {
-      "default": "ios-arrow-dropright-outline",
+      "default": "ios-arrow-dropright",
       "active": "ios-arrow-dropright"
     }
   },
@@ -185,7 +185,7 @@
       "active": "md-arrow-dropright-circle"
     },
     "ios": {
-      "default": "ios-arrow-dropright-circle-outline",
+      "default": "ios-arrow-dropright-circle",
       "active": "ios-arrow-dropright-circle"
     }
   },
@@ -195,7 +195,7 @@
       "active": "md-arrow-dropup"
     },
     "ios": {
-      "default": "ios-arrow-dropup-outline",
+      "default": "ios-arrow-dropup",
       "active": "ios-arrow-dropup"
     }
   },
@@ -205,7 +205,7 @@
       "active": "md-arrow-dropup-circle"
     },
     "ios": {
-      "default": "ios-arrow-dropup-circle-outline",
+      "default": "ios-arrow-dropup-circle",
       "active": "ios-arrow-dropup-circle"
     }
   },
@@ -215,7 +215,7 @@
       "active": "md-arrow-forward"
     },
     "ios": {
-      "default": "ios-arrow-forward-outline",
+      "default": "ios-arrow-forward",
       "active": "ios-arrow-forward"
     }
   },
@@ -225,7 +225,7 @@
       "active": "md-arrow-round-back"
     },
     "ios": {
-      "default": "ios-arrow-round-back-outline",
+      "default": "ios-arrow-round-back",
       "active": "ios-arrow-round-back"
     }
   },
@@ -235,7 +235,7 @@
       "active": "md-arrow-round-down"
     },
     "ios": {
-      "default": "ios-arrow-round-down-outline",
+      "default": "ios-arrow-round-down",
       "active": "ios-arrow-round-down"
     }
   },
@@ -245,7 +245,7 @@
       "active": "md-arrow-round-forward"
     },
     "ios": {
-      "default": "ios-arrow-round-forward-outline",
+      "default": "ios-arrow-round-forward",
       "active": "ios-arrow-round-forward"
     }
   },
@@ -255,7 +255,7 @@
       "active": "md-arrow-round-up"
     },
     "ios": {
-      "default": "ios-arrow-round-up-outline",
+      "default": "ios-arrow-round-up",
       "active": "ios-arrow-round-up"
     }
   },
@@ -265,7 +265,7 @@
       "active": "md-arrow-up"
     },
     "ios": {
-      "default": "ios-arrow-up-outline",
+      "default": "ios-arrow-up",
       "active": "ios-arrow-up"
     }
   },
@@ -275,7 +275,7 @@
       "active": "md-at"
     },
     "ios": {
-      "default": "ios-at-outline",
+      "default": "ios-at",
       "active": "ios-at"
     }
   },
@@ -285,7 +285,7 @@
       "active": "md-attach"
     },
     "ios": {
-      "default": "ios-attach-outline",
+      "default": "ios-attach",
       "active": "ios-attach"
     }
   },
@@ -295,7 +295,7 @@
       "active": "md-backspace"
     },
     "ios": {
-      "default": "ios-backspace-outline",
+      "default": "ios-backspace",
       "active": "ios-backspace"
     }
   },
@@ -305,7 +305,7 @@
       "active": "md-barcode"
     },
     "ios": {
-      "default": "ios-barcode-outline",
+      "default": "ios-barcode",
       "active": "ios-barcode"
     }
   },
@@ -315,7 +315,7 @@
       "active": "md-baseball"
     },
     "ios": {
-      "default": "ios-baseball-outline",
+      "default": "ios-baseball",
       "active": "ios-baseball"
     }
   },
@@ -325,7 +325,7 @@
       "active": "md-basket"
     },
     "ios": {
-      "default": "ios-basket-outline",
+      "default": "ios-basket",
       "active": "ios-basket"
     }
   },
@@ -335,7 +335,7 @@
       "active": "md-basketball"
     },
     "ios": {
-      "default": "ios-basketball-outline",
+      "default": "ios-basketball",
       "active": "ios-basketball"
     }
   },
@@ -345,7 +345,7 @@
       "active": "md-battery-charging"
     },
     "ios": {
-      "default": "ios-battery-charging-outline",
+      "default": "ios-battery-charging",
       "active": "ios-battery-charging"
     }
   },
@@ -355,7 +355,7 @@
       "active": "md-battery-dead"
     },
     "ios": {
-      "default": "ios-battery-dead-outline",
+      "default": "ios-battery-dead",
       "active": "ios-battery-dead"
     }
   },
@@ -365,7 +365,7 @@
       "active": "md-battery-full"
     },
     "ios": {
-      "default": "ios-battery-full-outline",
+      "default": "ios-battery-full",
       "active": "ios-battery-full"
     }
   },
@@ -375,7 +375,7 @@
       "active": "md-beaker"
     },
     "ios": {
-      "default": "ios-beaker-outline",
+      "default": "ios-beaker",
       "active": "ios-beaker"
     }
   },
@@ -385,7 +385,7 @@
       "active": "md-beer"
     },
     "ios": {
-      "default": "ios-beer-outline",
+      "default": "ios-beer",
       "active": "ios-beer"
     }
   },
@@ -395,7 +395,7 @@
       "active": "md-bicycle"
     },
     "ios": {
-      "default": "ios-bicycle-outline",
+      "default": "ios-bicycle",
       "active": "ios-bicycle"
     }
   },
@@ -405,7 +405,7 @@
       "active": "md-bluetooth"
     },
     "ios": {
-      "default": "ios-bluetooth-outline",
+      "default": "ios-bluetooth",
       "active": "ios-bluetooth"
     }
   },
@@ -415,7 +415,7 @@
       "active": "md-boat"
     },
     "ios": {
-      "default": "ios-boat-outline",
+      "default": "ios-boat",
       "active": "ios-boat"
     }
   },
@@ -425,7 +425,7 @@
       "active": "md-body"
     },
     "ios": {
-      "default": "ios-body-outline",
+      "default": "ios-body",
       "active": "ios-body"
     }
   },
@@ -435,7 +435,7 @@
       "active": "md-bonfire"
     },
     "ios": {
-      "default": "ios-bonfire-outline",
+      "default": "ios-bonfire",
       "active": "ios-bonfire"
     }
   },
@@ -445,7 +445,7 @@
       "active": "md-book"
     },
     "ios": {
-      "default": "ios-book-outline",
+      "default": "ios-book",
       "active": "ios-book"
     }
   },
@@ -455,7 +455,7 @@
       "active": "md-bookmark"
     },
     "ios": {
-      "default": "ios-bookmark-outline",
+      "default": "ios-bookmark",
       "active": "ios-bookmark"
     }
   },
@@ -465,7 +465,7 @@
       "active": "md-bookmarks"
     },
     "ios": {
-      "default": "ios-bookmarks-outline",
+      "default": "ios-bookmarks",
       "active": "ios-bookmarks"
     }
   },
@@ -475,7 +475,7 @@
       "active": "md-bowtie"
     },
     "ios": {
-      "default": "ios-bowtie-outline",
+      "default": "ios-bowtie",
       "active": "ios-bowtie"
     }
   },
@@ -485,7 +485,7 @@
       "active": "md-briefcase"
     },
     "ios": {
-      "default": "ios-briefcase-outline",
+      "default": "ios-briefcase",
       "active": "ios-briefcase"
     }
   },
@@ -495,7 +495,7 @@
       "active": "md-browsers"
     },
     "ios": {
-      "default": "ios-browsers-outline",
+      "default": "ios-browsers",
       "active": "ios-browsers"
     }
   },
@@ -505,7 +505,7 @@
       "active": "md-brush"
     },
     "ios": {
-      "default": "ios-brush-outline",
+      "default": "ios-brush",
       "active": "ios-brush"
     }
   },
@@ -515,7 +515,7 @@
       "active": "md-bug"
     },
     "ios": {
-      "default": "ios-bug-outline",
+      "default": "ios-bug",
       "active": "ios-bug"
     }
   },
@@ -525,7 +525,7 @@
       "active": "md-build"
     },
     "ios": {
-      "default": "ios-build-outline",
+      "default": "ios-build",
       "active": "ios-build"
     }
   },
@@ -535,7 +535,7 @@
       "active": "md-bulb"
     },
     "ios": {
-      "default": "ios-bulb-outline",
+      "default": "ios-bulb",
       "active": "ios-bulb"
     }
   },
@@ -545,7 +545,7 @@
       "active": "md-bus"
     },
     "ios": {
-      "default": "ios-bus-outline",
+      "default": "ios-bus",
       "active": "ios-bus"
     }
   },
@@ -555,7 +555,7 @@
       "active": "md-cafe"
     },
     "ios": {
-      "default": "ios-cafe-outline",
+      "default": "ios-cafe",
       "active": "ios-cafe"
     }
   },
@@ -565,7 +565,7 @@
       "active": "md-calculator"
     },
     "ios": {
-      "default": "ios-calculator-outline",
+      "default": "ios-calculator",
       "active": "ios-calculator"
     }
   },
@@ -575,7 +575,7 @@
       "active": "md-calendar"
     },
     "ios": {
-      "default": "ios-calendar-outline",
+      "default": "ios-calendar",
       "active": "ios-calendar"
     }
   },
@@ -585,7 +585,7 @@
       "active": "md-call"
     },
     "ios": {
-      "default": "ios-call-outline",
+      "default": "ios-call",
       "active": "ios-call"
     }
   },
@@ -595,7 +595,7 @@
       "active": "md-camera"
     },
     "ios": {
-      "default": "ios-camera-outline",
+      "default": "ios-camera",
       "active": "ios-camera"
     }
   },
@@ -605,7 +605,7 @@
       "active": "md-car"
     },
     "ios": {
-      "default": "ios-car-outline",
+      "default": "ios-car",
       "active": "ios-car"
     }
   },
@@ -615,7 +615,7 @@
       "active": "md-card"
     },
     "ios": {
-      "default": "ios-card-outline",
+      "default": "ios-card",
       "active": "ios-card"
     }
   },
@@ -625,7 +625,7 @@
       "active": "md-cart"
     },
     "ios": {
-      "default": "ios-cart-outline",
+      "default": "ios-cart",
       "active": "ios-cart"
     }
   },
@@ -635,7 +635,7 @@
       "active": "md-cash"
     },
     "ios": {
-      "default": "ios-cash-outline",
+      "default": "ios-cash",
       "active": "ios-cash"
     }
   },
@@ -645,7 +645,7 @@
       "active": "md-chatboxes"
     },
     "ios": {
-      "default": "ios-chatboxes-outline",
+      "default": "ios-chatboxes",
       "active": "ios-chatboxes"
     }
   },
@@ -655,7 +655,7 @@
       "active": "md-chatbubbles"
     },
     "ios": {
-      "default": "ios-chatbubbles-outline",
+      "default": "ios-chatbubbles",
       "active": "ios-chatbubbles"
     }
   },
@@ -665,7 +665,7 @@
       "active": "md-checkbox"
     },
     "ios": {
-      "default": "ios-checkbox-outline",
+      "default": "ios-checkbox",
       "active": "ios-checkbox"
     }
   },
@@ -675,7 +675,7 @@
       "active": "md-checkmark"
     },
     "ios": {
-      "default": "ios-checkmark-outline",
+      "default": "ios-checkmark",
       "active": "ios-checkmark"
     }
   },
@@ -685,7 +685,7 @@
       "active": "md-checkmark-circle"
     },
     "ios": {
-      "default": "ios-checkmark-circle-outline",
+      "default": "ios-checkmark-circle",
       "active": "ios-checkmark-circle"
     }
   },
@@ -695,7 +695,7 @@
       "active": "md-clipboard"
     },
     "ios": {
-      "default": "ios-clipboard-outline",
+      "default": "ios-clipboard",
       "active": "ios-clipboard"
     }
   },
@@ -705,7 +705,7 @@
       "active": "md-clock"
     },
     "ios": {
-      "default": "ios-clock-outline",
+      "default": "ios-clock",
       "active": "ios-clock"
     }
   },
@@ -715,7 +715,7 @@
       "active": "md-close"
     },
     "ios": {
-      "default": "ios-close-outline",
+      "default": "ios-close",
       "active": "ios-close"
     }
   },
@@ -725,7 +725,7 @@
       "active": "md-close-circle"
     },
     "ios": {
-      "default": "ios-close-circle-outline",
+      "default": "ios-close-circle",
       "active": "ios-close-circle"
     }
   },
@@ -735,7 +735,7 @@
       "active": "md-cloud"
     },
     "ios": {
-      "default": "ios-cloud-outline",
+      "default": "ios-cloud",
       "active": "ios-cloud"
     }
   },
@@ -745,7 +745,7 @@
       "active": "md-cloud-circle"
     },
     "ios": {
-      "default": "ios-cloud-circle-outline",
+      "default": "ios-cloud-circle",
       "active": "ios-cloud-circle"
     }
   },
@@ -755,7 +755,7 @@
       "active": "md-cloud-done"
     },
     "ios": {
-      "default": "ios-cloud-done-outline",
+      "default": "ios-cloud-done",
       "active": "ios-cloud-done"
     }
   },
@@ -765,7 +765,7 @@
       "active": "md-cloud-download"
     },
     "ios": {
-      "default": "ios-cloud-download-outline",
+      "default": "ios-cloud-download",
       "active": "ios-cloud-download"
     }
   },
@@ -775,8 +775,8 @@
       "active": "md-cloud-outline"
     },
     "ios": {
-      "default": "ios-cloud-outline-outline",
-      "active": "ios-cloud-outline"
+      "default": "ios-cloud",
+      "active": "ios-cloud"
     }
   },
   "cloud-upload": {
@@ -785,7 +785,7 @@
       "active": "md-cloud-upload"
     },
     "ios": {
-      "default": "ios-cloud-upload-outline",
+      "default": "ios-cloud-upload",
       "active": "ios-cloud-upload"
     }
   },
@@ -795,7 +795,7 @@
       "active": "md-cloudy"
     },
     "ios": {
-      "default": "ios-cloudy-outline",
+      "default": "ios-cloudy",
       "active": "ios-cloudy"
     }
   },
@@ -805,7 +805,7 @@
       "active": "md-cloudy-night"
     },
     "ios": {
-      "default": "ios-cloudy-night-outline",
+      "default": "ios-cloudy-night",
       "active": "ios-cloudy-night"
     }
   },
@@ -815,7 +815,7 @@
       "active": "md-code"
     },
     "ios": {
-      "default": "ios-code-outline",
+      "default": "ios-code",
       "active": "ios-code"
     }
   },
@@ -825,7 +825,7 @@
       "active": "md-code-download"
     },
     "ios": {
-      "default": "ios-code-download-outline",
+      "default": "ios-code-download",
       "active": "ios-code-download"
     }
   },
@@ -835,7 +835,7 @@
       "active": "md-code-working"
     },
     "ios": {
-      "default": "ios-code-working-outline",
+      "default": "ios-code-working",
       "active": "ios-code-working"
     }
   },
@@ -845,7 +845,7 @@
       "active": "md-cog"
     },
     "ios": {
-      "default": "ios-cog-outline",
+      "default": "ios-cog",
       "active": "ios-cog"
     }
   },
@@ -855,7 +855,7 @@
       "active": "md-color-fill"
     },
     "ios": {
-      "default": "ios-color-fill-outline",
+      "default": "ios-color-fill",
       "active": "ios-color-fill"
     }
   },
@@ -865,7 +865,7 @@
       "active": "md-color-filter"
     },
     "ios": {
-      "default": "ios-color-filter-outline",
+      "default": "ios-color-filter",
       "active": "ios-color-filter"
     }
   },
@@ -875,7 +875,7 @@
       "active": "md-color-palette"
     },
     "ios": {
-      "default": "ios-color-palette-outline",
+      "default": "ios-color-palette",
       "active": "ios-color-palette"
     }
   },
@@ -885,7 +885,7 @@
       "active": "md-color-wand"
     },
     "ios": {
-      "default": "ios-color-wand-outline",
+      "default": "ios-color-wand",
       "active": "ios-color-wand"
     }
   },
@@ -895,7 +895,7 @@
       "active": "md-compass"
     },
     "ios": {
-      "default": "ios-compass-outline",
+      "default": "ios-compass",
       "active": "ios-compass"
     }
   },
@@ -905,7 +905,7 @@
       "active": "md-construct"
     },
     "ios": {
-      "default": "ios-construct-outline",
+      "default": "ios-construct",
       "active": "ios-construct"
     }
   },
@@ -915,7 +915,7 @@
       "active": "md-contact"
     },
     "ios": {
-      "default": "ios-contact-outline",
+      "default": "ios-contact",
       "active": "ios-contact"
     }
   },
@@ -925,7 +925,7 @@
       "active": "md-contacts"
     },
     "ios": {
-      "default": "ios-contacts-outline",
+      "default": "ios-contacts",
       "active": "ios-contacts"
     }
   },
@@ -935,7 +935,7 @@
       "active": "md-contract"
     },
     "ios": {
-      "default": "ios-contract-outline",
+      "default": "ios-contract",
       "active": "ios-contract"
     }
   },
@@ -945,7 +945,7 @@
       "active": "md-contrast"
     },
     "ios": {
-      "default": "ios-contrast-outline",
+      "default": "ios-contrast",
       "active": "ios-contrast"
     }
   },
@@ -955,7 +955,7 @@
       "active": "md-copy"
     },
     "ios": {
-      "default": "ios-copy-outline",
+      "default": "ios-copy",
       "active": "ios-copy"
     }
   },
@@ -965,7 +965,7 @@
       "active": "md-create"
     },
     "ios": {
-      "default": "ios-create-outline",
+      "default": "ios-create",
       "active": "ios-create"
     }
   },
@@ -975,7 +975,7 @@
       "active": "md-crop"
     },
     "ios": {
-      "default": "ios-crop-outline",
+      "default": "ios-crop",
       "active": "ios-crop"
     }
   },
@@ -985,7 +985,7 @@
       "active": "md-cube"
     },
     "ios": {
-      "default": "ios-cube-outline",
+      "default": "ios-cube",
       "active": "ios-cube"
     }
   },
@@ -995,7 +995,7 @@
       "active": "md-cut"
     },
     "ios": {
-      "default": "ios-cut-outline",
+      "default": "ios-cut",
       "active": "ios-cut"
     }
   },
@@ -1005,7 +1005,7 @@
       "active": "md-desktop"
     },
     "ios": {
-      "default": "ios-desktop-outline",
+      "default": "ios-desktop",
       "active": "ios-desktop"
     }
   },
@@ -1015,7 +1015,7 @@
       "active": "md-disc"
     },
     "ios": {
-      "default": "ios-disc-outline",
+      "default": "ios-disc",
       "active": "ios-disc"
     }
   },
@@ -1025,7 +1025,7 @@
       "active": "md-document"
     },
     "ios": {
-      "default": "ios-document-outline",
+      "default": "ios-document",
       "active": "ios-document"
     }
   },
@@ -1035,7 +1035,7 @@
       "active": "md-done-all"
     },
     "ios": {
-      "default": "ios-done-all-outline",
+      "default": "ios-done-all",
       "active": "ios-done-all"
     }
   },
@@ -1045,7 +1045,7 @@
       "active": "md-download"
     },
     "ios": {
-      "default": "ios-download-outline",
+      "default": "ios-download",
       "active": "ios-download"
     }
   },
@@ -1055,7 +1055,7 @@
       "active": "md-easel"
     },
     "ios": {
-      "default": "ios-easel-outline",
+      "default": "ios-easel",
       "active": "ios-easel"
     }
   },
@@ -1065,7 +1065,7 @@
       "active": "md-egg"
     },
     "ios": {
-      "default": "ios-egg-outline",
+      "default": "ios-egg",
       "active": "ios-egg"
     }
   },
@@ -1075,7 +1075,7 @@
       "active": "md-exit"
     },
     "ios": {
-      "default": "ios-exit-outline",
+      "default": "ios-exit",
       "active": "ios-exit"
     }
   },
@@ -1085,7 +1085,7 @@
       "active": "md-expand"
     },
     "ios": {
-      "default": "ios-expand-outline",
+      "default": "ios-expand",
       "active": "ios-expand"
     }
   },
@@ -1095,7 +1095,7 @@
       "active": "md-eye"
     },
     "ios": {
-      "default": "ios-eye-outline",
+      "default": "ios-eye",
       "active": "ios-eye"
     }
   },
@@ -1105,7 +1105,7 @@
       "active": "md-eye-off"
     },
     "ios": {
-      "default": "ios-eye-off-outline",
+      "default": "ios-eye-off",
       "active": "ios-eye-off"
     }
   },
@@ -1115,7 +1115,7 @@
       "active": "md-fastforward"
     },
     "ios": {
-      "default": "ios-fastforward-outline",
+      "default": "ios-fastforward",
       "active": "ios-fastforward"
     }
   },
@@ -1125,7 +1125,7 @@
       "active": "md-female"
     },
     "ios": {
-      "default": "ios-female-outline",
+      "default": "ios-female",
       "active": "ios-female"
     }
   },
@@ -1135,7 +1135,7 @@
       "active": "md-filing"
     },
     "ios": {
-      "default": "ios-filing-outline",
+      "default": "ios-filing",
       "active": "ios-filing"
     }
   },
@@ -1145,7 +1145,7 @@
       "active": "md-film"
     },
     "ios": {
-      "default": "ios-film-outline",
+      "default": "ios-film",
       "active": "ios-film"
     }
   },
@@ -1155,7 +1155,7 @@
       "active": "md-finger-print"
     },
     "ios": {
-      "default": "ios-finger-print-outline",
+      "default": "ios-finger-print",
       "active": "ios-finger-print"
     }
   },
@@ -1165,7 +1165,7 @@
       "active": "md-flag"
     },
     "ios": {
-      "default": "ios-flag-outline",
+      "default": "ios-flag",
       "active": "ios-flag"
     }
   },
@@ -1175,7 +1175,7 @@
       "active": "md-flame"
     },
     "ios": {
-      "default": "ios-flame-outline",
+      "default": "ios-flame",
       "active": "ios-flame"
     }
   },
@@ -1185,7 +1185,7 @@
       "active": "md-flash"
     },
     "ios": {
-      "default": "ios-flash-outline",
+      "default": "ios-flash",
       "active": "ios-flash"
     }
   },
@@ -1195,7 +1195,7 @@
       "active": "md-flask"
     },
     "ios": {
-      "default": "ios-flask-outline",
+      "default": "ios-flask",
       "active": "ios-flask"
     }
   },
@@ -1205,7 +1205,7 @@
       "active": "md-flower"
     },
     "ios": {
-      "default": "ios-flower-outline",
+      "default": "ios-flower",
       "active": "ios-flower"
     }
   },
@@ -1215,7 +1215,7 @@
       "active": "md-folder"
     },
     "ios": {
-      "default": "ios-folder-outline",
+      "default": "ios-folder",
       "active": "ios-folder"
     }
   },
@@ -1225,7 +1225,7 @@
       "active": "md-folder-open"
     },
     "ios": {
-      "default": "ios-folder-open-outline",
+      "default": "ios-folder-open",
       "active": "ios-folder-open"
     }
   },
@@ -1235,7 +1235,7 @@
       "active": "md-football"
     },
     "ios": {
-      "default": "ios-football-outline",
+      "default": "ios-football",
       "active": "ios-football"
     }
   },
@@ -1245,7 +1245,7 @@
       "active": "md-funnel"
     },
     "ios": {
-      "default": "ios-funnel-outline",
+      "default": "ios-funnel",
       "active": "ios-funnel"
     }
   },
@@ -1255,7 +1255,7 @@
       "active": "md-game-controller-a"
     },
     "ios": {
-      "default": "ios-game-controller-a-outline",
+      "default": "ios-game-controller-a",
       "active": "ios-game-controller-a"
     }
   },
@@ -1265,7 +1265,7 @@
       "active": "md-game-controller-b"
     },
     "ios": {
-      "default": "ios-game-controller-b-outline",
+      "default": "ios-game-controller-b",
       "active": "ios-game-controller-b"
     }
   },
@@ -1275,7 +1275,7 @@
       "active": "md-git-branch"
     },
     "ios": {
-      "default": "ios-git-branch-outline",
+      "default": "ios-git-branch",
       "active": "ios-git-branch"
     }
   },
@@ -1285,7 +1285,7 @@
       "active": "md-git-commit"
     },
     "ios": {
-      "default": "ios-git-commit-outline",
+      "default": "ios-git-commit",
       "active": "ios-git-commit"
     }
   },
@@ -1295,7 +1295,7 @@
       "active": "md-git-merge"
     },
     "ios": {
-      "default": "ios-git-merge-outline",
+      "default": "ios-git-merge",
       "active": "ios-git-merge"
     }
   },
@@ -1305,7 +1305,7 @@
       "active": "md-git-compare"
     },
     "ios": {
-      "default": "ios-git-compare-outline",
+      "default": "ios-git-compare",
       "active": "ios-git-compare"
     }
   },
@@ -1315,7 +1315,7 @@
       "active": "md-git-network"
     },
     "ios": {
-      "default": "ios-git-network-outline",
+      "default": "ios-git-network",
       "active": "ios-git-network"
     }
   },
@@ -1325,7 +1325,7 @@
       "active": "md-git-pull-request"
     },
     "ios": {
-      "default": "ios-git-pull-request-outline",
+      "default": "ios-git-pull-request",
       "active": "ios-git-pull-request"
     }
   },
@@ -1335,7 +1335,7 @@
       "active": "md-glasses"
     },
     "ios": {
-      "default": "ios-glasses-outline",
+      "default": "ios-glasses",
       "active": "ios-glasses"
     }
   },
@@ -1345,7 +1345,7 @@
       "active": "md-globe"
     },
     "ios": {
-      "default": "ios-globe-outline",
+      "default": "ios-globe",
       "active": "ios-globe"
     }
   },
@@ -1355,7 +1355,7 @@
       "active": "md-grid"
     },
     "ios": {
-      "default": "ios-grid-outline",
+      "default": "ios-grid",
       "active": "ios-grid"
     }
   },
@@ -1365,7 +1365,7 @@
       "active": "md-hammer"
     },
     "ios": {
-      "default": "ios-hammer-outline",
+      "default": "ios-hammer",
       "active": "ios-hammer"
     }
   },
@@ -1375,7 +1375,7 @@
       "active": "md-hand"
     },
     "ios": {
-      "default": "ios-hand-outline",
+      "default": "ios-hand",
       "active": "ios-hand"
     }
   },
@@ -1385,7 +1385,7 @@
       "active": "md-headset"
     },
     "ios": {
-      "default": "ios-headset-outline",
+      "default": "ios-headset",
       "active": "ios-headset"
     }
   },
@@ -1395,7 +1395,7 @@
       "active": "md-heart"
     },
     "ios": {
-      "default": "ios-heart-outline",
+      "default": "ios-heart",
       "active": "ios-heart"
     }
   },
@@ -1405,7 +1405,7 @@
       "active": "md-happy"
     },
     "ios": {
-      "default": "ios-happy-outline",
+      "default": "ios-happy",
       "active": "ios-happy"
     }
   },
@@ -1415,7 +1415,7 @@
       "active": "md-help"
     },
     "ios": {
-      "default": "ios-help-outline",
+      "default": "ios-help",
       "active": "ios-help"
     }
   },
@@ -1425,7 +1425,7 @@
       "active": "md-help-buoy"
     },
     "ios": {
-      "default": "ios-help-buoy-outline",
+      "default": "ios-help-buoy",
       "active": "ios-help-buoy"
     }
   },
@@ -1435,7 +1435,7 @@
       "active": "md-help-circle"
     },
     "ios": {
-      "default": "ios-help-circle-outline",
+      "default": "ios-help-circle",
       "active": "ios-help-circle"
     }
   },
@@ -1445,7 +1445,7 @@
       "active": "md-home"
     },
     "ios": {
-      "default": "ios-home-outline",
+      "default": "ios-home",
       "active": "ios-home"
     }
   },
@@ -1455,7 +1455,7 @@
       "active": "md-ice-cream"
     },
     "ios": {
-      "default": "ios-ice-cream-outline",
+      "default": "ios-ice-cream",
       "active": "ios-ice-cream"
     }
   },
@@ -1465,7 +1465,7 @@
       "active": "md-image"
     },
     "ios": {
-      "default": "ios-image-outline",
+      "default": "ios-image",
       "active": "ios-image"
     }
   },
@@ -1475,7 +1475,7 @@
       "active": "md-images"
     },
     "ios": {
-      "default": "ios-images-outline",
+      "default": "ios-images",
       "active": "ios-images"
     }
   },
@@ -1485,7 +1485,7 @@
       "active": "md-infinite"
     },
     "ios": {
-      "default": "ios-infinite-outline",
+      "default": "ios-infinite",
       "active": "ios-infinite"
     }
   },
@@ -1495,7 +1495,7 @@
       "active": "md-information"
     },
     "ios": {
-      "default": "ios-information-outline",
+      "default": "ios-information",
       "active": "ios-information"
     }
   },
@@ -1505,7 +1505,7 @@
       "active": "md-information-circle"
     },
     "ios": {
-      "default": "ios-information-circle-outline",
+      "default": "ios-information-circle",
       "active": "ios-information-circle"
     }
   },
@@ -1515,7 +1515,7 @@
       "active": "md-ionic"
     },
     "ios": {
-      "default": "ios-ionic-outline",
+      "default": "ios-ionic",
       "active": "ios-ionic"
     }
   },
@@ -1525,7 +1525,7 @@
       "active": "md-ionitron"
     },
     "ios": {
-      "default": "ios-ionitron-outline",
+      "default": "ios-ionitron",
       "active": "ios-ionitron"
     }
   },
@@ -1535,7 +1535,7 @@
       "active": "md-jet"
     },
     "ios": {
-      "default": "ios-jet-outline",
+      "default": "ios-jet",
       "active": "ios-jet"
     }
   },
@@ -1545,7 +1545,7 @@
       "active": "md-key"
     },
     "ios": {
-      "default": "ios-key-outline",
+      "default": "ios-key",
       "active": "ios-key"
     }
   },
@@ -1555,7 +1555,7 @@
       "active": "md-keypad"
     },
     "ios": {
-      "default": "ios-keypad-outline",
+      "default": "ios-keypad",
       "active": "ios-keypad"
     }
   },
@@ -1565,7 +1565,7 @@
       "active": "md-laptop"
     },
     "ios": {
-      "default": "ios-laptop-outline",
+      "default": "ios-laptop",
       "active": "ios-laptop"
     }
   },
@@ -1575,7 +1575,7 @@
       "active": "md-leaf"
     },
     "ios": {
-      "default": "ios-leaf-outline",
+      "default": "ios-leaf",
       "active": "ios-leaf"
     }
   },
@@ -1585,7 +1585,7 @@
       "active": "md-link"
     },
     "ios": {
-      "default": "ios-link-outline",
+      "default": "ios-link",
       "active": "ios-link"
     }
   },
@@ -1595,7 +1595,7 @@
       "active": "md-list"
     },
     "ios": {
-      "default": "ios-list-outline",
+      "default": "ios-list",
       "active": "ios-list"
     }
   },
@@ -1605,7 +1605,7 @@
       "active": "md-list-box"
     },
     "ios": {
-      "default": "ios-list-box-outline",
+      "default": "ios-list-box",
       "active": "ios-list-box"
     }
   },
@@ -1615,7 +1615,7 @@
       "active": "md-locate"
     },
     "ios": {
-      "default": "ios-locate-outline",
+      "default": "ios-locate",
       "active": "ios-locate"
     }
   },
@@ -1625,7 +1625,7 @@
       "active": "md-lock"
     },
     "ios": {
-      "default": "ios-lock-outline",
+      "default": "ios-lock",
       "active": "ios-lock"
     }
   },
@@ -1635,7 +1635,7 @@
       "active": "md-log-in"
     },
     "ios": {
-      "default": "ios-log-in-outline",
+      "default": "ios-log-in",
       "active": "ios-log-in"
     }
   },
@@ -1645,7 +1645,7 @@
       "active": "md-log-out"
     },
     "ios": {
-      "default": "ios-log-out-outline",
+      "default": "ios-log-out",
       "active": "ios-log-out"
     }
   },
@@ -1655,7 +1655,7 @@
       "active": "md-magnet"
     },
     "ios": {
-      "default": "ios-magnet-outline",
+      "default": "ios-magnet",
       "active": "ios-magnet"
     }
   },
@@ -1665,7 +1665,7 @@
       "active": "md-mail"
     },
     "ios": {
-      "default": "ios-mail-outline",
+      "default": "ios-mail",
       "active": "ios-mail"
     }
   },
@@ -1675,7 +1675,7 @@
       "active": "md-mail-open"
     },
     "ios": {
-      "default": "ios-mail-open-outline",
+      "default": "ios-mail-open",
       "active": "ios-mail-open"
     }
   },
@@ -1685,7 +1685,7 @@
       "active": "md-male"
     },
     "ios": {
-      "default": "ios-male-outline",
+      "default": "ios-male",
       "active": "ios-male"
     }
   },
@@ -1695,7 +1695,7 @@
       "active": "md-man"
     },
     "ios": {
-      "default": "ios-man-outline",
+      "default": "ios-man",
       "active": "ios-man"
     }
   },
@@ -1705,7 +1705,7 @@
       "active": "md-map"
     },
     "ios": {
-      "default": "ios-map-outline",
+      "default": "ios-map",
       "active": "ios-map"
     }
   },
@@ -1715,7 +1715,7 @@
       "active": "md-medal"
     },
     "ios": {
-      "default": "ios-medal-outline",
+      "default": "ios-medal",
       "active": "ios-medal"
     }
   },
@@ -1725,7 +1725,7 @@
       "active": "md-medical"
     },
     "ios": {
-      "default": "ios-medical-outline",
+      "default": "ios-medical",
       "active": "ios-medical"
     }
   },
@@ -1735,7 +1735,7 @@
       "active": "md-medkit"
     },
     "ios": {
-      "default": "ios-medkit-outline",
+      "default": "ios-medkit",
       "active": "ios-medkit"
     }
   },
@@ -1745,7 +1745,7 @@
       "active": "md-megaphone"
     },
     "ios": {
-      "default": "ios-megaphone-outline",
+      "default": "ios-megaphone",
       "active": "ios-megaphone"
     }
   },
@@ -1755,7 +1755,7 @@
       "active": "md-menu"
     },
     "ios": {
-      "default": "ios-menu-outline",
+      "default": "ios-menu",
       "active": "ios-menu"
     }
   },
@@ -1765,7 +1765,7 @@
       "active": "md-mic"
     },
     "ios": {
-      "default": "ios-mic-outline",
+      "default": "ios-mic",
       "active": "ios-mic"
     }
   },
@@ -1775,7 +1775,7 @@
       "active": "md-mic-off"
     },
     "ios": {
-      "default": "ios-mic-off-outline",
+      "default": "ios-mic-off",
       "active": "ios-mic-off"
     }
   },
@@ -1785,7 +1785,7 @@
       "active": "md-microphone"
     },
     "ios": {
-      "default": "ios-microphone-outline",
+      "default": "ios-microphone",
       "active": "ios-microphone"
     }
   },
@@ -1795,7 +1795,7 @@
       "active": "md-moon"
     },
     "ios": {
-      "default": "ios-moon-outline",
+      "default": "ios-moon",
       "active": "ios-moon"
     }
   },
@@ -1805,7 +1805,7 @@
       "active": "md-more"
     },
     "ios": {
-      "default": "ios-more-outline",
+      "default": "ios-more",
       "active": "ios-more"
     }
   },
@@ -1815,7 +1815,7 @@
       "active": "md-move"
     },
     "ios": {
-      "default": "ios-move-outline",
+      "default": "ios-move",
       "active": "ios-move"
     }
   },
@@ -1825,7 +1825,7 @@
       "active": "md-musical-note"
     },
     "ios": {
-      "default": "ios-musical-note-outline",
+      "default": "ios-musical-note",
       "active": "ios-musical-note"
     }
   },
@@ -1835,7 +1835,7 @@
       "active": "md-musical-notes"
     },
     "ios": {
-      "default": "ios-musical-notes-outline",
+      "default": "ios-musical-notes",
       "active": "ios-musical-notes"
     }
   },
@@ -1845,7 +1845,7 @@
       "active": "md-navigate"
     },
     "ios": {
-      "default": "ios-navigate-outline",
+      "default": "ios-navigate",
       "active": "ios-navigate"
     }
   },
@@ -1855,7 +1855,7 @@
       "active": "md-no-smoking"
     },
     "ios": {
-      "default": "ios-no-smoking-outline",
+      "default": "ios-no-smoking",
       "active": "ios-no-smoking"
     }
   },
@@ -1865,7 +1865,7 @@
       "active": "md-notifications"
     },
     "ios": {
-      "default": "ios-notifications-outline",
+      "default": "ios-notifications",
       "active": "ios-notifications"
     }
   },
@@ -1875,7 +1875,7 @@
       "active": "md-notifications-off"
     },
     "ios": {
-      "default": "ios-notifications-off-outline",
+      "default": "ios-notifications-off",
       "active": "ios-notifications-off"
     }
   },
@@ -1885,7 +1885,7 @@
       "active": "md-nuclear"
     },
     "ios": {
-      "default": "ios-nuclear-outline",
+      "default": "ios-nuclear",
       "active": "ios-nuclear"
     }
   },
@@ -1895,7 +1895,7 @@
       "active": "md-nutrition"
     },
     "ios": {
-      "default": "ios-nutrition-outline",
+      "default": "ios-nutrition",
       "active": "ios-nutrition"
     }
   },
@@ -1905,7 +1905,7 @@
       "active": "md-open"
     },
     "ios": {
-      "default": "ios-open-outline",
+      "default": "ios-open",
       "active": "ios-open"
     }
   },
@@ -1915,7 +1915,7 @@
       "active": "md-options"
     },
     "ios": {
-      "default": "ios-options-outline",
+      "default": "ios-options",
       "active": "ios-options"
     }
   },
@@ -1925,7 +1925,7 @@
       "active": "md-outlet"
     },
     "ios": {
-      "default": "ios-outlet-outline",
+      "default": "ios-outlet",
       "active": "ios-outlet"
     }
   },
@@ -1935,7 +1935,7 @@
       "active": "md-paper"
     },
     "ios": {
-      "default": "ios-paper-outline",
+      "default": "ios-paper",
       "active": "ios-paper"
     }
   },
@@ -1945,7 +1945,7 @@
       "active": "md-paper-plane"
     },
     "ios": {
-      "default": "ios-paper-plane-outline",
+      "default": "ios-paper-plane",
       "active": "ios-paper-plane"
     }
   },
@@ -1955,7 +1955,7 @@
       "active": "md-partly-sunny"
     },
     "ios": {
-      "default": "ios-partly-sunny-outline",
+      "default": "ios-partly-sunny",
       "active": "ios-partly-sunny"
     }
   },
@@ -1965,7 +1965,7 @@
       "active": "md-pause"
     },
     "ios": {
-      "default": "ios-pause-outline",
+      "default": "ios-pause",
       "active": "ios-pause"
     }
   },
@@ -1975,7 +1975,7 @@
       "active": "md-paw"
     },
     "ios": {
-      "default": "ios-paw-outline",
+      "default": "ios-paw",
       "active": "ios-paw"
     }
   },
@@ -1985,7 +1985,7 @@
       "active": "md-people"
     },
     "ios": {
-      "default": "ios-people-outline",
+      "default": "ios-people",
       "active": "ios-people"
     }
   },
@@ -1995,7 +1995,7 @@
       "active": "md-person"
     },
     "ios": {
-      "default": "ios-person-outline",
+      "default": "ios-person",
       "active": "ios-person"
     }
   },
@@ -2005,7 +2005,7 @@
       "active": "md-person-add"
     },
     "ios": {
-      "default": "ios-person-add-outline",
+      "default": "ios-person-add",
       "active": "ios-person-add"
     }
   },
@@ -2015,7 +2015,7 @@
       "active": "md-phone-landscape"
     },
     "ios": {
-      "default": "ios-phone-landscape-outline",
+      "default": "ios-phone-landscape",
       "active": "ios-phone-landscape"
     }
   },
@@ -2025,7 +2025,7 @@
       "active": "md-phone-portrait"
     },
     "ios": {
-      "default": "ios-phone-portrait-outline",
+      "default": "ios-phone-portrait",
       "active": "ios-phone-portrait"
     }
   },
@@ -2035,7 +2035,7 @@
       "active": "md-photos"
     },
     "ios": {
-      "default": "ios-photos-outline",
+      "default": "ios-photos",
       "active": "ios-photos"
     }
   },
@@ -2045,7 +2045,7 @@
       "active": "md-pie"
     },
     "ios": {
-      "default": "ios-pie-outline",
+      "default": "ios-pie",
       "active": "ios-pie"
     }
   },
@@ -2055,7 +2055,7 @@
       "active": "md-pin"
     },
     "ios": {
-      "default": "ios-pin-outline",
+      "default": "ios-pin",
       "active": "ios-pin"
     }
   },
@@ -2065,7 +2065,7 @@
       "active": "md-pint"
     },
     "ios": {
-      "default": "ios-pint-outline",
+      "default": "ios-pint",
       "active": "ios-pint"
     }
   },
@@ -2075,7 +2075,7 @@
       "active": "md-pizza"
     },
     "ios": {
-      "default": "ios-pizza-outline",
+      "default": "ios-pizza",
       "active": "ios-pizza"
     }
   },
@@ -2085,7 +2085,7 @@
       "active": "md-plane"
     },
     "ios": {
-      "default": "ios-plane-outline",
+      "default": "ios-plane",
       "active": "ios-plane"
     }
   },
@@ -2095,7 +2095,7 @@
       "active": "md-planet"
     },
     "ios": {
-      "default": "ios-planet-outline",
+      "default": "ios-planet",
       "active": "ios-planet"
     }
   },
@@ -2105,7 +2105,7 @@
       "active": "md-play"
     },
     "ios": {
-      "default": "ios-play-outline",
+      "default": "ios-play",
       "active": "ios-play"
     }
   },
@@ -2115,7 +2115,7 @@
       "active": "md-podium"
     },
     "ios": {
-      "default": "ios-podium-outline",
+      "default": "ios-podium",
       "active": "ios-podium"
     }
   },
@@ -2125,7 +2125,7 @@
       "active": "md-power"
     },
     "ios": {
-      "default": "ios-power-outline",
+      "default": "ios-power",
       "active": "ios-power"
     }
   },
@@ -2135,7 +2135,7 @@
       "active": "md-pricetag"
     },
     "ios": {
-      "default": "ios-pricetag-outline",
+      "default": "ios-pricetag",
       "active": "ios-pricetag"
     }
   },
@@ -2145,7 +2145,7 @@
       "active": "md-pricetags"
     },
     "ios": {
-      "default": "ios-pricetags-outline",
+      "default": "ios-pricetags",
       "active": "ios-pricetags"
     }
   },
@@ -2155,7 +2155,7 @@
       "active": "md-print"
     },
     "ios": {
-      "default": "ios-print-outline",
+      "default": "ios-print",
       "active": "ios-print"
     }
   },
@@ -2165,7 +2165,7 @@
       "active": "md-pulse"
     },
     "ios": {
-      "default": "ios-pulse-outline",
+      "default": "ios-pulse",
       "active": "ios-pulse"
     }
   },
@@ -2175,7 +2175,7 @@
       "active": "md-qr-scanner"
     },
     "ios": {
-      "default": "ios-qr-scanner-outline",
+      "default": "ios-qr-scanner",
       "active": "ios-qr-scanner"
     }
   },
@@ -2185,7 +2185,7 @@
       "active": "md-quote"
     },
     "ios": {
-      "default": "ios-quote-outline",
+      "default": "ios-quote",
       "active": "ios-quote"
     }
   },
@@ -2195,7 +2195,7 @@
       "active": "md-radio"
     },
     "ios": {
-      "default": "ios-radio-outline",
+      "default": "ios-radio",
       "active": "ios-radio"
     }
   },
@@ -2205,7 +2205,7 @@
       "active": "md-radio-button-off"
     },
     "ios": {
-      "default": "ios-radio-button-off-outline",
+      "default": "ios-radio-button-off",
       "active": "ios-radio-button-off"
     }
   },
@@ -2215,7 +2215,7 @@
       "active": "md-radio-button-on"
     },
     "ios": {
-      "default": "ios-radio-button-on-outline",
+      "default": "ios-radio-button-on",
       "active": "ios-radio-button-on"
     }
   },
@@ -2225,7 +2225,7 @@
       "active": "md-rainy"
     },
     "ios": {
-      "default": "ios-rainy-outline",
+      "default": "ios-rainy",
       "active": "ios-rainy"
     }
   },
@@ -2235,7 +2235,7 @@
       "active": "md-recording"
     },
     "ios": {
-      "default": "ios-recording-outline",
+      "default": "ios-recording",
       "active": "ios-recording"
     }
   },
@@ -2245,7 +2245,7 @@
       "active": "md-redo"
     },
     "ios": {
-      "default": "ios-redo-outline",
+      "default": "ios-redo",
       "active": "ios-redo"
     }
   },
@@ -2255,7 +2255,7 @@
       "active": "md-refresh"
     },
     "ios": {
-      "default": "ios-refresh-outline",
+      "default": "ios-refresh",
       "active": "ios-refresh"
     }
   },
@@ -2265,7 +2265,7 @@
       "active": "md-remove"
     },
     "ios": {
-      "default": "ios-remove-outline",
+      "default": "ios-remove",
       "active": "ios-remove"
     }
   },
@@ -2275,7 +2275,7 @@
       "active": "md-remove-circle"
     },
     "ios": {
-      "default": "ios-remove-circle-outline",
+      "default": "ios-remove-circle",
       "active": "ios-remove-circle"
     }
   },
@@ -2285,7 +2285,7 @@
       "active": "md-reorder"
     },
     "ios": {
-      "default": "ios-reorder-outline",
+      "default": "ios-reorder",
       "active": "ios-reorder"
     }
   },
@@ -2295,7 +2295,7 @@
       "active": "md-repeat"
     },
     "ios": {
-      "default": "ios-repeat-outline",
+      "default": "ios-repeat",
       "active": "ios-repeat"
     }
   },
@@ -2305,7 +2305,7 @@
       "active": "md-resize"
     },
     "ios": {
-      "default": "ios-resize-outline",
+      "default": "ios-resize",
       "active": "ios-resize"
     }
   },
@@ -2315,7 +2315,7 @@
       "active": "md-restaurant"
     },
     "ios": {
-      "default": "ios-restaurant-outline",
+      "default": "ios-restaurant",
       "active": "ios-restaurant"
     }
   },
@@ -2325,7 +2325,7 @@
       "active": "md-return-left"
     },
     "ios": {
-      "default": "ios-return-left-outline",
+      "default": "ios-return-left",
       "active": "ios-return-left"
     }
   },
@@ -2335,7 +2335,7 @@
       "active": "md-return-right"
     },
     "ios": {
-      "default": "ios-return-right-outline",
+      "default": "ios-return-right",
       "active": "ios-return-right"
     }
   },
@@ -2345,7 +2345,7 @@
       "active": "md-reverse-camera"
     },
     "ios": {
-      "default": "ios-reverse-camera-outline",
+      "default": "ios-reverse-camera",
       "active": "ios-reverse-camera"
     }
   },
@@ -2355,7 +2355,7 @@
       "active": "md-rewind"
     },
     "ios": {
-      "default": "ios-rewind-outline",
+      "default": "ios-rewind",
       "active": "ios-rewind"
     }
   },
@@ -2365,7 +2365,7 @@
       "active": "md-ribbon"
     },
     "ios": {
-      "default": "ios-ribbon-outline",
+      "default": "ios-ribbon",
       "active": "ios-ribbon"
     }
   },
@@ -2375,7 +2375,7 @@
       "active": "md-rose"
     },
     "ios": {
-      "default": "ios-rose-outline",
+      "default": "ios-rose",
       "active": "ios-rose"
     }
   },
@@ -2385,7 +2385,7 @@
       "active": "md-sad"
     },
     "ios": {
-      "default": "ios-sad-outline",
+      "default": "ios-sad",
       "active": "ios-sad"
     }
   },
@@ -2395,7 +2395,7 @@
       "active": "md-school"
     },
     "ios": {
-      "default": "ios-school-outline",
+      "default": "ios-school",
       "active": "ios-school"
     }
   },
@@ -2405,7 +2405,7 @@
       "active": "md-search"
     },
     "ios": {
-      "default": "ios-search-outline",
+      "default": "ios-search",
       "active": "ios-search"
     }
   },
@@ -2415,7 +2415,7 @@
       "active": "md-send"
     },
     "ios": {
-      "default": "ios-send-outline",
+      "default": "ios-send",
       "active": "ios-send"
     }
   },
@@ -2425,7 +2425,7 @@
       "active": "md-settings"
     },
     "ios": {
-      "default": "ios-settings-outline",
+      "default": "ios-settings",
       "active": "ios-settings"
     }
   },
@@ -2435,7 +2435,7 @@
       "active": "md-share"
     },
     "ios": {
-      "default": "ios-share-outline",
+      "default": "ios-share",
       "active": "ios-share"
     }
   },
@@ -2445,7 +2445,7 @@
       "active": "md-share-all"
     },
     "ios": {
-      "default": "ios-share-all-outline",
+      "default": "ios-share-all",
       "active": "ios-share-all"
     }
   },
@@ -2455,7 +2455,7 @@
       "active": "md-shirt"
     },
     "ios": {
-      "default": "ios-shirt-outline",
+      "default": "ios-shirt",
       "active": "ios-shirt"
     }
   },
@@ -2465,7 +2465,7 @@
       "active": "md-shuffle"
     },
     "ios": {
-      "default": "ios-shuffle-outline",
+      "default": "ios-shuffle",
       "active": "ios-shuffle"
     }
   },
@@ -2475,7 +2475,7 @@
       "active": "md-skip-backward"
     },
     "ios": {
-      "default": "ios-skip-backward-outline",
+      "default": "ios-skip-backward",
       "active": "ios-skip-backward"
     }
   },
@@ -2485,7 +2485,7 @@
       "active": "md-skip-forward"
     },
     "ios": {
-      "default": "ios-skip-forward-outline",
+      "default": "ios-skip-forward",
       "active": "ios-skip-forward"
     }
   },
@@ -2495,7 +2495,7 @@
       "active": "md-snow"
     },
     "ios": {
-      "default": "ios-snow-outline",
+      "default": "ios-snow",
       "active": "ios-snow"
     }
   },
@@ -2505,7 +2505,7 @@
       "active": "md-speedometer"
     },
     "ios": {
-      "default": "ios-speedometer-outline",
+      "default": "ios-speedometer",
       "active": "ios-speedometer"
     }
   },
@@ -2515,7 +2515,7 @@
       "active": "md-square"
     },
     "ios": {
-      "default": "ios-square-outline",
+      "default": "ios-square",
       "active": "ios-square"
     }
   },
@@ -2525,7 +2525,7 @@
       "active": "md-star"
     },
     "ios": {
-      "default": "ios-star-outline",
+      "default": "ios-star",
       "active": "ios-star"
     }
   },
@@ -2535,7 +2535,7 @@
       "active": "md-star-half"
     },
     "ios": {
-      "default": "ios-star-half-outline",
+      "default": "ios-star-half",
       "active": "ios-star-half"
     }
   },
@@ -2545,7 +2545,7 @@
       "active": "md-stats"
     },
     "ios": {
-      "default": "ios-stats-outline",
+      "default": "ios-stats",
       "active": "ios-stats"
     }
   },
@@ -2555,7 +2555,7 @@
       "active": "md-stopwatch"
     },
     "ios": {
-      "default": "ios-stopwatch-outline",
+      "default": "ios-stopwatch",
       "active": "ios-stopwatch"
     }
   },
@@ -2565,7 +2565,7 @@
       "active": "md-subway"
     },
     "ios": {
-      "default": "ios-subway-outline",
+      "default": "ios-subway",
       "active": "ios-subway"
     }
   },
@@ -2575,7 +2575,7 @@
       "active": "md-sunny"
     },
     "ios": {
-      "default": "ios-sunny-outline",
+      "default": "ios-sunny",
       "active": "ios-sunny"
     }
   },
@@ -2585,7 +2585,7 @@
       "active": "md-swap"
     },
     "ios": {
-      "default": "ios-swap-outline",
+      "default": "ios-swap",
       "active": "ios-swap"
     }
   },
@@ -2595,7 +2595,7 @@
       "active": "md-switch"
     },
     "ios": {
-      "default": "ios-switch-outline",
+      "default": "ios-switch",
       "active": "ios-switch"
     }
   },
@@ -2605,7 +2605,7 @@
       "active": "md-sync"
     },
     "ios": {
-      "default": "ios-sync-outline",
+      "default": "ios-sync",
       "active": "ios-sync"
     }
   },
@@ -2615,7 +2615,7 @@
       "active": "md-tablet-landscape"
     },
     "ios": {
-      "default": "ios-tablet-landscape-outline",
+      "default": "ios-tablet-landscape",
       "active": "ios-tablet-landscape"
     }
   },
@@ -2625,7 +2625,7 @@
       "active": "md-tablet-portrait"
     },
     "ios": {
-      "default": "ios-tablet-portrait-outline",
+      "default": "ios-tablet-portrait",
       "active": "ios-tablet-portrait"
     }
   },
@@ -2635,7 +2635,7 @@
       "active": "md-tennisball"
     },
     "ios": {
-      "default": "ios-tennisball-outline",
+      "default": "ios-tennisball",
       "active": "ios-tennisball"
     }
   },
@@ -2645,7 +2645,7 @@
       "active": "md-text"
     },
     "ios": {
-      "default": "ios-text-outline",
+      "default": "ios-text",
       "active": "ios-text"
     }
   },
@@ -2655,7 +2655,7 @@
       "active": "md-thermometer"
     },
     "ios": {
-      "default": "ios-thermometer-outline",
+      "default": "ios-thermometer",
       "active": "ios-thermometer"
     }
   },
@@ -2665,7 +2665,7 @@
       "active": "md-thumbs-down"
     },
     "ios": {
-      "default": "ios-thumbs-down-outline",
+      "default": "ios-thumbs-down",
       "active": "ios-thumbs-down"
     }
   },
@@ -2675,7 +2675,7 @@
       "active": "md-thumbs-up"
     },
     "ios": {
-      "default": "ios-thumbs-up-outline",
+      "default": "ios-thumbs-up",
       "active": "ios-thumbs-up"
     }
   },
@@ -2685,7 +2685,7 @@
       "active": "md-thunderstorm"
     },
     "ios": {
-      "default": "ios-thunderstorm-outline",
+      "default": "ios-thunderstorm",
       "active": "ios-thunderstorm"
     }
   },
@@ -2695,7 +2695,7 @@
       "active": "md-time"
     },
     "ios": {
-      "default": "ios-time-outline",
+      "default": "ios-time",
       "active": "ios-time"
     }
   },
@@ -2705,7 +2705,7 @@
       "active": "md-timer"
     },
     "ios": {
-      "default": "ios-timer-outline",
+      "default": "ios-timer",
       "active": "ios-timer"
     }
   },
@@ -2715,7 +2715,7 @@
       "active": "md-train"
     },
     "ios": {
-      "default": "ios-train-outline",
+      "default": "ios-train",
       "active": "ios-train"
     }
   },
@@ -2725,7 +2725,7 @@
       "active": "md-transgender"
     },
     "ios": {
-      "default": "ios-transgender-outline",
+      "default": "ios-transgender",
       "active": "ios-transgender"
     }
   },
@@ -2735,7 +2735,7 @@
       "active": "md-trash"
     },
     "ios": {
-      "default": "ios-trash-outline",
+      "default": "ios-trash",
       "active": "ios-trash"
     }
   },
@@ -2745,7 +2745,7 @@
       "active": "md-trending-down"
     },
     "ios": {
-      "default": "ios-trending-down-outline",
+      "default": "ios-trending-down",
       "active": "ios-trending-down"
     }
   },
@@ -2755,7 +2755,7 @@
       "active": "md-trending-up"
     },
     "ios": {
-      "default": "ios-trending-up-outline",
+      "default": "ios-trending-up",
       "active": "ios-trending-up"
     }
   },
@@ -2765,7 +2765,7 @@
       "active": "md-trophy"
     },
     "ios": {
-      "default": "ios-trophy-outline",
+      "default": "ios-trophy",
       "active": "ios-trophy"
     }
   },
@@ -2775,7 +2775,7 @@
       "active": "md-umbrella"
     },
     "ios": {
-      "default": "ios-umbrella-outline",
+      "default": "ios-umbrella",
       "active": "ios-umbrella"
     }
   },
@@ -2785,7 +2785,7 @@
       "active": "md-undo"
     },
     "ios": {
-      "default": "ios-undo-outline",
+      "default": "ios-undo",
       "active": "ios-undo"
     }
   },
@@ -2795,7 +2795,7 @@
       "active": "md-unlock"
     },
     "ios": {
-      "default": "ios-unlock-outline",
+      "default": "ios-unlock",
       "active": "ios-unlock"
     }
   },
@@ -2805,7 +2805,7 @@
       "active": "md-videocam"
     },
     "ios": {
-      "default": "ios-videocam-outline",
+      "default": "ios-videocam",
       "active": "ios-videocam"
     }
   },
@@ -2815,7 +2815,7 @@
       "active": "md-volume-down"
     },
     "ios": {
-      "default": "ios-volume-down-outline",
+      "default": "ios-volume-down",
       "active": "ios-volume-down"
     }
   },
@@ -2825,7 +2825,7 @@
       "active": "md-volume-up"
     },
     "ios": {
-      "default": "ios-volume-up-outline",
+      "default": "ios-volume-up",
       "active": "ios-volume-up"
     }
   },
@@ -2835,7 +2835,7 @@
       "active": "md-volume-mute"
     },
     "ios": {
-      "default": "ios-volume-mute-outline",
+      "default": "ios-volume-mute",
       "active": "ios-volume-mute"
     }
   },
@@ -2845,7 +2845,7 @@
       "active": "md-volume-off"
     },
     "ios": {
-      "default": "ios-volume-off-outline",
+      "default": "ios-volume-off",
       "active": "ios-volume-off"
     }
   },
@@ -2855,7 +2855,7 @@
       "active": "md-walk"
     },
     "ios": {
-      "default": "ios-walk-outline",
+      "default": "ios-walk",
       "active": "ios-walk"
     }
   },
@@ -2865,7 +2865,7 @@
       "active": "md-warning"
     },
     "ios": {
-      "default": "ios-warning-outline",
+      "default": "ios-warning",
       "active": "ios-warning"
     }
   },
@@ -2875,7 +2875,7 @@
       "active": "md-watch"
     },
     "ios": {
-      "default": "ios-watch-outline",
+      "default": "ios-watch",
       "active": "ios-watch"
     }
   },
@@ -2885,7 +2885,7 @@
       "active": "md-water"
     },
     "ios": {
-      "default": "ios-water-outline",
+      "default": "ios-water",
       "active": "ios-water"
     }
   },
@@ -2895,7 +2895,7 @@
       "active": "md-wifi"
     },
     "ios": {
-      "default": "ios-wifi-outline",
+      "default": "ios-wifi",
       "active": "ios-wifi"
     }
   },
@@ -2905,7 +2905,7 @@
       "active": "md-wine"
     },
     "ios": {
-      "default": "ios-wine-outline",
+      "default": "ios-wine",
       "active": "ios-wine"
     }
   },
@@ -2915,7 +2915,7 @@
       "active": "md-woman"
     },
     "ios": {
-      "default": "ios-woman-outline",
+      "default": "ios-woman",
       "active": "ios-woman"
     }
   }

--- a/src/basic/Icon/NBIcons.json
+++ b/src/basic/Icon/NBIcons.json
@@ -5,7 +5,7 @@
       "active": "md-add"
     },
     "ios": {
-      "default": "ios-add-outline",
+      "default": "ios-add",
       "active": "ios-add"
     }
   },
@@ -15,7 +15,7 @@
       "active": "md-add-circle"
     },
     "ios": {
-      "default": "ios-add-circle-outline",
+      "default": "ios-add-circle",
       "active": "ios-add-circle"
     }
   },
@@ -25,7 +25,7 @@
       "active": "md-alarm"
     },
     "ios": {
-      "default": "ios-alarm-outline",
+      "default": "ios-alarm",
       "active": "ios-alarm"
     }
   },
@@ -35,7 +35,7 @@
       "active": "md-albums"
     },
     "ios": {
-      "default": "ios-albums-outline",
+      "default": "ios-albums",
       "active": "ios-albums"
     }
   },
@@ -45,7 +45,7 @@
       "active": "md-alert"
     },
     "ios": {
-      "default": "ios-alert-outline",
+      "default": "ios-alert",
       "active": "ios-alert"
     }
   },
@@ -55,7 +55,7 @@
       "active": "md-american-football"
     },
     "ios": {
-      "default": "ios-american-football-outline",
+      "default": "ios-american-football",
       "active": "ios-american-football"
     }
   },
@@ -65,7 +65,7 @@
       "active": "md-analytics"
     },
     "ios": {
-      "default": "ios-analytics-outline",
+      "default": "ios-analytics",
       "active": "ios-analytics"
     }
   },
@@ -75,7 +75,7 @@
       "active": "md-aperture"
     },
     "ios": {
-      "default": "ios-aperture-outline",
+      "default": "ios-aperture",
       "active": "ios-aperture"
     }
   },
@@ -85,7 +85,7 @@
       "active": "md-apps"
     },
     "ios": {
-      "default": "ios-apps-outline",
+      "default": "ios-apps",
       "active": "ios-apps"
     }
   },
@@ -95,7 +95,7 @@
       "active": "md-appstore"
     },
     "ios": {
-      "default": "ios-appstore-outline",
+      "default": "ios-appstore",
       "active": "ios-apps"
     }
   },
@@ -105,7 +105,7 @@
       "active": "md-archive"
     },
     "ios": {
-      "default": "ios-archive-outline",
+      "default": "ios-archive",
       "active": "ios-archive"
     }
   },
@@ -115,7 +115,7 @@
       "active": "md-arrow-back"
     },
     "ios": {
-      "default": "ios-arrow-back-outline",
+      "default": "ios-arrow-back",
       "active": "ios-arrow-back"
     }
   },
@@ -125,7 +125,7 @@
       "active": "md-arrow-down"
     },
     "ios": {
-      "default": "ios-arrow-down-outline",
+      "default": "ios-arrow-down",
       "active": "ios-arrow-down"
     }
   },
@@ -135,7 +135,7 @@
       "active": "md-arrow-dropdown"
     },
     "ios": {
-      "default": "ios-arrow-dropdown-outline",
+      "default": "ios-arrow-dropdown",
       "active": "ios-arrow-dropdown"
     }
   },
@@ -145,7 +145,7 @@
       "active": "md-arrow-dropdown-circle"
     },
     "ios": {
-      "default": "ios-arrow-dropdown-circle-outline",
+      "default": "ios-arrow-dropdown-circle",
       "active": "ios-arrow-dropdown-circle"
     }
   },
@@ -155,7 +155,7 @@
       "active": "md-arrow-dropleft"
     },
     "ios": {
-      "default": "ios-arrow-dropleft-outline",
+      "default": "ios-arrow-dropleft",
       "active": "ios-arrow-dropleft"
     }
   },
@@ -165,7 +165,7 @@
       "active": "md-arrow-dropleft-circle"
     },
     "ios": {
-      "default": "ios-arrow-dropleft-circle-outline",
+      "default": "ios-arrow-dropleft-circle",
       "active": "ios-arrow-dropleft-circle"
     }
   },
@@ -175,7 +175,7 @@
       "active": "md-arrow-dropright"
     },
     "ios": {
-      "default": "ios-arrow-dropright-outline",
+      "default": "ios-arrow-dropright",
       "active": "ios-arrow-dropright"
     }
   },
@@ -185,7 +185,7 @@
       "active": "md-arrow-dropright-circle"
     },
     "ios": {
-      "default": "ios-arrow-dropright-circle-outline",
+      "default": "ios-arrow-dropright-circle",
       "active": "ios-arrow-dropright-circle"
     }
   },
@@ -195,7 +195,7 @@
       "active": "md-arrow-dropup"
     },
     "ios": {
-      "default": "ios-arrow-dropup-outline",
+      "default": "ios-arrow-dropup",
       "active": "ios-arrow-dropup"
     }
   },
@@ -205,7 +205,7 @@
       "active": "md-arrow-dropup-circle"
     },
     "ios": {
-      "default": "ios-arrow-dropup-circle-outline",
+      "default": "ios-arrow-dropup-circle",
       "active": "ios-arrow-dropup-circle"
     }
   },
@@ -215,7 +215,7 @@
       "active": "md-arrow-forward"
     },
     "ios": {
-      "default": "ios-arrow-forward-outline",
+      "default": "ios-arrow-forward",
       "active": "ios-arrow-forward"
     }
   },
@@ -225,7 +225,7 @@
       "active": "md-arrow-round-back"
     },
     "ios": {
-      "default": "ios-arrow-round-back-outline",
+      "default": "ios-arrow-round-back",
       "active": "ios-arrow-round-back"
     }
   },
@@ -235,7 +235,7 @@
       "active": "md-arrow-round-down"
     },
     "ios": {
-      "default": "ios-arrow-round-down-outline",
+      "default": "ios-arrow-round-down",
       "active": "ios-arrow-round-down"
     }
   },
@@ -245,7 +245,7 @@
       "active": "md-arrow-round-forward"
     },
     "ios": {
-      "default": "ios-arrow-round-forward-outline",
+      "default": "ios-arrow-round-forward",
       "active": "ios-arrow-round-forward"
     }
   },
@@ -255,7 +255,7 @@
       "active": "md-arrow-round-up"
     },
     "ios": {
-      "default": "ios-arrow-round-up-outline",
+      "default": "ios-arrow-round-up",
       "active": "ios-arrow-round-up"
     }
   },
@@ -265,7 +265,7 @@
       "active": "md-arrow-up"
     },
     "ios": {
-      "default": "ios-arrow-up-outline",
+      "default": "ios-arrow-up",
       "active": "ios-arrow-up"
     }
   },
@@ -275,7 +275,7 @@
       "active": "md-at"
     },
     "ios": {
-      "default": "ios-at-outline",
+      "default": "ios-at",
       "active": "ios-at"
     }
   },
@@ -285,7 +285,7 @@
       "active": "md-attach"
     },
     "ios": {
-      "default": "ios-attach-outline",
+      "default": "ios-attach",
       "active": "ios-attach"
     }
   },
@@ -295,7 +295,7 @@
       "active": "md-backspace"
     },
     "ios": {
-      "default": "ios-backspace-outline",
+      "default": "ios-backspace",
       "active": "ios-backspace"
     }
   },
@@ -305,7 +305,7 @@
       "active": "md-barcode"
     },
     "ios": {
-      "default": "ios-barcode-outline",
+      "default": "ios-barcode",
       "active": "ios-barcode"
     }
   },
@@ -315,7 +315,7 @@
       "active": "md-baseball"
     },
     "ios": {
-      "default": "ios-baseball-outline",
+      "default": "ios-baseball",
       "active": "ios-baseball"
     }
   },
@@ -325,7 +325,7 @@
       "active": "md-basket"
     },
     "ios": {
-      "default": "ios-basket-outline",
+      "default": "ios-basket",
       "active": "ios-basket"
     }
   },
@@ -335,7 +335,7 @@
       "active": "md-basketball"
     },
     "ios": {
-      "default": "ios-basketball-outline",
+      "default": "ios-basketball",
       "active": "ios-basketball"
     }
   },
@@ -345,7 +345,7 @@
       "active": "md-battery-charging"
     },
     "ios": {
-      "default": "ios-battery-charging-outline",
+      "default": "ios-battery-charging",
       "active": "ios-battery-charging"
     }
   },
@@ -355,7 +355,7 @@
       "active": "md-battery-dead"
     },
     "ios": {
-      "default": "ios-battery-dead-outline",
+      "default": "ios-battery-dead",
       "active": "ios-battery-dead"
     }
   },
@@ -365,7 +365,7 @@
       "active": "md-battery-full"
     },
     "ios": {
-      "default": "ios-battery-full-outline",
+      "default": "ios-battery-full",
       "active": "ios-battery-full"
     }
   },
@@ -375,7 +375,7 @@
       "active": "md-beaker"
     },
     "ios": {
-      "default": "ios-beaker-outline",
+      "default": "ios-beaker",
       "active": "ios-beaker"
     }
   },
@@ -385,7 +385,7 @@
       "active": "md-beer"
     },
     "ios": {
-      "default": "ios-beer-outline",
+      "default": "ios-beer",
       "active": "ios-beer"
     }
   },
@@ -395,7 +395,7 @@
       "active": "md-bicycle"
     },
     "ios": {
-      "default": "ios-bicycle-outline",
+      "default": "ios-bicycle",
       "active": "ios-bicycle"
     }
   },
@@ -405,7 +405,7 @@
       "active": "md-bluetooth"
     },
     "ios": {
-      "default": "ios-bluetooth-outline",
+      "default": "ios-bluetooth",
       "active": "ios-bluetooth"
     }
   },
@@ -415,7 +415,7 @@
       "active": "md-boat"
     },
     "ios": {
-      "default": "ios-boat-outline",
+      "default": "ios-boat",
       "active": "ios-boat"
     }
   },
@@ -425,7 +425,7 @@
       "active": "md-body"
     },
     "ios": {
-      "default": "ios-body-outline",
+      "default": "ios-body",
       "active": "ios-body"
     }
   },
@@ -435,7 +435,7 @@
       "active": "md-bonfire"
     },
     "ios": {
-      "default": "ios-bonfire-outline",
+      "default": "ios-bonfire",
       "active": "ios-bonfire"
     }
   },
@@ -445,7 +445,7 @@
       "active": "md-book"
     },
     "ios": {
-      "default": "ios-book-outline",
+      "default": "ios-book",
       "active": "ios-book"
     }
   },
@@ -455,7 +455,7 @@
       "active": "md-bookmark"
     },
     "ios": {
-      "default": "ios-bookmark-outline",
+      "default": "ios-bookmark",
       "active": "ios-bookmark"
     }
   },
@@ -465,7 +465,7 @@
       "active": "md-bookmarks"
     },
     "ios": {
-      "default": "ios-bookmarks-outline",
+      "default": "ios-bookmarks",
       "active": "ios-bookmarks"
     }
   },
@@ -475,7 +475,7 @@
       "active": "md-bowtie"
     },
     "ios": {
-      "default": "ios-bowtie-outline",
+      "default": "ios-bowtie",
       "active": "ios-bowtie"
     }
   },
@@ -485,7 +485,7 @@
       "active": "md-briefcase"
     },
     "ios": {
-      "default": "ios-briefcase-outline",
+      "default": "ios-briefcase",
       "active": "ios-briefcase"
     }
   },
@@ -495,7 +495,7 @@
       "active": "md-browsers"
     },
     "ios": {
-      "default": "ios-browsers-outline",
+      "default": "ios-browsers",
       "active": "ios-browsers"
     }
   },
@@ -505,7 +505,7 @@
       "active": "md-brush"
     },
     "ios": {
-      "default": "ios-brush-outline",
+      "default": "ios-brush",
       "active": "ios-brush"
     }
   },
@@ -515,7 +515,7 @@
       "active": "md-bug"
     },
     "ios": {
-      "default": "ios-bug-outline",
+      "default": "ios-bug",
       "active": "ios-bug"
     }
   },
@@ -525,7 +525,7 @@
       "active": "md-build"
     },
     "ios": {
-      "default": "ios-build-outline",
+      "default": "ios-build",
       "active": "ios-build"
     }
   },
@@ -535,7 +535,7 @@
       "active": "md-bulb"
     },
     "ios": {
-      "default": "ios-bulb-outline",
+      "default": "ios-bulb",
       "active": "ios-bulb"
     }
   },
@@ -545,7 +545,7 @@
       "active": "md-bus"
     },
     "ios": {
-      "default": "ios-bus-outline",
+      "default": "ios-bus",
       "active": "ios-bus"
     }
   },
@@ -555,7 +555,7 @@
       "active": "md-cafe"
     },
     "ios": {
-      "default": "ios-cafe-outline",
+      "default": "ios-cafe",
       "active": "ios-cafe"
     }
   },
@@ -565,7 +565,7 @@
       "active": "md-calculator"
     },
     "ios": {
-      "default": "ios-calculator-outline",
+      "default": "ios-calculator",
       "active": "ios-calculator"
     }
   },
@@ -575,7 +575,7 @@
       "active": "md-calendar"
     },
     "ios": {
-      "default": "ios-calendar-outline",
+      "default": "ios-calendar",
       "active": "ios-calendar"
     }
   },
@@ -585,7 +585,7 @@
       "active": "md-call"
     },
     "ios": {
-      "default": "ios-call-outline",
+      "default": "ios-call",
       "active": "ios-call"
     }
   },
@@ -595,7 +595,7 @@
       "active": "md-camera"
     },
     "ios": {
-      "default": "ios-camera-outline",
+      "default": "ios-camera",
       "active": "ios-camera"
     }
   },
@@ -605,7 +605,7 @@
       "active": "md-car"
     },
     "ios": {
-      "default": "ios-car-outline",
+      "default": "ios-car",
       "active": "ios-car"
     }
   },
@@ -615,7 +615,7 @@
       "active": "md-card"
     },
     "ios": {
-      "default": "ios-card-outline",
+      "default": "ios-card",
       "active": "ios-card"
     }
   },
@@ -625,7 +625,7 @@
       "active": "md-cart"
     },
     "ios": {
-      "default": "ios-cart-outline",
+      "default": "ios-cart",
       "active": "ios-cart"
     }
   },
@@ -635,7 +635,7 @@
       "active": "md-cash"
     },
     "ios": {
-      "default": "ios-cash-outline",
+      "default": "ios-cash",
       "active": "ios-cash"
     }
   },
@@ -645,7 +645,7 @@
       "active": "md-chatboxes"
     },
     "ios": {
-      "default": "ios-chatboxes-outline",
+      "default": "ios-chatboxes",
       "active": "ios-chatboxes"
     }
   },
@@ -655,7 +655,7 @@
       "active": "md-chatbubbles"
     },
     "ios": {
-      "default": "ios-chatbubbles-outline",
+      "default": "ios-chatbubbles",
       "active": "ios-chatbubbles"
     }
   },
@@ -665,7 +665,7 @@
       "active": "md-checkbox"
     },
     "ios": {
-      "default": "ios-checkbox-outline",
+      "default": "ios-checkbox",
       "active": "ios-checkbox"
     }
   },
@@ -675,7 +675,7 @@
       "active": "md-checkmark"
     },
     "ios": {
-      "default": "ios-checkmark-outline",
+      "default": "ios-checkmark",
       "active": "ios-checkmark"
     }
   },
@@ -685,7 +685,7 @@
       "active": "md-checkmark-circle"
     },
     "ios": {
-      "default": "ios-checkmark-circle-outline",
+      "default": "ios-checkmark-circle",
       "active": "ios-checkmark-circle"
     }
   },
@@ -695,7 +695,7 @@
       "active": "md-clipboard"
     },
     "ios": {
-      "default": "ios-clipboard-outline",
+      "default": "ios-clipboard",
       "active": "ios-clipboard"
     }
   },
@@ -705,7 +705,7 @@
       "active": "md-clock"
     },
     "ios": {
-      "default": "ios-clock-outline",
+      "default": "ios-clock",
       "active": "ios-clock"
     }
   },
@@ -715,7 +715,7 @@
       "active": "md-close"
     },
     "ios": {
-      "default": "ios-close-outline",
+      "default": "ios-close",
       "active": "ios-close"
     }
   },
@@ -725,7 +725,7 @@
       "active": "md-close-circle"
     },
     "ios": {
-      "default": "ios-close-circle-outline",
+      "default": "ios-close-circle",
       "active": "ios-close-circle"
     }
   },
@@ -735,7 +735,7 @@
       "active": "md-cloud"
     },
     "ios": {
-      "default": "ios-cloud-outline",
+      "default": "ios-cloud",
       "active": "ios-cloud"
     }
   },
@@ -745,7 +745,7 @@
       "active": "md-cloud-circle"
     },
     "ios": {
-      "default": "ios-cloud-circle-outline",
+      "default": "ios-cloud-circle",
       "active": "ios-cloud-circle"
     }
   },
@@ -755,7 +755,7 @@
       "active": "md-cloud-done"
     },
     "ios": {
-      "default": "ios-cloud-done-outline",
+      "default": "ios-cloud-done",
       "active": "ios-cloud-done"
     }
   },
@@ -765,7 +765,7 @@
       "active": "md-cloud-download"
     },
     "ios": {
-      "default": "ios-cloud-download-outline",
+      "default": "ios-cloud-download",
       "active": "ios-cloud-download"
     }
   },
@@ -775,8 +775,8 @@
       "active": "md-cloud-outline"
     },
     "ios": {
-      "default": "ios-cloud-outline-outline",
-      "active": "ios-cloud-outline"
+      "default": "ios-cloud",
+      "active": "ios-cloud"
     }
   },
   "cloud-upload": {
@@ -785,7 +785,7 @@
       "active": "md-cloud-upload"
     },
     "ios": {
-      "default": "ios-cloud-upload-outline",
+      "default": "ios-cloud-upload",
       "active": "ios-cloud-upload"
     }
   },
@@ -795,7 +795,7 @@
       "active": "md-cloudy"
     },
     "ios": {
-      "default": "ios-cloudy-outline",
+      "default": "ios-cloudy",
       "active": "ios-cloudy"
     }
   },
@@ -805,7 +805,7 @@
       "active": "md-cloudy-night"
     },
     "ios": {
-      "default": "ios-cloudy-night-outline",
+      "default": "ios-cloudy-night",
       "active": "ios-cloudy-night"
     }
   },
@@ -815,7 +815,7 @@
       "active": "md-code"
     },
     "ios": {
-      "default": "ios-code-outline",
+      "default": "ios-code",
       "active": "ios-code"
     }
   },
@@ -825,7 +825,7 @@
       "active": "md-code-download"
     },
     "ios": {
-      "default": "ios-code-download-outline",
+      "default": "ios-code-download",
       "active": "ios-code-download"
     }
   },
@@ -835,7 +835,7 @@
       "active": "md-code-working"
     },
     "ios": {
-      "default": "ios-code-working-outline",
+      "default": "ios-code-working",
       "active": "ios-code-working"
     }
   },
@@ -845,7 +845,7 @@
       "active": "md-cog"
     },
     "ios": {
-      "default": "ios-cog-outline",
+      "default": "ios-cog",
       "active": "ios-cog"
     }
   },
@@ -855,7 +855,7 @@
       "active": "md-color-fill"
     },
     "ios": {
-      "default": "ios-color-fill-outline",
+      "default": "ios-color-fill",
       "active": "ios-color-fill"
     }
   },
@@ -865,7 +865,7 @@
       "active": "md-color-filter"
     },
     "ios": {
-      "default": "ios-color-filter-outline",
+      "default": "ios-color-filter",
       "active": "ios-color-filter"
     }
   },
@@ -875,7 +875,7 @@
       "active": "md-color-palette"
     },
     "ios": {
-      "default": "ios-color-palette-outline",
+      "default": "ios-color-palette",
       "active": "ios-color-palette"
     }
   },
@@ -885,7 +885,7 @@
       "active": "md-color-wand"
     },
     "ios": {
-      "default": "ios-color-wand-outline",
+      "default": "ios-color-wand",
       "active": "ios-color-wand"
     }
   },
@@ -895,7 +895,7 @@
       "active": "md-compass"
     },
     "ios": {
-      "default": "ios-compass-outline",
+      "default": "ios-compass",
       "active": "ios-compass"
     }
   },
@@ -905,7 +905,7 @@
       "active": "md-construct"
     },
     "ios": {
-      "default": "ios-construct-outline",
+      "default": "ios-construct",
       "active": "ios-construct"
     }
   },
@@ -915,7 +915,7 @@
       "active": "md-contact"
     },
     "ios": {
-      "default": "ios-contact-outline",
+      "default": "ios-contact",
       "active": "ios-contact"
     }
   },
@@ -925,7 +925,7 @@
       "active": "md-contacts"
     },
     "ios": {
-      "default": "ios-contacts-outline",
+      "default": "ios-contacts",
       "active": "ios-contacts"
     }
   },
@@ -935,7 +935,7 @@
       "active": "md-contract"
     },
     "ios": {
-      "default": "ios-contract-outline",
+      "default": "ios-contract",
       "active": "ios-contract"
     }
   },
@@ -945,7 +945,7 @@
       "active": "md-contrast"
     },
     "ios": {
-      "default": "ios-contrast-outline",
+      "default": "ios-contrast",
       "active": "ios-contrast"
     }
   },
@@ -955,7 +955,7 @@
       "active": "md-copy"
     },
     "ios": {
-      "default": "ios-copy-outline",
+      "default": "ios-copy",
       "active": "ios-copy"
     }
   },
@@ -965,7 +965,7 @@
       "active": "md-create"
     },
     "ios": {
-      "default": "ios-create-outline",
+      "default": "ios-create",
       "active": "ios-create"
     }
   },
@@ -975,7 +975,7 @@
       "active": "md-crop"
     },
     "ios": {
-      "default": "ios-crop-outline",
+      "default": "ios-crop",
       "active": "ios-crop"
     }
   },
@@ -985,7 +985,7 @@
       "active": "md-cube"
     },
     "ios": {
-      "default": "ios-cube-outline",
+      "default": "ios-cube",
       "active": "ios-cube"
     }
   },
@@ -995,7 +995,7 @@
       "active": "md-cut"
     },
     "ios": {
-      "default": "ios-cut-outline",
+      "default": "ios-cut",
       "active": "ios-cut"
     }
   },
@@ -1005,7 +1005,7 @@
       "active": "md-desktop"
     },
     "ios": {
-      "default": "ios-desktop-outline",
+      "default": "ios-desktop",
       "active": "ios-desktop"
     }
   },
@@ -1015,7 +1015,7 @@
       "active": "md-disc"
     },
     "ios": {
-      "default": "ios-disc-outline",
+      "default": "ios-disc",
       "active": "ios-disc"
     }
   },
@@ -1025,7 +1025,7 @@
       "active": "md-document"
     },
     "ios": {
-      "default": "ios-document-outline",
+      "default": "ios-document",
       "active": "ios-document"
     }
   },
@@ -1035,7 +1035,7 @@
       "active": "md-done-all"
     },
     "ios": {
-      "default": "ios-done-all-outline",
+      "default": "ios-done-all",
       "active": "ios-done-all"
     }
   },
@@ -1045,7 +1045,7 @@
       "active": "md-download"
     },
     "ios": {
-      "default": "ios-download-outline",
+      "default": "ios-download",
       "active": "ios-download"
     }
   },
@@ -1055,7 +1055,7 @@
       "active": "md-easel"
     },
     "ios": {
-      "default": "ios-easel-outline",
+      "default": "ios-easel",
       "active": "ios-easel"
     }
   },
@@ -1065,7 +1065,7 @@
       "active": "md-egg"
     },
     "ios": {
-      "default": "ios-egg-outline",
+      "default": "ios-egg",
       "active": "ios-egg"
     }
   },
@@ -1075,7 +1075,7 @@
       "active": "md-exit"
     },
     "ios": {
-      "default": "ios-exit-outline",
+      "default": "ios-exit",
       "active": "ios-exit"
     }
   },
@@ -1085,7 +1085,7 @@
       "active": "md-expand"
     },
     "ios": {
-      "default": "ios-expand-outline",
+      "default": "ios-expand",
       "active": "ios-expand"
     }
   },
@@ -1095,7 +1095,7 @@
       "active": "md-eye"
     },
     "ios": {
-      "default": "ios-eye-outline",
+      "default": "ios-eye",
       "active": "ios-eye"
     }
   },
@@ -1105,7 +1105,7 @@
       "active": "md-eye-off"
     },
     "ios": {
-      "default": "ios-eye-off-outline",
+      "default": "ios-eye-off",
       "active": "ios-eye-off"
     }
   },
@@ -1115,7 +1115,7 @@
       "active": "md-fastforward"
     },
     "ios": {
-      "default": "ios-fastforward-outline",
+      "default": "ios-fastforward",
       "active": "ios-fastforward"
     }
   },
@@ -1125,7 +1125,7 @@
       "active": "md-female"
     },
     "ios": {
-      "default": "ios-female-outline",
+      "default": "ios-female",
       "active": "ios-female"
     }
   },
@@ -1135,7 +1135,7 @@
       "active": "md-filing"
     },
     "ios": {
-      "default": "ios-filing-outline",
+      "default": "ios-filing",
       "active": "ios-filing"
     }
   },
@@ -1145,7 +1145,7 @@
       "active": "md-film"
     },
     "ios": {
-      "default": "ios-film-outline",
+      "default": "ios-film",
       "active": "ios-film"
     }
   },
@@ -1155,7 +1155,7 @@
       "active": "md-finger-print"
     },
     "ios": {
-      "default": "ios-finger-print-outline",
+      "default": "ios-finger-print",
       "active": "ios-finger-print"
     }
   },
@@ -1165,7 +1165,7 @@
       "active": "md-flag"
     },
     "ios": {
-      "default": "ios-flag-outline",
+      "default": "ios-flag",
       "active": "ios-flag"
     }
   },
@@ -1175,7 +1175,7 @@
       "active": "md-flame"
     },
     "ios": {
-      "default": "ios-flame-outline",
+      "default": "ios-flame",
       "active": "ios-flame"
     }
   },
@@ -1185,7 +1185,7 @@
       "active": "md-flash"
     },
     "ios": {
-      "default": "ios-flash-outline",
+      "default": "ios-flash",
       "active": "ios-flash"
     }
   },
@@ -1195,7 +1195,7 @@
       "active": "md-flask"
     },
     "ios": {
-      "default": "ios-flask-outline",
+      "default": "ios-flask",
       "active": "ios-flask"
     }
   },
@@ -1205,7 +1205,7 @@
       "active": "md-flower"
     },
     "ios": {
-      "default": "ios-flower-outline",
+      "default": "ios-flower",
       "active": "ios-flower"
     }
   },
@@ -1215,7 +1215,7 @@
       "active": "md-folder"
     },
     "ios": {
-      "default": "ios-folder-outline",
+      "default": "ios-folder",
       "active": "ios-folder"
     }
   },
@@ -1225,7 +1225,7 @@
       "active": "md-folder-open"
     },
     "ios": {
-      "default": "ios-folder-open-outline",
+      "default": "ios-folder-open",
       "active": "ios-folder-open"
     }
   },
@@ -1235,7 +1235,7 @@
       "active": "md-football"
     },
     "ios": {
-      "default": "ios-football-outline",
+      "default": "ios-football",
       "active": "ios-football"
     }
   },
@@ -1245,7 +1245,7 @@
       "active": "md-funnel"
     },
     "ios": {
-      "default": "ios-funnel-outline",
+      "default": "ios-funnel",
       "active": "ios-funnel"
     }
   },
@@ -1255,7 +1255,7 @@
       "active": "md-game-controller-a"
     },
     "ios": {
-      "default": "ios-game-controller-a-outline",
+      "default": "ios-game-controller-a",
       "active": "ios-game-controller-a"
     }
   },
@@ -1265,7 +1265,7 @@
       "active": "md-game-controller-b"
     },
     "ios": {
-      "default": "ios-game-controller-b-outline",
+      "default": "ios-game-controller-b",
       "active": "ios-game-controller-b"
     }
   },
@@ -1275,7 +1275,7 @@
       "active": "md-git-branch"
     },
     "ios": {
-      "default": "ios-git-branch-outline",
+      "default": "ios-git-branch",
       "active": "ios-git-branch"
     }
   },
@@ -1285,7 +1285,7 @@
       "active": "md-git-commit"
     },
     "ios": {
-      "default": "ios-git-commit-outline",
+      "default": "ios-git-commit",
       "active": "ios-git-commit"
     }
   },
@@ -1295,7 +1295,7 @@
       "active": "md-git-merge"
     },
     "ios": {
-      "default": "ios-git-merge-outline",
+      "default": "ios-git-merge",
       "active": "ios-git-merge"
     }
   },
@@ -1305,7 +1305,7 @@
       "active": "md-git-compare"
     },
     "ios": {
-      "default": "ios-git-compare-outline",
+      "default": "ios-git-compare",
       "active": "ios-git-compare"
     }
   },
@@ -1315,7 +1315,7 @@
       "active": "md-git-network"
     },
     "ios": {
-      "default": "ios-git-network-outline",
+      "default": "ios-git-network",
       "active": "ios-git-network"
     }
   },
@@ -1325,7 +1325,7 @@
       "active": "md-git-pull-request"
     },
     "ios": {
-      "default": "ios-git-pull-request-outline",
+      "default": "ios-git-pull-request",
       "active": "ios-git-pull-request"
     }
   },
@@ -1335,7 +1335,7 @@
       "active": "md-glasses"
     },
     "ios": {
-      "default": "ios-glasses-outline",
+      "default": "ios-glasses",
       "active": "ios-glasses"
     }
   },
@@ -1345,7 +1345,7 @@
       "active": "md-globe"
     },
     "ios": {
-      "default": "ios-globe-outline",
+      "default": "ios-globe",
       "active": "ios-globe"
     }
   },
@@ -1355,7 +1355,7 @@
       "active": "md-grid"
     },
     "ios": {
-      "default": "ios-grid-outline",
+      "default": "ios-grid",
       "active": "ios-grid"
     }
   },
@@ -1365,7 +1365,7 @@
       "active": "md-hammer"
     },
     "ios": {
-      "default": "ios-hammer-outline",
+      "default": "ios-hammer",
       "active": "ios-hammer"
     }
   },
@@ -1375,7 +1375,7 @@
       "active": "md-hand"
     },
     "ios": {
-      "default": "ios-hand-outline",
+      "default": "ios-hand",
       "active": "ios-hand"
     }
   },
@@ -1385,7 +1385,7 @@
       "active": "md-headset"
     },
     "ios": {
-      "default": "ios-headset-outline",
+      "default": "ios-headset",
       "active": "ios-headset"
     }
   },
@@ -1395,7 +1395,7 @@
       "active": "md-heart"
     },
     "ios": {
-      "default": "ios-heart-outline",
+      "default": "ios-heart",
       "active": "ios-heart"
     }
   },
@@ -1405,7 +1405,7 @@
       "active": "md-happy"
     },
     "ios": {
-      "default": "ios-happy-outline",
+      "default": "ios-happy",
       "active": "ios-happy"
     }
   },
@@ -1415,7 +1415,7 @@
       "active": "md-help"
     },
     "ios": {
-      "default": "ios-help-outline",
+      "default": "ios-help",
       "active": "ios-help"
     }
   },
@@ -1425,7 +1425,7 @@
       "active": "md-help-buoy"
     },
     "ios": {
-      "default": "ios-help-buoy-outline",
+      "default": "ios-help-buoy",
       "active": "ios-help-buoy"
     }
   },
@@ -1435,7 +1435,7 @@
       "active": "md-help-circle"
     },
     "ios": {
-      "default": "ios-help-circle-outline",
+      "default": "ios-help-circle",
       "active": "ios-help-circle"
     }
   },
@@ -1445,7 +1445,7 @@
       "active": "md-home"
     },
     "ios": {
-      "default": "ios-home-outline",
+      "default": "ios-home",
       "active": "ios-home"
     }
   },
@@ -1455,7 +1455,7 @@
       "active": "md-ice-cream"
     },
     "ios": {
-      "default": "ios-ice-cream-outline",
+      "default": "ios-ice-cream",
       "active": "ios-ice-cream"
     }
   },
@@ -1465,7 +1465,7 @@
       "active": "md-image"
     },
     "ios": {
-      "default": "ios-image-outline",
+      "default": "ios-image",
       "active": "ios-image"
     }
   },
@@ -1475,7 +1475,7 @@
       "active": "md-images"
     },
     "ios": {
-      "default": "ios-images-outline",
+      "default": "ios-images",
       "active": "ios-images"
     }
   },
@@ -1485,7 +1485,7 @@
       "active": "md-infinite"
     },
     "ios": {
-      "default": "ios-infinite-outline",
+      "default": "ios-infinite",
       "active": "ios-infinite"
     }
   },
@@ -1495,7 +1495,7 @@
       "active": "md-information"
     },
     "ios": {
-      "default": "ios-information-outline",
+      "default": "ios-information",
       "active": "ios-information"
     }
   },
@@ -1505,7 +1505,7 @@
       "active": "md-information-circle"
     },
     "ios": {
-      "default": "ios-information-circle-outline",
+      "default": "ios-information-circle",
       "active": "ios-information-circle"
     }
   },
@@ -1515,7 +1515,7 @@
       "active": "md-ionic"
     },
     "ios": {
-      "default": "ios-ionic-outline",
+      "default": "ios-ionic",
       "active": "ios-ionic"
     }
   },
@@ -1525,7 +1525,7 @@
       "active": "md-ionitron"
     },
     "ios": {
-      "default": "ios-ionitron-outline",
+      "default": "ios-ionitron",
       "active": "ios-ionitron"
     }
   },
@@ -1535,7 +1535,7 @@
       "active": "md-jet"
     },
     "ios": {
-      "default": "ios-jet-outline",
+      "default": "ios-jet",
       "active": "ios-jet"
     }
   },
@@ -1545,7 +1545,7 @@
       "active": "md-key"
     },
     "ios": {
-      "default": "ios-key-outline",
+      "default": "ios-key",
       "active": "ios-key"
     }
   },
@@ -1555,7 +1555,7 @@
       "active": "md-keypad"
     },
     "ios": {
-      "default": "ios-keypad-outline",
+      "default": "ios-keypad",
       "active": "ios-keypad"
     }
   },
@@ -1565,7 +1565,7 @@
       "active": "md-laptop"
     },
     "ios": {
-      "default": "ios-laptop-outline",
+      "default": "ios-laptop",
       "active": "ios-laptop"
     }
   },
@@ -1575,7 +1575,7 @@
       "active": "md-leaf"
     },
     "ios": {
-      "default": "ios-leaf-outline",
+      "default": "ios-leaf",
       "active": "ios-leaf"
     }
   },
@@ -1585,7 +1585,7 @@
       "active": "md-link"
     },
     "ios": {
-      "default": "ios-link-outline",
+      "default": "ios-link",
       "active": "ios-link"
     }
   },
@@ -1595,7 +1595,7 @@
       "active": "md-list"
     },
     "ios": {
-      "default": "ios-list-outline",
+      "default": "ios-list",
       "active": "ios-list"
     }
   },
@@ -1605,7 +1605,7 @@
       "active": "md-list-box"
     },
     "ios": {
-      "default": "ios-list-box-outline",
+      "default": "ios-list-box",
       "active": "ios-list-box"
     }
   },
@@ -1615,7 +1615,7 @@
       "active": "md-locate"
     },
     "ios": {
-      "default": "ios-locate-outline",
+      "default": "ios-locate",
       "active": "ios-locate"
     }
   },
@@ -1625,7 +1625,7 @@
       "active": "md-lock"
     },
     "ios": {
-      "default": "ios-lock-outline",
+      "default": "ios-lock",
       "active": "ios-lock"
     }
   },
@@ -1635,7 +1635,7 @@
       "active": "md-log-in"
     },
     "ios": {
-      "default": "ios-log-in-outline",
+      "default": "ios-log-in",
       "active": "ios-log-in"
     }
   },
@@ -1645,7 +1645,7 @@
       "active": "md-log-out"
     },
     "ios": {
-      "default": "ios-log-out-outline",
+      "default": "ios-log-out",
       "active": "ios-log-out"
     }
   },
@@ -1655,7 +1655,7 @@
       "active": "md-magnet"
     },
     "ios": {
-      "default": "ios-magnet-outline",
+      "default": "ios-magnet",
       "active": "ios-magnet"
     }
   },
@@ -1665,7 +1665,7 @@
       "active": "md-mail"
     },
     "ios": {
-      "default": "ios-mail-outline",
+      "default": "ios-mail",
       "active": "ios-mail"
     }
   },
@@ -1675,7 +1675,7 @@
       "active": "md-mail-open"
     },
     "ios": {
-      "default": "ios-mail-open-outline",
+      "default": "ios-mail-open",
       "active": "ios-mail-open"
     }
   },
@@ -1685,7 +1685,7 @@
       "active": "md-male"
     },
     "ios": {
-      "default": "ios-male-outline",
+      "default": "ios-male",
       "active": "ios-male"
     }
   },
@@ -1695,7 +1695,7 @@
       "active": "md-man"
     },
     "ios": {
-      "default": "ios-man-outline",
+      "default": "ios-man",
       "active": "ios-man"
     }
   },
@@ -1705,7 +1705,7 @@
       "active": "md-map"
     },
     "ios": {
-      "default": "ios-map-outline",
+      "default": "ios-map",
       "active": "ios-map"
     }
   },
@@ -1715,7 +1715,7 @@
       "active": "md-medal"
     },
     "ios": {
-      "default": "ios-medal-outline",
+      "default": "ios-medal",
       "active": "ios-medal"
     }
   },
@@ -1725,7 +1725,7 @@
       "active": "md-medical"
     },
     "ios": {
-      "default": "ios-medical-outline",
+      "default": "ios-medical",
       "active": "ios-medical"
     }
   },
@@ -1735,7 +1735,7 @@
       "active": "md-medkit"
     },
     "ios": {
-      "default": "ios-medkit-outline",
+      "default": "ios-medkit",
       "active": "ios-medkit"
     }
   },
@@ -1745,7 +1745,7 @@
       "active": "md-megaphone"
     },
     "ios": {
-      "default": "ios-megaphone-outline",
+      "default": "ios-megaphone",
       "active": "ios-megaphone"
     }
   },
@@ -1755,7 +1755,7 @@
       "active": "md-menu"
     },
     "ios": {
-      "default": "ios-menu-outline",
+      "default": "ios-menu",
       "active": "ios-menu"
     }
   },
@@ -1765,7 +1765,7 @@
       "active": "md-mic"
     },
     "ios": {
-      "default": "ios-mic-outline",
+      "default": "ios-mic",
       "active": "ios-mic"
     }
   },
@@ -1775,7 +1775,7 @@
       "active": "md-mic-off"
     },
     "ios": {
-      "default": "ios-mic-off-outline",
+      "default": "ios-mic-off",
       "active": "ios-mic-off"
     }
   },
@@ -1785,7 +1785,7 @@
       "active": "md-microphone"
     },
     "ios": {
-      "default": "ios-microphone-outline",
+      "default": "ios-microphone",
       "active": "ios-microphone"
     }
   },
@@ -1795,7 +1795,7 @@
       "active": "md-moon"
     },
     "ios": {
-      "default": "ios-moon-outline",
+      "default": "ios-moon",
       "active": "ios-moon"
     }
   },
@@ -1805,7 +1805,7 @@
       "active": "md-more"
     },
     "ios": {
-      "default": "ios-more-outline",
+      "default": "ios-more",
       "active": "ios-more"
     }
   },
@@ -1815,7 +1815,7 @@
       "active": "md-move"
     },
     "ios": {
-      "default": "ios-move-outline",
+      "default": "ios-move",
       "active": "ios-move"
     }
   },
@@ -1825,7 +1825,7 @@
       "active": "md-musical-note"
     },
     "ios": {
-      "default": "ios-musical-note-outline",
+      "default": "ios-musical-note",
       "active": "ios-musical-note"
     }
   },
@@ -1835,7 +1835,7 @@
       "active": "md-musical-notes"
     },
     "ios": {
-      "default": "ios-musical-notes-outline",
+      "default": "ios-musical-notes",
       "active": "ios-musical-notes"
     }
   },
@@ -1845,7 +1845,7 @@
       "active": "md-navigate"
     },
     "ios": {
-      "default": "ios-navigate-outline",
+      "default": "ios-navigate",
       "active": "ios-navigate"
     }
   },
@@ -1855,7 +1855,7 @@
       "active": "md-no-smoking"
     },
     "ios": {
-      "default": "ios-no-smoking-outline",
+      "default": "ios-no-smoking",
       "active": "ios-no-smoking"
     }
   },
@@ -1865,7 +1865,7 @@
       "active": "md-notifications"
     },
     "ios": {
-      "default": "ios-notifications-outline",
+      "default": "ios-notifications",
       "active": "ios-notifications"
     }
   },
@@ -1875,7 +1875,7 @@
       "active": "md-notifications-off"
     },
     "ios": {
-      "default": "ios-notifications-off-outline",
+      "default": "ios-notifications-off",
       "active": "ios-notifications-off"
     }
   },
@@ -1885,7 +1885,7 @@
       "active": "md-nuclear"
     },
     "ios": {
-      "default": "ios-nuclear-outline",
+      "default": "ios-nuclear",
       "active": "ios-nuclear"
     }
   },
@@ -1895,7 +1895,7 @@
       "active": "md-nutrition"
     },
     "ios": {
-      "default": "ios-nutrition-outline",
+      "default": "ios-nutrition",
       "active": "ios-nutrition"
     }
   },
@@ -1905,7 +1905,7 @@
       "active": "md-open"
     },
     "ios": {
-      "default": "ios-open-outline",
+      "default": "ios-open",
       "active": "ios-open"
     }
   },
@@ -1915,7 +1915,7 @@
       "active": "md-options"
     },
     "ios": {
-      "default": "ios-options-outline",
+      "default": "ios-options",
       "active": "ios-options"
     }
   },
@@ -1925,7 +1925,7 @@
       "active": "md-outlet"
     },
     "ios": {
-      "default": "ios-outlet-outline",
+      "default": "ios-outlet",
       "active": "ios-outlet"
     }
   },
@@ -1935,7 +1935,7 @@
       "active": "md-paper"
     },
     "ios": {
-      "default": "ios-paper-outline",
+      "default": "ios-paper",
       "active": "ios-paper"
     }
   },
@@ -1945,7 +1945,7 @@
       "active": "md-paper-plane"
     },
     "ios": {
-      "default": "ios-paper-plane-outline",
+      "default": "ios-paper-plane",
       "active": "ios-paper-plane"
     }
   },
@@ -1955,7 +1955,7 @@
       "active": "md-partly-sunny"
     },
     "ios": {
-      "default": "ios-partly-sunny-outline",
+      "default": "ios-partly-sunny",
       "active": "ios-partly-sunny"
     }
   },
@@ -1965,7 +1965,7 @@
       "active": "md-pause"
     },
     "ios": {
-      "default": "ios-pause-outline",
+      "default": "ios-pause",
       "active": "ios-pause"
     }
   },
@@ -1975,7 +1975,7 @@
       "active": "md-paw"
     },
     "ios": {
-      "default": "ios-paw-outline",
+      "default": "ios-paw",
       "active": "ios-paw"
     }
   },
@@ -1985,7 +1985,7 @@
       "active": "md-people"
     },
     "ios": {
-      "default": "ios-people-outline",
+      "default": "ios-people",
       "active": "ios-people"
     }
   },
@@ -1995,7 +1995,7 @@
       "active": "md-person"
     },
     "ios": {
-      "default": "ios-person-outline",
+      "default": "ios-person",
       "active": "ios-person"
     }
   },
@@ -2005,7 +2005,7 @@
       "active": "md-person-add"
     },
     "ios": {
-      "default": "ios-person-add-outline",
+      "default": "ios-person-add",
       "active": "ios-person-add"
     }
   },
@@ -2015,7 +2015,7 @@
       "active": "md-phone-landscape"
     },
     "ios": {
-      "default": "ios-phone-landscape-outline",
+      "default": "ios-phone-landscape",
       "active": "ios-phone-landscape"
     }
   },
@@ -2025,7 +2025,7 @@
       "active": "md-phone-portrait"
     },
     "ios": {
-      "default": "ios-phone-portrait-outline",
+      "default": "ios-phone-portrait",
       "active": "ios-phone-portrait"
     }
   },
@@ -2035,7 +2035,7 @@
       "active": "md-photos"
     },
     "ios": {
-      "default": "ios-photos-outline",
+      "default": "ios-photos",
       "active": "ios-photos"
     }
   },
@@ -2045,7 +2045,7 @@
       "active": "md-pie"
     },
     "ios": {
-      "default": "ios-pie-outline",
+      "default": "ios-pie",
       "active": "ios-pie"
     }
   },
@@ -2055,7 +2055,7 @@
       "active": "md-pin"
     },
     "ios": {
-      "default": "ios-pin-outline",
+      "default": "ios-pin",
       "active": "ios-pin"
     }
   },
@@ -2065,7 +2065,7 @@
       "active": "md-pint"
     },
     "ios": {
-      "default": "ios-pint-outline",
+      "default": "ios-pint",
       "active": "ios-pint"
     }
   },
@@ -2075,7 +2075,7 @@
       "active": "md-pizza"
     },
     "ios": {
-      "default": "ios-pizza-outline",
+      "default": "ios-pizza",
       "active": "ios-pizza"
     }
   },
@@ -2085,7 +2085,7 @@
       "active": "md-plane"
     },
     "ios": {
-      "default": "ios-plane-outline",
+      "default": "ios-plane",
       "active": "ios-plane"
     }
   },
@@ -2095,7 +2095,7 @@
       "active": "md-planet"
     },
     "ios": {
-      "default": "ios-planet-outline",
+      "default": "ios-planet",
       "active": "ios-planet"
     }
   },
@@ -2105,7 +2105,7 @@
       "active": "md-play"
     },
     "ios": {
-      "default": "ios-play-outline",
+      "default": "ios-play",
       "active": "ios-play"
     }
   },
@@ -2115,7 +2115,7 @@
       "active": "md-podium"
     },
     "ios": {
-      "default": "ios-podium-outline",
+      "default": "ios-podium",
       "active": "ios-podium"
     }
   },
@@ -2125,7 +2125,7 @@
       "active": "md-power"
     },
     "ios": {
-      "default": "ios-power-outline",
+      "default": "ios-power",
       "active": "ios-power"
     }
   },
@@ -2135,7 +2135,7 @@
       "active": "md-pricetag"
     },
     "ios": {
-      "default": "ios-pricetag-outline",
+      "default": "ios-pricetag",
       "active": "ios-pricetag"
     }
   },
@@ -2145,7 +2145,7 @@
       "active": "md-pricetags"
     },
     "ios": {
-      "default": "ios-pricetags-outline",
+      "default": "ios-pricetags",
       "active": "ios-pricetags"
     }
   },
@@ -2155,7 +2155,7 @@
       "active": "md-print"
     },
     "ios": {
-      "default": "ios-print-outline",
+      "default": "ios-print",
       "active": "ios-print"
     }
   },
@@ -2165,7 +2165,7 @@
       "active": "md-pulse"
     },
     "ios": {
-      "default": "ios-pulse-outline",
+      "default": "ios-pulse",
       "active": "ios-pulse"
     }
   },
@@ -2175,7 +2175,7 @@
       "active": "md-qr-scanner"
     },
     "ios": {
-      "default": "ios-qr-scanner-outline",
+      "default": "ios-qr-scanner",
       "active": "ios-qr-scanner"
     }
   },
@@ -2185,7 +2185,7 @@
       "active": "md-quote"
     },
     "ios": {
-      "default": "ios-quote-outline",
+      "default": "ios-quote",
       "active": "ios-quote"
     }
   },
@@ -2195,7 +2195,7 @@
       "active": "md-radio"
     },
     "ios": {
-      "default": "ios-radio-outline",
+      "default": "ios-radio",
       "active": "ios-radio"
     }
   },
@@ -2205,7 +2205,7 @@
       "active": "md-radio-button-off"
     },
     "ios": {
-      "default": "ios-radio-button-off-outline",
+      "default": "ios-radio-button-off",
       "active": "ios-radio-button-off"
     }
   },
@@ -2215,7 +2215,7 @@
       "active": "md-radio-button-on"
     },
     "ios": {
-      "default": "ios-radio-button-on-outline",
+      "default": "ios-radio-button-on",
       "active": "ios-radio-button-on"
     }
   },
@@ -2225,7 +2225,7 @@
       "active": "md-rainy"
     },
     "ios": {
-      "default": "ios-rainy-outline",
+      "default": "ios-rainy",
       "active": "ios-rainy"
     }
   },
@@ -2235,7 +2235,7 @@
       "active": "md-recording"
     },
     "ios": {
-      "default": "ios-recording-outline",
+      "default": "ios-recording",
       "active": "ios-recording"
     }
   },
@@ -2245,7 +2245,7 @@
       "active": "md-redo"
     },
     "ios": {
-      "default": "ios-redo-outline",
+      "default": "ios-redo",
       "active": "ios-redo"
     }
   },
@@ -2255,7 +2255,7 @@
       "active": "md-refresh"
     },
     "ios": {
-      "default": "ios-refresh-outline",
+      "default": "ios-refresh",
       "active": "ios-refresh"
     }
   },
@@ -2265,7 +2265,7 @@
       "active": "md-remove"
     },
     "ios": {
-      "default": "ios-remove-outline",
+      "default": "ios-remove",
       "active": "ios-remove"
     }
   },
@@ -2275,7 +2275,7 @@
       "active": "md-remove-circle"
     },
     "ios": {
-      "default": "ios-remove-circle-outline",
+      "default": "ios-remove-circle",
       "active": "ios-remove-circle"
     }
   },
@@ -2285,7 +2285,7 @@
       "active": "md-reorder"
     },
     "ios": {
-      "default": "ios-reorder-outline",
+      "default": "ios-reorder",
       "active": "ios-reorder"
     }
   },
@@ -2295,7 +2295,7 @@
       "active": "md-repeat"
     },
     "ios": {
-      "default": "ios-repeat-outline",
+      "default": "ios-repeat",
       "active": "ios-repeat"
     }
   },
@@ -2305,7 +2305,7 @@
       "active": "md-resize"
     },
     "ios": {
-      "default": "ios-resize-outline",
+      "default": "ios-resize",
       "active": "ios-resize"
     }
   },
@@ -2315,7 +2315,7 @@
       "active": "md-restaurant"
     },
     "ios": {
-      "default": "ios-restaurant-outline",
+      "default": "ios-restaurant",
       "active": "ios-restaurant"
     }
   },
@@ -2325,7 +2325,7 @@
       "active": "md-return-left"
     },
     "ios": {
-      "default": "ios-return-left-outline",
+      "default": "ios-return-left",
       "active": "ios-return-left"
     }
   },
@@ -2335,7 +2335,7 @@
       "active": "md-return-right"
     },
     "ios": {
-      "default": "ios-return-right-outline",
+      "default": "ios-return-right",
       "active": "ios-return-right"
     }
   },
@@ -2345,7 +2345,7 @@
       "active": "md-reverse-camera"
     },
     "ios": {
-      "default": "ios-reverse-camera-outline",
+      "default": "ios-reverse-camera",
       "active": "ios-reverse-camera"
     }
   },
@@ -2355,7 +2355,7 @@
       "active": "md-rewind"
     },
     "ios": {
-      "default": "ios-rewind-outline",
+      "default": "ios-rewind",
       "active": "ios-rewind"
     }
   },
@@ -2365,7 +2365,7 @@
       "active": "md-ribbon"
     },
     "ios": {
-      "default": "ios-ribbon-outline",
+      "default": "ios-ribbon",
       "active": "ios-ribbon"
     }
   },
@@ -2375,7 +2375,7 @@
       "active": "md-rose"
     },
     "ios": {
-      "default": "ios-rose-outline",
+      "default": "ios-rose",
       "active": "ios-rose"
     }
   },
@@ -2385,7 +2385,7 @@
       "active": "md-sad"
     },
     "ios": {
-      "default": "ios-sad-outline",
+      "default": "ios-sad",
       "active": "ios-sad"
     }
   },
@@ -2395,7 +2395,7 @@
       "active": "md-school"
     },
     "ios": {
-      "default": "ios-school-outline",
+      "default": "ios-school",
       "active": "ios-school"
     }
   },
@@ -2405,7 +2405,7 @@
       "active": "md-search"
     },
     "ios": {
-      "default": "ios-search-outline",
+      "default": "ios-search",
       "active": "ios-search"
     }
   },
@@ -2415,7 +2415,7 @@
       "active": "md-send"
     },
     "ios": {
-      "default": "ios-send-outline",
+      "default": "ios-send",
       "active": "ios-send"
     }
   },
@@ -2425,7 +2425,7 @@
       "active": "md-settings"
     },
     "ios": {
-      "default": "ios-settings-outline",
+      "default": "ios-settings",
       "active": "ios-settings"
     }
   },
@@ -2435,7 +2435,7 @@
       "active": "md-share"
     },
     "ios": {
-      "default": "ios-share-outline",
+      "default": "ios-share",
       "active": "ios-share"
     }
   },
@@ -2445,7 +2445,7 @@
       "active": "md-share-all"
     },
     "ios": {
-      "default": "ios-share-all-outline",
+      "default": "ios-share-all",
       "active": "ios-share-all"
     }
   },
@@ -2455,7 +2455,7 @@
       "active": "md-shirt"
     },
     "ios": {
-      "default": "ios-shirt-outline",
+      "default": "ios-shirt",
       "active": "ios-shirt"
     }
   },
@@ -2465,7 +2465,7 @@
       "active": "md-shuffle"
     },
     "ios": {
-      "default": "ios-shuffle-outline",
+      "default": "ios-shuffle",
       "active": "ios-shuffle"
     }
   },
@@ -2475,7 +2475,7 @@
       "active": "md-skip-backward"
     },
     "ios": {
-      "default": "ios-skip-backward-outline",
+      "default": "ios-skip-backward",
       "active": "ios-skip-backward"
     }
   },
@@ -2485,7 +2485,7 @@
       "active": "md-skip-forward"
     },
     "ios": {
-      "default": "ios-skip-forward-outline",
+      "default": "ios-skip-forward",
       "active": "ios-skip-forward"
     }
   },
@@ -2495,7 +2495,7 @@
       "active": "md-snow"
     },
     "ios": {
-      "default": "ios-snow-outline",
+      "default": "ios-snow",
       "active": "ios-snow"
     }
   },
@@ -2505,7 +2505,7 @@
       "active": "md-speedometer"
     },
     "ios": {
-      "default": "ios-speedometer-outline",
+      "default": "ios-speedometer",
       "active": "ios-speedometer"
     }
   },
@@ -2515,7 +2515,7 @@
       "active": "md-square"
     },
     "ios": {
-      "default": "ios-square-outline",
+      "default": "ios-square",
       "active": "ios-square"
     }
   },
@@ -2525,7 +2525,7 @@
       "active": "md-star"
     },
     "ios": {
-      "default": "ios-star-outline",
+      "default": "ios-star",
       "active": "ios-star"
     }
   },
@@ -2535,7 +2535,7 @@
       "active": "md-star-half"
     },
     "ios": {
-      "default": "ios-star-half-outline",
+      "default": "ios-star-half",
       "active": "ios-star-half"
     }
   },
@@ -2545,7 +2545,7 @@
       "active": "md-stats"
     },
     "ios": {
-      "default": "ios-stats-outline",
+      "default": "ios-stats",
       "active": "ios-stats"
     }
   },
@@ -2555,7 +2555,7 @@
       "active": "md-stopwatch"
     },
     "ios": {
-      "default": "ios-stopwatch-outline",
+      "default": "ios-stopwatch",
       "active": "ios-stopwatch"
     }
   },
@@ -2565,7 +2565,7 @@
       "active": "md-subway"
     },
     "ios": {
-      "default": "ios-subway-outline",
+      "default": "ios-subway",
       "active": "ios-subway"
     }
   },
@@ -2575,7 +2575,7 @@
       "active": "md-sunny"
     },
     "ios": {
-      "default": "ios-sunny-outline",
+      "default": "ios-sunny",
       "active": "ios-sunny"
     }
   },
@@ -2585,7 +2585,7 @@
       "active": "md-swap"
     },
     "ios": {
-      "default": "ios-swap-outline",
+      "default": "ios-swap",
       "active": "ios-swap"
     }
   },
@@ -2595,7 +2595,7 @@
       "active": "md-switch"
     },
     "ios": {
-      "default": "ios-switch-outline",
+      "default": "ios-switch",
       "active": "ios-switch"
     }
   },
@@ -2605,7 +2605,7 @@
       "active": "md-sync"
     },
     "ios": {
-      "default": "ios-sync-outline",
+      "default": "ios-sync",
       "active": "ios-sync"
     }
   },
@@ -2615,7 +2615,7 @@
       "active": "md-tablet-landscape"
     },
     "ios": {
-      "default": "ios-tablet-landscape-outline",
+      "default": "ios-tablet-landscape",
       "active": "ios-tablet-landscape"
     }
   },
@@ -2625,7 +2625,7 @@
       "active": "md-tablet-portrait"
     },
     "ios": {
-      "default": "ios-tablet-portrait-outline",
+      "default": "ios-tablet-portrait",
       "active": "ios-tablet-portrait"
     }
   },
@@ -2635,7 +2635,7 @@
       "active": "md-tennisball"
     },
     "ios": {
-      "default": "ios-tennisball-outline",
+      "default": "ios-tennisball",
       "active": "ios-tennisball"
     }
   },
@@ -2645,7 +2645,7 @@
       "active": "md-text"
     },
     "ios": {
-      "default": "ios-text-outline",
+      "default": "ios-text",
       "active": "ios-text"
     }
   },
@@ -2655,7 +2655,7 @@
       "active": "md-thermometer"
     },
     "ios": {
-      "default": "ios-thermometer-outline",
+      "default": "ios-thermometer",
       "active": "ios-thermometer"
     }
   },
@@ -2665,7 +2665,7 @@
       "active": "md-thumbs-down"
     },
     "ios": {
-      "default": "ios-thumbs-down-outline",
+      "default": "ios-thumbs-down",
       "active": "ios-thumbs-down"
     }
   },
@@ -2675,7 +2675,7 @@
       "active": "md-thumbs-up"
     },
     "ios": {
-      "default": "ios-thumbs-up-outline",
+      "default": "ios-thumbs-up",
       "active": "ios-thumbs-up"
     }
   },
@@ -2685,7 +2685,7 @@
       "active": "md-thunderstorm"
     },
     "ios": {
-      "default": "ios-thunderstorm-outline",
+      "default": "ios-thunderstorm",
       "active": "ios-thunderstorm"
     }
   },
@@ -2695,7 +2695,7 @@
       "active": "md-time"
     },
     "ios": {
-      "default": "ios-time-outline",
+      "default": "ios-time",
       "active": "ios-time"
     }
   },
@@ -2705,7 +2705,7 @@
       "active": "md-timer"
     },
     "ios": {
-      "default": "ios-timer-outline",
+      "default": "ios-timer",
       "active": "ios-timer"
     }
   },
@@ -2715,7 +2715,7 @@
       "active": "md-train"
     },
     "ios": {
-      "default": "ios-train-outline",
+      "default": "ios-train",
       "active": "ios-train"
     }
   },
@@ -2725,7 +2725,7 @@
       "active": "md-transgender"
     },
     "ios": {
-      "default": "ios-transgender-outline",
+      "default": "ios-transgender",
       "active": "ios-transgender"
     }
   },
@@ -2735,7 +2735,7 @@
       "active": "md-trash"
     },
     "ios": {
-      "default": "ios-trash-outline",
+      "default": "ios-trash",
       "active": "ios-trash"
     }
   },
@@ -2745,7 +2745,7 @@
       "active": "md-trending-down"
     },
     "ios": {
-      "default": "ios-trending-down-outline",
+      "default": "ios-trending-down",
       "active": "ios-trending-down"
     }
   },
@@ -2755,7 +2755,7 @@
       "active": "md-trending-up"
     },
     "ios": {
-      "default": "ios-trending-up-outline",
+      "default": "ios-trending-up",
       "active": "ios-trending-up"
     }
   },
@@ -2765,7 +2765,7 @@
       "active": "md-trophy"
     },
     "ios": {
-      "default": "ios-trophy-outline",
+      "default": "ios-trophy",
       "active": "ios-trophy"
     }
   },
@@ -2775,7 +2775,7 @@
       "active": "md-umbrella"
     },
     "ios": {
-      "default": "ios-umbrella-outline",
+      "default": "ios-umbrella",
       "active": "ios-umbrella"
     }
   },
@@ -2785,7 +2785,7 @@
       "active": "md-undo"
     },
     "ios": {
-      "default": "ios-undo-outline",
+      "default": "ios-undo",
       "active": "ios-undo"
     }
   },
@@ -2795,7 +2795,7 @@
       "active": "md-unlock"
     },
     "ios": {
-      "default": "ios-unlock-outline",
+      "default": "ios-unlock",
       "active": "ios-unlock"
     }
   },
@@ -2805,7 +2805,7 @@
       "active": "md-videocam"
     },
     "ios": {
-      "default": "ios-videocam-outline",
+      "default": "ios-videocam",
       "active": "ios-videocam"
     }
   },
@@ -2815,7 +2815,7 @@
       "active": "md-volume-down"
     },
     "ios": {
-      "default": "ios-volume-down-outline",
+      "default": "ios-volume-down",
       "active": "ios-volume-down"
     }
   },
@@ -2825,7 +2825,7 @@
       "active": "md-volume-up"
     },
     "ios": {
-      "default": "ios-volume-up-outline",
+      "default": "ios-volume-up",
       "active": "ios-volume-up"
     }
   },
@@ -2835,7 +2835,7 @@
       "active": "md-volume-mute"
     },
     "ios": {
-      "default": "ios-volume-mute-outline",
+      "default": "ios-volume-mute",
       "active": "ios-volume-mute"
     }
   },
@@ -2845,7 +2845,7 @@
       "active": "md-volume-off"
     },
     "ios": {
-      "default": "ios-volume-off-outline",
+      "default": "ios-volume-off",
       "active": "ios-volume-off"
     }
   },
@@ -2855,7 +2855,7 @@
       "active": "md-walk"
     },
     "ios": {
-      "default": "ios-walk-outline",
+      "default": "ios-walk",
       "active": "ios-walk"
     }
   },
@@ -2865,7 +2865,7 @@
       "active": "md-warning"
     },
     "ios": {
-      "default": "ios-warning-outline",
+      "default": "ios-warning",
       "active": "ios-warning"
     }
   },
@@ -2875,7 +2875,7 @@
       "active": "md-watch"
     },
     "ios": {
-      "default": "ios-watch-outline",
+      "default": "ios-watch",
       "active": "ios-watch"
     }
   },
@@ -2885,7 +2885,7 @@
       "active": "md-water"
     },
     "ios": {
-      "default": "ios-water-outline",
+      "default": "ios-water",
       "active": "ios-water"
     }
   },
@@ -2895,7 +2895,7 @@
       "active": "md-wifi"
     },
     "ios": {
-      "default": "ios-wifi-outline",
+      "default": "ios-wifi",
       "active": "ios-wifi"
     }
   },
@@ -2905,7 +2905,7 @@
       "active": "md-wine"
     },
     "ios": {
-      "default": "ios-wine-outline",
+      "default": "ios-wine",
       "active": "ios-wine"
     }
   },
@@ -2915,7 +2915,7 @@
       "active": "md-woman"
     },
     "ios": {
-      "default": "ios-woman-outline",
+      "default": "ios-woman",
       "active": "ios-woman"
     }
   }


### PR DESCRIPTION
Used this Regex to find the strings (ios-\w*(-*\w*)*)-outline and removed the outline of all icons that are broken.

Fixes #2461 