### PR TITLE
Removes implicit any issue.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -305,7 +305,7 @@ declare module "native-base" {
 			disableLeftSwipe?: boolean;
 			disableRightSwipe?: boolean;
       rightOpenValue?: number;
-      keyExtractor?: (item, index: number) => string;
+      keyExtractor?: (item: any, index: number) => string;
 			leftOpenValue?: number;
 			renderRightHiddenRow?: (
 				rowData: any,


### PR DESCRIPTION
# Problem

When using NativeBase in any typescript project with the setting "noImplicitAny" enabled, the typescript checker fails with error:

`node_modules/native-base/index.d.ts:308:23 - error TS7006: Parameter 'item' implicitly has an 'any' type.`

# How to reproduce

* Create a new typescript project with the setting `noImplicitAny` set to `true`.
* Add NativeBase package.
* Use any NativeBase component in a view.
* Run the type checker.

# Solution

Explicitly adding the any type for the item parameter removes the error.

---

Fixes #2971 