### PR TITLE
Pass through iosBarStyle from Picker to Header

### DIFF
--- a/src/basic/Header.js
+++ b/src/basic/Header.js
@@ -66,6 +66,7 @@ class Header extends Component {
     return (
       <View onLayout={e => this.layoutChange(e.nativeEvent.layout)}>
         <StatusBar
+          hidden={false}
           backgroundColor={
             this.props.androidStatusBarColor
               ? this.props.androidStatusBarColor

--- a/src/basic/Picker.ios.js
+++ b/src/basic/Picker.ios.js
@@ -150,7 +150,7 @@ class PickerNB extends Component {
     return this.props.renderHeader ? (
       this.props.renderHeader(() => this._setModalVisible(false))
     ) : (
-        <Header style={this.props.headerStyle}>
+        <Header style={this.props.headerStyle} iosBarStyle={this.props.iosBarStyle}>
           <Left>
             <Button
               style={{


### PR DESCRIPTION
Previously there was no way to set the barStyle on iOS when using the Picker component.

Also adds <StatusBar hidden={false} /> for react-native v0.58.