### PR TITLE
Fix disabled true/false have the same effect on Tab (issue#2833)

### DIFF
--- a/src/basic/Tabs/DefaultTabBar.js
+++ b/src/basic/Tabs/DefaultTabBar.js
@@ -66,7 +66,7 @@ const DefaultTabBar = createReactClass({
       typeof name !== 'string' ? name.props.children : undefined;
     const { activeTextColor, inactiveTextColor } = this.props;
     const fontWeight = isTabActive ? 'bold' : 'normal';
-    const isDisabled = disabled !== undefined;
+    const isDisabled = !!disabled;
     let textColor;
     if (isDisabled) {
       textColor = disabledTextColor;


### PR DESCRIPTION
This PR contains the fix for the issue in `Tab` due to which passing them `disabled={true}` or `disabled={false}` keeps them disabled.

For reference: 
https://github.com/GeekyAnts/NativeBase/issues/2833