### PR TITLE
Fixing warning -> Animated: useNativeDriver was not specified.

### DIFF
--- a/src/basic/ToastContainer.js
+++ b/src/basic/ToastContainer.js
@@ -51,7 +51,8 @@ class ToastContainer extends Component {
         if (dx !== 0) {
           Animated.timing(this.state.pan, {
             toValue: { x: dx, y: 0 },
-            duration: 100
+            duration: 100,
+            useNativeDriver: false
           }).start(() => this.closeToast('swipe'));
         }
       }


### PR DESCRIPTION
Added useNativeDriver to animated.timing call in ToastContainer