### PR TITLE
replace bgColor `null` with `transparent`

### DIFF
--- a/src/basic/Tabs/DefaultTabBar.js
+++ b/src/basic/Tabs/DefaultTabBar.js
@@ -37,7 +37,7 @@ const DefaultTabBar = createReactClass({
       activeTextColor: variable.topTabBarActiveTextColor,
       inactiveTextColor: variable.topTabBarTextColor,
       disabledTextColor: variable.tabBarDisabledTextColor,
-      backgroundColor: null,
+      backgroundColor: 'transparent',
       tabFontSize: variable.tabFontSize
     };
   },


### PR DESCRIPTION
I have seen some crash reports about backgroundColor: null in my tools, specially with 32bit android devices.