### PR TITLE
Extends the Content type with KeyboardAwareProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 declare module "native-base" {
 	import * as React from "react";
 	import * as ReactNative from "react-native";
+	import { KeyboardAwareProps } from "react-native-keyboard-aware-scroll-view";
 
 	type RnViewStyleProp = ReactNative.StyleProp<ReactNative.ViewStyle>;
 	type RnTextStyleProp = ReactNative.StyleProp<ReactNative.TextStyle>;
@@ -169,7 +170,7 @@ declare module "native-base" {
 		/**
          * see Widget Content.js
          */
-		interface Content extends Testable {
+		interface Content extends KeyboardAwareProps, Testable {
 			/**
              * The theme prop can be applied to any component of NativeBase.
              */


### PR DESCRIPTION
This correct the Content type so that it reflects how the Content component passes forward props to the react-native-keyboard-aware-scroll-view component it uses. Otherwise, when I use a Content prop that's made available from react-native-keyboard-aware-scroll-view, such as `enableOnAndroid`, a type error is shown in my Typescript React-Native project using Native-Base. This is technically an incorrect error. All props made available by react-native-keyboard-aware-scroll-view should also be available in the Content type.

It may also be worth looking into adding props from react-native-keyboard-aware-scroll-view into Content's `propTyps`. But, since I'm using Typescript and not pure JavaScript, this was not a concern to me at the type. Moreover, the `propTypes` would also need to be exposed in [`KeyboardAwareHOC.js` from  react-native-keyboard-aware-scroll-view](https://github.com/APSL/react-native-keyboard-aware-scroll-view/blob/master/lib/KeyboardAwareHOC.js).

I hope this PR helps.