### PR TITLE
Make ListItem Show Visual Feedback by Default for Android

### DIFF
--- a/src/basic/ListItem.js
+++ b/src/basic/ListItem.js
@@ -43,7 +43,7 @@ class ListItem extends Component {
       );
     }
     return (
-      <TouchableNativeFeedback ref={c => (this._root = c)} {...this.props}>
+      <TouchableNativeFeedback ref={c => (this._root = c)} useForeground {...this.props}>
         <View style={{ marginLeft: -17, paddingLeft: 17 }}>
           <View {...this.props} testID={undefined}>
             {this.props.children}

--- a/src/basic/ListItem.js
+++ b/src/basic/ListItem.js
@@ -43,7 +43,11 @@ class ListItem extends Component {
       );
     }
     return (
-      <TouchableNativeFeedback ref={c => (this._root = c)} useForeground {...this.props}>
+      <TouchableNativeFeedback
+        ref={c => (this._root = c)}
+        useForeground
+        {...this.props}
+      >
         <View style={{ marginLeft: -17, paddingLeft: 17 }}>
           <View {...this.props} testID={undefined}>
             {this.props.children}


### PR DESCRIPTION
The issue this PR addresses is here: https://github.com/GeekyAnts/NativeBase/issues/3028

Currently on the latest version of native-base 2.13.8, `ListItem` component does not show visual feedback of press on Android. It does, however, show visual feedback of press on iOS and web. To clarify, the press is being registered as can be seen by checking `onPress`. It is just the visual feedback not showing anything.

This is fixed by adding the prop `useForeground` for ListItem since it uses react-native's `TouchableNativeFeedback` for android only.

Since ListItem works straight out of the box for iOS and web as intended, it should also do the same for android without having to add that prop every time before using it.

The snack reproducible is in the issue linked above but will link here again. https://snack.expo.io/HyUs_mS0r

It will not work as it is written in the snack above. However, try adding the prop `useForeground` inside `ListItem` and confirm in android it shows visual press feedback.