### PR TITLE
bug fix 2904

### DIFF
--- a/src/basic/Button.js
+++ b/src/basic/Button.js
@@ -64,7 +64,8 @@ class Button extends Component {
         : React.Children.map(this.props.children, child =>
             child && child.type === Text
               ? React.cloneElement(child, {
-                uppercase: variables.buttonUppercaseAndroidText,
+                uppercase: this.props.buttonUppercaseAndroidText === false
+                ? false : variables.buttonUppercaseAndroidText,
                 ...child.props
               })
               : child


### PR DESCRIPTION
Hi, `buttonUppercaseAndroidText={false}` will work from now on in `Button`. 

![Screenshot 2020-03-27 at 11 55 51 AM](https://user-images.githubusercontent.com/15860517/77729763-7e1aae00-7025-11ea-97bc-e934e360ea08.png)
