### PR TITLE
[TS] Add `expanded` prop to Accordion and allow Accordion's item strong-typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -849,6 +849,7 @@ declare module "native-base" {
 			renderHeader?: (item: T, expanded: boolean) => React.ReactElement<any>;
 			renderContent?: (item: T) => React.ReactElement<any>;
 			icon?: string;
+			expanded?: number;
 			expandedIcon?: string;
 			iconStyle?: ReactNative.TextStyle;
 			expandedIconStyle?: ReactNative.TextStyle;

--- a/index.d.ts
+++ b/index.d.ts
@@ -842,12 +842,12 @@ declare module "native-base" {
 			style?: ReactNative.ViewStyle;
 		}
 
-		interface Accordion {
-			dataArray: Array<any>;
+		interface Accordion<T> {
+			dataArray: Array<T>;
 			headerStyle?: ReactNative.ViewStyle;
 			contentStyle?: ReactNative.ViewStyle;
-			renderHeader?: (item: any, expanded: boolean) => React.ReactElement<any>;
-			renderContent?: (item: any) => React.ReactElement<any>;
+			renderHeader?: (item: T, expanded: boolean) => React.ReactElement<any>;
+			renderContent?: (item: T) => React.ReactElement<any>;
 			icon?: string;
 			expandedIcon?: string;
 			iconStyle?: ReactNative.TextStyle;
@@ -1163,7 +1163,7 @@ declare module "native-base" {
 		}): void;
 	}
 
-	export class Accordion extends React.Component<NativeBase.Accordion, any>{ }
+	export class Accordion<T> extends React.Component<NativeBase.Accordion<T>, any>{ }
 
 	export class DatePicker extends React.Component<NativeBase.DatePicker, any> { }
 }


### PR DESCRIPTION
This PR fixes https://github.com/GeekyAnts/NativeBase/issues/2490.

By the way I also used generics to strong-type Accordion item type.