### PR TITLE
bug fix 2990

### DIFF
--- a/src/basic/Picker.ios.js
+++ b/src/basic/Picker.ios.js
@@ -14,6 +14,7 @@ import mapPropsToStyleNames from '../utils/mapPropsToStyleNames';
 import { Text } from './Text';
 import { Radio } from './Radio';
 import { Container } from './Container';
+import { Content } from './Content';
 import { ListItem } from './ListItem';
 import { Button } from './Button';
 import { Header } from './Header';
@@ -209,6 +210,7 @@ class PickerNB extends Component {
         >
           <Container style={this.props.modalStyle}>
             {this.renderHeader()}
+            <Content>
             <FlatList
               testID={this.props.testID}
               data={this.state.dataSource}
@@ -239,6 +241,7 @@ class PickerNB extends Component {
                 </ListItem>
               )}
             />
+            </Content>
           </Container>
         </Modal>
       </View>


### PR DESCRIPTION
`Picker` will also check `SafeAreaView` now because I have added `content` for `Flatlist` on device rotation.

![Screenshot 2020-03-16 at 1 18 33 PM](https://user-images.githubusercontent.com/15860517/76737575-0c25a780-678f-11ea-9c53-809073536509.png)
