### PR TITLE
fix(): warning uppercase a text component

### DIFF
--- a/src/basic/Text.js
+++ b/src/basic/Text.js
@@ -8,7 +8,7 @@ import mapPropsToStyleNames from '../utils/mapPropsToStyleNames';
 
 class Text extends Component {
   render() {
-    const { uppercase, children } = this.props;
+    const { uppercase, children, ...rest } = this.props;
 
     let text;
     if (uppercase) {
@@ -23,7 +23,7 @@ class Text extends Component {
     }
 
     return (
-      <RNText ref={c => (this._root = c)} {...this.props}>
+      <RNText ref={c => (this._root = c)} {...rest}>
         {text}
       </RNText>
     );


### PR DESCRIPTION
This happens since they are sending invalid properties with this.props

```
Warning: Received `true` for a non-boolean attribute `uppercase`.

If you want to write it to the DOM, pass a string instead: uppercase="true" or uppercase={value.toString()}.
```