### PR TITLE
bump react-native-vector-icons from 6.1.0 to 6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jest": "23.3.0",
     "react": "16.4.1",
     "react-native": "0.56.0",
-    "react-native-vector-icons": "6.1.0",
+    "react-native-vector-icons": "6.3.0",
     "react-test-renderer": "16.4.1"
   },
   "gitHead": "5bbeacc403ba97622703699132c55d8359344004",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-native-drawer": "2.5.1",
     "react-native-easy-grid": "0.2.1",
     "react-native-keyboard-aware-scroll-view": "0.8.0",
-    "react-native-vector-icons": "6.1.0",
+    "react-native-vector-icons": "6.3.0",
     "react-tween-state": "^0.1.5",
     "tween-functions": "^1.0.1",
     "react-timer-mixin": "^0.13.4"


### PR DESCRIPTION
it permits to use the updated version of the icon sets (which gives access to even more icons)

the changelog: 

```
    Add support for aliases in the IconMoon factory.
    Update MaterialCommunityIcons to 3.4.93.
    Update Octicons to 8.4.1.
    Fix issues with Android Gradle Plugin 3.1
    Update FontAwesome5 to 5.6.3
```
