### PR TITLE
Fix <Content> typescript definition & Revert use of forked library

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "license": "Apache-2.0",
   "private": false,
   "dependencies": {
-    "@codler/react-native-keyboard-aware-scroll-view": "1.0.0",
     "blueimp-md5": "^2.5.0",
     "clamp": "^1.0.1",
     "color": "~3.1.2",
@@ -45,6 +44,7 @@
     "prop-types": "^15.5.10",
     "react-native-drawer": "2.5.1",
     "react-native-easy-grid": "0.2.2",
+    "react-native-keyboard-aware-scroll-view": "0.9.2",
     "react-native-vector-icons": "^7.0.0",
     "react-tween-state": "^0.1.5",
     "tween-functions": "^1.0.1"

--- a/src/basic/Content.js
+++ b/src/basic/Content.js
@@ -2,7 +2,7 @@ import { connectStyle } from 'native-base-shoutem-theme';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { SafeAreaView } from 'react-native';
-import { KeyboardAwareScrollView } from '@codler/react-native-keyboard-aware-scroll-view';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 import variable from '../theme/variables/platform';
 import mapPropsToStyleNames from '../utils/mapPropsToStyleNames';


### PR DESCRIPTION
Motivation/error explained in Issue #3209 

This PR switches `native-base` back to the upstream version of [`react-native-keyboard-aware-scroll-view`](https://github.com/APSL/react-native-keyboard-aware-scroll-view) in order to fix typescript errors on the <Content> component.  It was nice of @codler to provide a quick fix for RN 0.63, but since the fix was incompletely implemented, and the [upstream repository has active maintenance](https://github.com/APSL/react-native-keyboard-aware-scroll-view/issues/440#issuecomment-659358713), I think it's appropriate to switch back to the main library.


Thanks for reading!

---

TO DISCUSS:
NativeBase uses a combination of locked, semver-compat ("^version"), and minor-version ("~version") specifications for dependencies. I used a locked version to match the previous style, but perhaps the version of `react-native-keyboard-aware-scroll-view` could be minor-version unlocked? 
It seems that more minor deprecations & changes may be coming (see here: https://github.com/APSL/react-native-keyboard-aware-scroll-view/issues/440), so perhaps unlocking the version could allow consuming apps to receive the minor patches without requiring a NativeBase update.

Let me know what you think.