### PR TITLE
Import package name `"react-native-keyboard-aware-scroll-view"` -> `"@codler/react-native-keyboard-aware-scroll-view"`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module "native-base" {
 	import * as React from "react";
 	import * as ReactNative from "react-native";
-	import { KeyboardAwareScrollViewProps } from '@codler/react-native-keyboard-aware-scroll-view';
+	import { KeyboardAwareScrollViewProps } from "@codler/react-native-keyboard-aware-scroll-view";
 
 	type RnViewStyleProp = ReactNative.StyleProp<ReactNative.ViewStyle>;
 	type RnTextStyleProp = ReactNative.StyleProp<ReactNative.TextStyle>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module "native-base" {
 	import * as React from "react";
 	import * as ReactNative from "react-native";
-	import { KeyboardAwareScrollViewProps } from "react-native-keyboard-aware-scroll-view";
+	import { KeyboardAwareScrollViewProps } from '@codler/react-native-keyboard-aware-scroll-view';
 
 	type RnViewStyleProp = ReactNative.StyleProp<ReactNative.ViewStyle>;
 	type RnTextStyleProp = ReactNative.StyleProp<ReactNative.TextStyle>;


### PR DESCRIPTION
Closes #3282 
Import type `KeyboardAwareScrollViewProps` from `"@codler/react-native-keyboard-aware-scroll-view"` rather than `"react-native-keyboard-aware-scroll-view"`