### PR TITLE
bug fix 3095

### DIFF
--- a/src/theme/components/Header.js
+++ b/src/theme/components/Header.js
@@ -393,7 +393,7 @@ export default (variables /* : * */ = variable) => {
         : 10,
     paddingRight: 10,
     justifyContent: 'center',
-    paddingTop: platform === PLATFORM.IOS ? 18 : 0,
+    // paddingTop: platform === PLATFORM.IOS ? 18 : 0,
     borderBottomWidth:
       platform === PLATFORM.IOS
         ? 1 / PixelRatio.getPixelSizeForLayoutSize(1)


### PR DESCRIPTION
#3095 fixed. 
paddingTop has been removed from Header for iOS.

Before
![Screenshot 2020-03-31 at 11 50 58 AM](https://user-images.githubusercontent.com/15860517/77994884-6d7d7700-7348-11ea-93b3-53bcb92b0b33.png)

After
![Screenshot 2020-03-31 at 11 50 28 AM](https://user-images.githubusercontent.com/15860517/77994898-73735800-7348-11ea-9d32-147511cb1db7.png)

