### PR TITLE
fix(types): add  floatBack for Label

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -648,6 +648,7 @@ declare module "native-base" {
 
 		interface Label extends Testable {
 			style?: RnTextStyleProp;
+			floatBack?: number;
 		}
 		/**
          * see Widget Icon.js


### PR DESCRIPTION
Add missing type declaration `floatBack`  property for `Label`, used by [Item](https://github.com/GeekyAnts/NativeBase/blob/5c190746544293aa9c434c4831771f7e17043317/src/basic/Item.js#L423)