### PR TITLE
bug fix 3134

### DIFF
--- a/src/basic/Picker.ios.js
+++ b/src/basic/Picker.ios.js
@@ -222,7 +222,7 @@ class PickerNB extends Component {
                   style={this.props.itemStyle}
                   onPress={() => {
                     this._setModalVisible(false);
-                    this.props.onValueChange(item.props.value);
+                    this.props.onValueChange(item.props.value, item.key);
                     this.setState({ current: item.props.label });
                   }}
                 >


### PR DESCRIPTION
For Android, we are using picker from 'react-native' for picker but for iOS, we are using FlatList. 

**So we need to provide key for selected item in picker for iOS**. 
#3134 
![Screenshot 2020-04-19 at 12 52 25 PM](https://user-images.githubusercontent.com/15860517/79682360-25fb5400-823f-11ea-8866-c4a42c9a7d03.png)
![Screenshot 2020-04-19 at 12 53 48 PM](https://user-images.githubusercontent.com/15860517/79682363-2a277180-823f-11ea-9278-5748915f0b03.png)
![Screenshot 2020-04-19 at 12 54 26 PM](https://user-images.githubusercontent.com/15860517/79682366-2dbaf880-823f-11ea-9900-50b156f05d38.png)
