### PR TITLE
Resolving currentlyFocusedField error 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "Apache-2.0",
   "private": false,
   "dependencies": {
-    "@codler/react-native-keyboard-aware-scroll-view": "1.0.0",
+    "@codler/react-native-keyboard-aware-scroll-view": "1.0.1",
     "@react-native-community/datetimepicker": "^3.0.2",
     "@react-native-community/picker": "^1.6.6",
     "blueimp-md5": "^2.5.0",


### PR DESCRIPTION
When the keyboard is open console is throwing out an error `currentlyFocusedField is deprecated and will be removed in a future release. Use currentlyFocusedInput`

Native Base is using 1.0.0 version for `@codler/react-native-keyboard-aware-scroll-view` To resolve this issue it needs to update to the 1.0.1 version.
```
└─┬ native-base@2.13.15
  └── @codler/react-native-keyboard-aware-scroll-view@1.0.0
```