### PR TITLE
fix(types): make name of Icon optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -653,7 +653,7 @@ declare module "native-base" {
          * see Widget Icon.js
          */
 		interface Icon extends Testable {
-			name: string;
+			name?: string;
 			type?: "AntDesign" | "Entypo" | "EvilIcons" | "Feather" | "FontAwesome" | "FontAwesome5" | "Foundation" | "Ionicons" | "MaterialCommunityIcons" | "MaterialIcons" | "Octicons" | "SimpleLineIcons" | "Zocial";
 			// TODO position attribute of ReactNative.FlexStyle hasn't another position values without "absolute" and "relative"
 			style?: any;


### PR DESCRIPTION
I messed up the commit message of my last PR, so I opened this one.

The documentation says "`Icon` can take any two of the following attributes: name, ios, android."

But when using `ios` and `android`, it will trigger the error `Property 'name' is missing`.

Or maybe it's better to be defined like this to meet what the documentation says?

```typescript
interface IconBase extends Testable {
  name?: string;
  type?: "AntDesign" | "Entypo" | "EvilIcons" | "Feather" | "FontAwesome" | "FontAwesome5" | "Foundation" | "Ionicons" | "MaterialCommunityIcons" | "MaterialIcons" | "Octicons" | "SimpleLineIcons" | "Zocial";
  // TODO position attribute of ReactNative.FlexStyle hasn't another position values without "absolute" and "relative"
  style?: any;
  onPress?: (e?: any) => any;
  active?: boolean;
  ios?: string;
  android?: string;
  color?: string;
  fontSize?: number;
}
interface Icon extends IconBase {
  name: string;
}
interface IconPlatform extends IconBase {
  ios: string;
  android: string;
}
export class Icon extends React.Component<NativeBase.Icon | NativeBase.IconPlatform, any> { }
```