### PR TITLE
fix: missing value Fontisto added to IconNB's prop types

### DIFF
--- a/src/basic/IconNB.js
+++ b/src/basic/IconNB.js
@@ -103,6 +103,7 @@ IconNB.propTypes = {
     'Feather',
     'FontAwesome',
     'FontAwesome5',
+    'Fontisto',
     'Foundation',
     'Ionicons',
     'MaterialCommunityIcons',


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/18554425/83020885-d8d68300-a031-11ea-9f12-970512893a42.png)

`Fontisto` was not included in the propTypes of the `IconNB`