### PR TITLE
Extend radio styles for checkmark behaviour

### DIFF
--- a/src/basic/Radio.js
+++ b/src/basic/Radio.js
@@ -38,9 +38,9 @@ class Radio extends Component {
                 color: this.props.selectedColor
                   ? this.props.selectedColor
                   : variables.radioColor,
-                lineHeight: 25,
-                height: 20,
-                fontSize: variables.radioBtnSize
+                lineHeight: variables.radioCheckmarkBtnLineHeight || 25,
+                height: variables.radioCheckmarkBtnHeight || 20,
+                fontSize: variables.radioCheckmarkBtnSize || variables.radioBtnSize
               }}
               name="ios-checkmark"
             />

--- a/src/theme/variables/commonColor.js
+++ b/src/theme/variables/commonColor.js
@@ -210,8 +210,11 @@ export default {
 
   // Radio Button
   radioBtnSize: platform === "ios" ? 25 : 23,
+  radioCheckmarkBtnSize: platform === "ios" ? 25 : 23,
   radioSelectedColorAndroid: "#3F51B5",
   radioBtnLineHeight: platform === "ios" ? 29 : 24,
+  radioCheckmarkBtnLineHeight: platform === "ios" ? 29 : 24,
+  radioCheckmarkBtnHeight: 20,
   get radioColor() {
     return this.brandPrimary;
   },

--- a/src/theme/variables/material.js
+++ b/src/theme/variables/material.js
@@ -210,8 +210,10 @@ export default {
 
   // Radio Button
   radioBtnSize: 23,
+  radioCheckmarkBtnSize: 23,
   radioSelectedColorAndroid: "#3F51B5",
   radioBtnLineHeight: 24,
+  radioCheckmarkBtnLineHeight: 24,
   get radioColor() {
     return this.brandPrimary;
   },

--- a/src/theme/variables/platform.js
+++ b/src/theme/variables/platform.js
@@ -210,8 +210,10 @@ export default {
 
   // Radio Button
   radioBtnSize: platform === "ios" ? 25 : 23,
+  radioCheckmarkBtnSize: platform === "ios" ? 25 : 23,
   radioSelectedColorAndroid: "#3F51B5",
   radioBtnLineHeight: platform === "ios" ? 29 : 24,
+  radioCheckmarkBtnLineHeight: platform === "ios" ? 29 : 24,
   get radioColor() {
     return this.brandPrimary;
   },


### PR DESCRIPTION
1. It's impossible to set line height for radio in selected picker item. Radio has property `standardStyle` as false by default. `lineHeight` has value as `25` in this case :(
```
<Icon
    style={{
    color: this.props.selectedColor
        ? this.props.selectedColor
        : variables.radioColor,
    lineHeight: 25,
    height: 20,
    fontSize: variables.radioBtnSize
    }}
    name="ios-checkmark"
/>
```

2. I want to set different styles for standard radio and radio in selected picker item.
So i divided variables to `radioBtnLineHeight` and `radioCheckmarkBtnLineHeight`, `radioBtnSize` and `radioCheckmarkBtnSize` and created `radioCheckmarkBtnHeight` variable support. If those variables not defined (for existing custom themes), they will be default values (as previous).

If you find my contribution useful, could you update the version as soon as possible? 

Thank you very much for your excellent product 👍 