### PR TITLE
ListItem having weird marginLeft as described on issue #1274

### DIFF
--- a/src/theme/components/ListItem.js
+++ b/src/theme/components/ListItem.js
@@ -434,7 +434,7 @@ export default (variables /*: * */ = variable) => {
     flexDirection: "row",
     paddingRight: variables.listItemPadding + 6,
     paddingVertical: variables.listItemPadding + 3,
-    marginLeft: variables.listItemPadding + 6,
+    paddingLeft: variables.listItemPadding + 6,
     borderBottomWidth: 1 / PixelRatio.getPixelSizeForLayoutSize(1),
     backgroundColor: variables.listBg,
     borderColor: variables.listBorderColor


### PR DESCRIPTION
This was a known issue, making lists look weird because the border-bottom is always cut on the left, and when you use background on listitem and items you can see the background lacking on left also. For some reason it is now marginLeft instead of paddingLeft, and a List needs to fit the component device width not having margins, because most of times you use it 100% wide and want to put some border-bottom`s on it and expect the border to cover 100%. And moreover, a ListItem having paddingRight, and instead of having a paddingLeft also to mantain simmetry you see a marginLeft? this just does not make sense. Changing to paddingLeft solved all my problems and i believe that will solve many problems of the comunnity also.

Before change:
![captura de tela de 2019-01-30 11-49-41](https://user-images.githubusercontent.com/6789373/51985774-dd167e80-2485-11e9-9340-80a2d45b0f41.png)

After change:
![captura de tela de 2019-01-30 11-49-23](https://user-images.githubusercontent.com/6789373/51985793-e7387d00-2485-11e9-9497-cb5c60946624.png)
