### PR TITLE
remove Content interface conflicts with KeyboardAwareScrollViewProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -175,17 +175,13 @@ declare module "native-base" {
              * The theme prop can be applied to any component of NativeBase.
              */
 			refreshing?: boolean;
-			refreshControl?: object;
 			theme?: Object;
 			padder?: boolean;
 			disableKBDismissScroll?: boolean;
 			enableResetScrollToCoords?: boolean;
-			contentOffset?: Object;
 			scrollEnabled?: boolean;
 			style?: RnViewStyleProp | Array<RnViewStyleProp>;
 			contentContainerStyle?: RnViewStyleProp | Array<RnViewStyleProp>;
-			keyboardShouldPersistTaps?: string;
-			keyboardDismissMode?: string;
 		}
 		/**
          * see Widget Button.js


### PR DESCRIPTION
Content interface in /index.d.ts extends KeyboardAwareScrollViewProps but defines some properties as Object and String, instead of the types from KeyboardAwareScrollViewProps