### PR TITLE
Add missing Textarea type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -632,6 +632,8 @@ declare module "native-base" {
          */
 		interface Textarea extends ReactNative.TextInputProps, Testable {
 			rowSpan: number;
+			bordered: boolean;
+			underline: boolean;
 			/**
              * Disables inputting data.
              */


### PR DESCRIPTION
Bordered and underline were missing from the type definition of Textarea.