### PR TITLE
ViewPropTypes error fix in src/basic/Tabs/

### DIFF
--- a/src/basic/Tabs/DefaultTabBar.js
+++ b/src/basic/Tabs/DefaultTabBar.js
@@ -8,7 +8,6 @@ import variable from './../../theme/variables/platform';
 import { TabHeading } from '../TabHeading';
 import { Text } from '../Text';
 import { TabContainer } from '../TabContainer';
-import { ViewPropTypes } from '../../utils';
 const ReactNative = require('react-native');
 
 const { StyleSheet, View, Animated, Platform } = ReactNative;
@@ -23,10 +22,16 @@ const DefaultTabBar = createReactClass({
     activeTextColor: PropTypes.string,
     inactiveTextColor: PropTypes.string,
     disabledTextColor: PropTypes.string,
-    tabStyle: ViewPropTypes.style,
+    tabStyle: PropTypes.shape({
+      style: PropTypes.any,
+    }),
     renderTab: PropTypes.func,
-    underlineStyle: ViewPropTypes.style,
-    tabContainerStyle: ViewPropTypes.style,
+    underlineStyle: PropTypes.shape({
+      style: PropTypes.any,
+    }),
+    tabContainerStyle: PropTypes.shape({
+      style: PropTypes.any,
+    }),
     accessible: PropTypes.array,
     accessibilityLabel: PropTypes.array
   },

--- a/src/basic/Tabs/ScrollableTabBar.js
+++ b/src/basic/Tabs/ScrollableTabBar.js
@@ -8,7 +8,6 @@ import variable from './../../theme/variables/platform';
 import { TabHeading } from '../TabHeading';
 import { Text } from '../Text';
 import { TabContainer } from '../TabContainer';
-import { ViewPropTypes } from '../../utils';
 const Button = require('./Button');
 const ReactNative = require('react-native');
 const {
@@ -31,11 +30,19 @@ const ScrollableTabBar = createReactClass({
     activeTextColor: PropTypes.string,
     inactiveTextColor: PropTypes.string,
     scrollOffset: PropTypes.number,
-    style: ViewPropTypes.style,
-    tabStyle: ViewPropTypes.style,
-    tabsContainerStyle: ViewPropTypes.style,
+    style: PropTypes.shape({
+      style: PropTypes.any,
+    }),
+    tabStyle: PropTypes.shape({
+      style: PropTypes.any,
+    }),
+    tabsContainerStyle: PropTypes.shape({
+      style: PropTypes.any,
+    }),
     renderTab: PropTypes.func,
-    underlineStyle: ViewPropTypes.style,
+    underlineStyle: PropTypes.shape({
+      style: PropTypes.any,
+    }),
     onScroll: PropTypes.func
   },
   contextTypes: {
@@ -204,7 +211,7 @@ const ScrollableTabBar = createReactClass({
         </TabHeading>
       </Button>
     );
-    
+
   },
 
   measureTab(page, event) {

--- a/src/basic/Tabs/index.js
+++ b/src/basic/Tabs/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import _ from 'lodash';
-import { InteractionManager, ViewPropTypes } from '../../utils';
+import { InteractionManager } from '../../utils';
 const React = require('react');
 const { Component } = React;
 const ReactNative = require('react-native');
@@ -36,7 +36,9 @@ const ScrollableTabView = createReactClass({
     onChangeTab: PropTypes.func,
     onScroll: PropTypes.func,
     renderTabBar: PropTypes.any,
-    style: ViewPropTypes.style,
+    style: PropTypes.shape({
+      style: PropTypes.any,
+    }),
     contentProps: PropTypes.object,
     scrollWithoutAnimation: PropTypes.bool,
     locked: PropTypes.bool,


### PR DESCRIPTION
@shivrajkumar this is a new PR based on your comment here: https://github.com/GeekyAnts/NativeBase/pull/3280#issuecomment-751583325

Using **NativeBase** with `react-native-web` latest version crashes the app because `ViewPropTypes` is undefined:

![image](https://user-images.githubusercontent.com/2778383/103424912-cc994200-4b8d-11eb-9af6-98c3f82fc2b6.png)

Related issues:
#3083
#3130
#3231
#3264
