### PR TITLE
FontSize fix for textHeading in scrollable tabs

### DIFF
--- a/src/basic/Tabs/ScrollableTabBar.js
+++ b/src/basic/Tabs/ScrollableTabBar.js
@@ -274,7 +274,7 @@ const ScrollableTabBar = createReactClass({
                 this.props.textStyle[page],
                 this.props.activeTextStyle[page],
                 this.props.tabHeaderStyle[page],
-                variables.tabFontSize
+                this.props.tabFontSize[page]
               );
             })}
             <Animated.View


### PR DESCRIPTION
The font size that was used previously was directly been taken from a variables files and we are required to have a font size coming directly from the parent, so just made the fix for that.