### PR TITLE
[#2591] fix getRef for item inputs.

### DIFF
--- a/src/basic/Item.js
+++ b/src/basic/Item.js
@@ -357,8 +357,8 @@ class Item extends Component {
         </View>
       );
     } else {
-      return React.Children.map(this.props.children, (child, i) => {
-        if (child.type.displayName === "Styled(Input)") {
+      return React.Children.map(this.props.children, (child) => {
+        if (child && child.type && child.type.displayName === "Styled(Input)") {
           return React.cloneElement(child, {
             ref: c => this._inputRef = c
           });

--- a/src/basic/Item.js
+++ b/src/basic/Item.js
@@ -33,9 +33,9 @@ class Item extends Component {
         this.setState({ isFocused: true });
         this.floatUp(-16);
       }
-      if (this.inputProps && this.inputProps.getRef)
-        this.inputProps.getRef(this._inputRef);
-    }
+    }    
+    if (this.inputProps && this.inputProps.getRef)
+      this.inputProps.getRef(this._inputRef);
   }
   componentWillReceiveProps(nextProps) {
     const childrenArray = React.Children.toArray(nextProps.children);
@@ -52,9 +52,9 @@ class Item extends Component {
         this.setState({ isFocused: true });
         this.floatUp(-16);
       }
-      if (this.inputProps && this.inputProps.getRef)
-        this.inputProps.getRef(this._inputRef);
     }
+    if (this.inputProps && this.inputProps.getRef)
+      this.inputProps.getRef(this._inputRef);
   }
 
   floatBack() {

--- a/src/basic/Item.js
+++ b/src/basic/Item.js
@@ -348,6 +348,7 @@ class Item extends Component {
           <View style={{ flexDirection: "column" }}>
             <Label key="s2" {...labelProps} />
             <Input
+              ref={c => (this._inputRef = c)}
               key="s3"
               {...inputProps}
               style={{ width: variables.deviceWidth - 40 }}
@@ -356,7 +357,15 @@ class Item extends Component {
         </View>
       );
     } else {
-      return this.props.children;
+      return React.Children.map(this.props.children, (child, i) => {
+        if (child.type.displayName === "Styled(Input)") {
+          return React.cloneElement(child, {
+            ref: c => this._inputRef = c
+          });
+        }
+
+        return child;
+      });
     }
     return newChildren;
   }


### PR DESCRIPTION
`this.inputProps.getRef` is only being called if `this.props.floatingLabel` is truthy. This fixes that so it will work with other label types. This is a proposed resolution to issue https://github.com/GeekyAnts/NativeBase/issues/2591 which contains a more detailed description of the issue.

This PR moves the `if (this.inputProps && this.inputProps.getRef)` statement outside of the if statement that checks for `this.props.floatingLabel`, so that `this.inputProps.getRef(this._inputRef);` can be called for any label type and not just for floatingLabels. It also attaches the `ref: c => this._inputRef = c` to all inputs, not just ones with floating labels.