### PR TITLE
Upgrade react-native-vector-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "jest": "23.3.0",
     "react": "16.4.1",
     "react-native": "0.56.0",
-    "react-native-vector-icons": "6.1.0",
+    "react-native-vector-icons": "6.3.0",
     "react-test-renderer": "16.4.1"
   },
   "gitHead": "5bbeacc403ba97622703699132c55d8359344004",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-native-drawer": "2.5.1",
     "react-native-easy-grid": "0.2.1",
     "react-native-keyboard-aware-scroll-view": "0.8.0",
-    "react-native-vector-icons": "6.3.0",
+    "react-native-vector-icons": "6.6.0",
     "react-timer-mixin": "^0.13.4",
     "react-tween-state": "^0.1.5",
     "tween-functions": "^1.0.1"
@@ -67,7 +67,7 @@
     "jest": "23.3.0",
     "react": "16.4.1",
     "react-native": "0.56.0",
-    "react-native-vector-icons": "6.3.0",
+    "react-native-vector-icons": "6.6.0",
     "react-test-renderer": "16.4.1"
   },
   "gitHead": "5bbeacc403ba97622703699132c55d8359344004",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-native-drawer": "2.5.1",
     "react-native-easy-grid": "0.2.1",
     "react-native-keyboard-aware-scroll-view": "0.8.0",
-    "react-native-vector-icons": "6.1.0",
+    "react-native-vector-icons": "6.3.0",
     "react-timer-mixin": "^0.13.4",
     "react-tween-state": "^0.1.5",
     "tween-functions": "^1.0.1"


### PR DESCRIPTION
Some icons couldn't be rendered with `react-native-vector-icons@6.1.0` on Android.
Fixed it by upgrading it to `6.3.0` as specified in this issue https://github.com/oblador/react-native-vector-icons/issues/961