### PR TITLE
Fix Accordian when expanded is not passed as props

### DIFF
--- a/src/basic/Accordion.js
+++ b/src/basic/Accordion.js
@@ -175,14 +175,16 @@ export class Accordion extends React.Component {
     super(props);
 
     const { expanded, expandMultiple } = this.props;
-    // eslint-disable-next-line no-unused-vars
+
     let selected;
     if (expanded !== undefined && expanded !== null) {
       selected = Array.isArray(expanded) ? expanded : [expanded];
       selected = expandMultiple ? selected : selected.slice(0, 1);
+    } else {
+      selected = [];
     }
     this.state = {
-      selected: props.expanded
+      selected
     };
   }
 


### PR DESCRIPTION
Add default value for selected when expanded is not passed. I don't have time to test this, hence marked as draft, but this is such a minor change I don't expect it to be problematic.

resolves #3364