### PR TITLE
Set default date for value attribute

### DIFF
--- a/src/basic/DatePicker.js
+++ b/src/basic/DatePicker.js
@@ -19,7 +19,7 @@ export class DatePicker extends React.Component {
     };
   }
 
-  setDate(event, selectedDate) {
+  setDate = (event, selectedDate) {
     this.setState({ chosenDate: new Date(selectedDate) });
     if (this.props.onDateChange) {
       this.props.onDateChange(selectedDate);

--- a/src/basic/DatePicker.js
+++ b/src/basic/DatePicker.js
@@ -19,10 +19,10 @@ export class DatePicker extends React.Component {
     };
   }
 
-  setDate(date) {
-    this.setState({ chosenDate: new Date(date) });
+  setDate(event, selectedDate) {
+    this.setState({ chosenDate: new Date(selectedDate) });
     if (this.props.onDateChange) {
-      this.props.onDateChange(date);
+      this.props.onDateChange(selectedDate);
     }
   }
 
@@ -53,7 +53,7 @@ export class DatePicker extends React.Component {
         value={
           this.state.chosenDate ? this.state.chosenDate : this.state.defaultDate
         }
-        onDateChange={date => this.setDate(date)}
+        onChange={this.setDate}
         minimumDate={minimumDate}
         maximumDate={maximumDate}
         mode="date"

--- a/src/basic/DatePicker.js
+++ b/src/basic/DatePicker.js
@@ -50,6 +50,9 @@ export class DatePicker extends React.Component {
         date={
           this.state.chosenDate ? this.state.chosenDate : this.state.defaultDate
         }
+        value={
+          this.state.chosenDate ? this.state.chosenDate : this.state.defaultDate
+        }
         onDateChange={date => this.setDate(date)}
         minimumDate={minimumDate}
         maximumDate={maximumDate}


### PR DESCRIPTION
This small fix fixes [this](https://github.com/GeekyAnts/NativeBase/issues/3381) issue. The problem is that the default date set was only for the `date` attribute which is deprecated. The fix is to add the default date for the `value` attribute too.