### PR TITLE
fix: android statusbarcolor for transparent header

### DIFF
--- a/src/basic/Header.js
+++ b/src/basic/Header.js
@@ -11,7 +11,7 @@ import variable from '../theme/variables/platform';
 
 class Header extends Component {
   static contextTypes = {
-    theme: PropTypes.object
+    theme: PropTypes.object,
   };
 
   render() {
@@ -20,7 +20,7 @@ class Header extends Component {
       iosBarStyle,
       style,
       transparent,
-      translucent
+      translucent,
     } = this.props;
 
     const variables = this.context.theme
@@ -35,6 +35,8 @@ class Header extends Component {
           backgroundColor={
             androidStatusBarColor
               ? androidStatusBarColor
+              : transparent
+              ? variables.darkenHeader
               : variables.statusBarColor
           }
           barStyle={
@@ -48,10 +50,10 @@ class Header extends Component {
         />
         <SafeAreaView
           style={{
-            backgroundColor: getStyle(style).backgroundColor
+            backgroundColor: getStyle(style).backgroundColor,
           }}
         >
-          <View ref={c => (this._root = c)} {...this.props} />
+          <View ref={(c) => (this._root = c)} {...this.props} />
         </SafeAreaView>
       </View>
     );
@@ -63,10 +65,10 @@ Header.propTypes = {
   style: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.number,
-    PropTypes.array
+    PropTypes.array,
   ]),
   searchBar: PropTypes.bool,
-  rounded: PropTypes.bool
+  rounded: PropTypes.bool,
 };
 
 const StyledHeader = connectStyle(


### PR DESCRIPTION
#3140 
android statusbarcolor for transparent header fixed.
Brefore:
![Screenshot 2020-09-16 at 1 27 14 PM](https://user-images.githubusercontent.com/15860517/93308897-7ee80c00-f820-11ea-97fe-e7fdaabd5cf6.png)

After:
![Screenshot 2020-09-16 at 1 26 59 PM](https://user-images.githubusercontent.com/15860517/93308936-8a3b3780-f820-11ea-9d7c-f6d89eb4f394.png)
