### PR TITLE
color prop defined in Radio Interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -691,6 +691,7 @@ declare module "native-base" {
          * see Widget CheckBox.js
          */
 		interface Radio extends ReactNative.TouchableOpacityProps, Testable {
+			color?: string;
 			selected?: boolean;
 			selectedColor?: string;
 		}


### PR DESCRIPTION
After exploring how to change the outer circle color of radio button in native base i have found that in Radio.js file 
this.props.color is defined but not defined in Interface of Radio Button in the file i.e index.d.ts

So it should be defined so that intelligence should work