### PR TITLE
fix: v3 - isDisabled and modal close button not responding

### DIFF
--- a/src/components/primitives/Button/index.tsx
+++ b/src/components/primitives/Button/index.tsx
@@ -22,7 +22,6 @@ import { default as Box, IBoxProps } from '../Box';
 import Flex from '../Flex';
 import Spinner from '../Spinner';
 import type { IButtonGroupProps, IButtonProps } from './types';
-import { useButton } from '@react-native-aria/button';
 
 const StyledButton = styled(TouchableOpacity)<
   IButtonProps & TouchableOpacityProps
@@ -80,6 +79,7 @@ const Button = (
     'bottom',
     'right',
     'position',
+    'zIndex',
     'minH',
     'minHeight',
     'minWidth',
@@ -130,25 +130,18 @@ const Button = (
     </Box>
   );
 
-  const ariaProps = useButton(
-    {
-      ...accessibilityProps,
-      children,
-    },
-    ref
-  );
   return (
     <StyledButton
       activeOpacity={highlight ? highlight : 0.8}
       ref={ref}
       style={style}
+      accessibilityRole="button"
+      disabled={accessibilityProps.isDisabled}
       opacity={isLoading ? 0.8 : accessibilityProps.isDisabled ? 0.5 : 1}
       {...accessibilityProps}
-      {...ariaProps}
       {...layoutProps}
       {...(Platform.OS === 'web'
         ? {
-            disabled: accessibilityProps.isDisabled,
             cursor: accessibilityProps.isDisabled ? 'not-allowed' : 'auto',
           }
         : {})}


### PR DESCRIPTION
This PR fixes,
1. Modal CloseButton not responding on mouse click events 
- whitelist zIndex prop
2. Removes useButton from rn-aria as currently it's types only support Pressable component and it's not doing much here and made debugging complicated.
3. Fix - isDisabled not working on Buttons
4. Spacebar not registering click event on Button