### PR TITLE
Pass variables.platformStyle instead of variables

### DIFF
--- a/src/theme/components/index.js
+++ b/src/theme/components/index.js
@@ -49,7 +49,9 @@ import variable from './../variables/platform';
 
 export default (variables /* : * */ = variable) => {
   const theme = {
-    variables,
+    variables: {
+      platformStyle: variables.platformStyle,
+    },
     'NativeBase.Left': {
       ...leftTheme(variables)
     },


### PR DESCRIPTION
Only platformStyle is used here, there is no point to pass whole variables