### PR TITLE
Add FontAwesome5 style props on type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -664,6 +664,8 @@ declare module "native-base" {
 			android?: string;
 			color?: string;
 			fontSize?: number;
+			solid?: boolean;
+			light?: boolean;
 		}
 		/**
          * see Widget Icon.js


### PR DESCRIPTION
Vector Icons supports `solid` and `light` props.
It works well, but does not exists on typescript definition. So I added it.

https://github.com/oblador/react-native-vector-icons#multi-style-fonts