### PR TITLE
scrollWithoutAnimation should be optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -783,7 +783,7 @@ declare module "native-base" {
 			tabContainerStyle?: RnViewStyleProp | Array<RnViewStyleProp>;
 			style?: RnViewStyleProp | Array<RnViewStyleProp>;
 			contentProps?: ReactNative.ScrollViewProperties;
-			scrollWithoutAnimation: boolean;
+			scrollWithoutAnimation?: boolean;
 			prerenderingSiblingsNumber?: number;
 		}
 


### PR DESCRIPTION
The scrollWithoutAnimation property of [Tabs](https://docs.nativebase.io/Components.html#tabs-def-headref) component has default property.
(See: https://github.com/GeekyAnts/NativeBase/blob/master/src/basic/Tabs/index.js#L56)

But, TS2741 error occur when not give it.

```
error TS2741: Property 'scrollWithoutAnimation' is missing in type '{ children: any[]; renderTabBar: () => Element; }' but required in type 'Readonly<Tabs>'.

146       <Tabs
           ~~~~

  node_modules/native-base/index.d.ts:786:4
    786                 scrollWithoutAnimation: boolean;
                        ~~~~~~~~~~~~~~~~~~~~~~
    'scrollWithoutAnimation' is declared here.
```

This is due to incorrect type definition file.