### PR TITLE
Fab: don't use TouchableNativeFeedback.Ripple if not Android

### DIFF
--- a/src/basic/Fab.js
+++ b/src/basic/Fab.js
@@ -462,7 +462,7 @@ class Fab extends Component {
     return (
       <Animated.View style={this.getContainerStyle()}>
         {this.renderButtons()}
-        {Platform.OS === PLATFORM.IOS ||
+        {Platform.OS !== PLATFORM.ANDROID ||
         variables.androidRipple === false ||
         Platform.Version <= 21 ? (
           <TouchableOpacity


### PR DESCRIPTION
Fixes web crash due to TouchableNativeFeedback.Ripple being undefined on web.
Fixes #3227