### PR TITLE
Fab: Fix web compatibility

### DIFF
--- a/src/basic/Fab.js
+++ b/src/basic/Fab.js
@@ -464,6 +464,7 @@ class Fab extends Component {
       <Animated.View style={this.getContainerStyle()}>
         {this.renderButtons()}
         {Platform.OS !== PLATFORM.ANDROID ||
+        Platform.OS !== PLATFORM.WEB ||
         variables.androidRipple === false ||
         Platform.Version <= 21 ? (
           <TouchableOpacity


### PR DESCRIPTION
This pull request fixes web compatibility with the Fab component.
Right now, when running on web, the component tries to load in `<TouchableNativeFeedback>`, which will throw an exception on web as it's not available.

Cheers