### PR TITLE
Fixed typo at NativeBase.Thumbnail definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1071,7 +1071,7 @@ declare module "native-base" {
      * NativeBase.Thumbnail
      *
      * Thumbnail component works very similar to Image.
-     * It helps you to showcase an image with variuos dimensions and shapes.
+     * It helps you to showcase an image with various dimensions and shapes.
      * By default, Thumbnail renders an image in circular shape.
      */
 	export class Thumbnail extends React.Component<NativeBase.Thumbnail, any> { }


### PR DESCRIPTION
Hi! I found this typo at index.d.ts where `NativeBase.Thumbnail` definition had a "variuos" instead of "various"

It's actually my first pull request into an OSS software, so I hope i did it right (i only changed the typo at my own branch).

Keep up with the nice work, and I hope to contribute more in the future! :D