### PR TITLE
Allow specifying icon type in icon ActionSheet

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1167,7 +1167,12 @@ declare module "native-base" {
 	export class ActionSheet {
 		static show: (
 			configuration: {
-				options: string[] | Array<{ text: string, icon?: string, iconColor?: string }>;
+				options: string[] | Array<{ 
+					text: string, 
+					icon?: string, 
+					iconColor?: string, 
+					iconType?: "AntDesign" | "Entypo" | "EvilIcons" | "Feather" | "FontAwesome" | "FontAwesome5" | "Foundation" | "Ionicons" | "MaterialCommunityIcons" | "MaterialIcons" | "Octicons" | "SimpleLineIcons" | "Zocial",
+				}>;
 				cancelButtonIndex?: number;
 				destructiveButtonIndex?: number;
 				title?: string;

--- a/src/basic/Actionsheet.js
+++ b/src/basic/Actionsheet.js
@@ -137,6 +137,7 @@ class ActionSheetContainer extends Component {
                     <Left>
                       <Icon
                         name={item.icon}
+                        type={item.iconType}
                         style={{
                           color: item.iconColor ? item.iconColor : undefined
                         }}


### PR DESCRIPTION
This change allows configuring the icon type when using an ActionSheet with icons. Right now you can only use icons from the default IonIcons family.