### PR TITLE
Fix requestAnimationFrame bug in Tabs

### DIFF
--- a/src/basic/Tabs/index.js
+++ b/src/basic/Tabs/index.js
@@ -277,7 +277,7 @@ const ScrollableTabView = createReactClass({
       return;
     }
     this.setState({ containerWidth: width });
-    this.requestAnimationFrame(() => {
+    this.requestAnimationFrame && this.requestAnimationFrame(() => {
       this.goToPage(this.state.currentPage);
     });
   },


### PR DESCRIPTION
fix for "TypeError: this.requestAnimationFrame is not a function" bug when using Tabs