### PR TITLE
Fix/accessibility modal

### DIFF
--- a/example/storybook/stories/components/composites/Modal/Basic.tsx
+++ b/example/storybook/stories/components/composites/Modal/Basic.tsx
@@ -6,6 +6,7 @@ export default function () {
   return (
     <>
       <Modal
+        accessibilityLabel="this is a simple form"
         isOpen={modalVisible}
         onClose={setModalVisible}
         overlayVisible={true}

--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -119,6 +119,8 @@ const Modal = (
             </ModalContext.Provider>,
             {
               onClose: onClose,
+              isKeyboardDismissable: true,
+              accessibilityViewIsModal: true,
               closeOnPress:
                 newProps.closeOnOverlayClick === false ? false : true,
               backgroundColor: overlayColor ? overlayColor : undefined,

--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -19,6 +19,7 @@ import { Box, View } from '../../primitives';
 import type { IModalProps, IModalSemiProps } from './types';
 import { default as ModalOverlay } from './ModalOverlay';
 import { ModalContext } from './Context';
+import { themeTools } from '../../../theme';
 
 const ModalWeb = ({
   initialFocusRef,
@@ -87,9 +88,15 @@ const Modal = (
     toggleOnClose: onClose ? onClose : () => {},
     contentSize: contentSize,
   };
+
+  // Accessibility label will be added to the overlay wrapper or else VoiceOver announces it twice
+  let [accessibilityProps, restProps] = themeTools.extractInObject(newProps, [
+    'accessibilityLabel',
+  ]);
+
   const modalChildren = (
     <Box
-      {...newProps}
+      {...restProps}
       justifyContent={justifyContent ?? 'center'}
       alignItems={alignItems ?? 'center'}
     >
@@ -119,8 +126,9 @@ const Modal = (
             </ModalContext.Provider>,
             {
               onClose: onClose,
-              isKeyboardDismissable: true,
+              isKeyboardDismissable: props.isKeyboardDismissable ?? true,
               accessibilityViewIsModal: true,
+              accessibilityLabel: accessibilityProps.accessibilityLabel,
               closeOnPress:
                 newProps.closeOnOverlayClick === false ? false : true,
               backgroundColor: overlayColor ? overlayColor : undefined,

--- a/src/components/composites/Modal/ModalCloseButton.tsx
+++ b/src/components/composites/Modal/ModalCloseButton.tsx
@@ -8,8 +8,8 @@ const ModalCloseButton = (props: ICloseButtonProps) => {
   const { toggleVisible, toggleOnClose } = React.useContext(ModalContext);
   return (
     <CloseButton
+      accessibilityLabel="Close dialog"
       {...newProps}
-      // accessibilityLabel="Close dialog"
       onPress={() => {
         toggleVisible(false);
         toggleOnClose(false);

--- a/src/components/composites/Modal/types.ts
+++ b/src/components/composites/Modal/types.ts
@@ -41,6 +41,12 @@ export type IModalSemiProps = ModalProps &
     id?: any;
     motionPreset?: 'slide' | 'fade' | 'none';
     closeOnOverlayClick?: boolean;
+
+    /*
+    Specifies if a modal can be closed by pressing Escape
+    */
+    isKeyboardDismissable?: boolean;
+
     overlayVisible?: boolean;
     overlayColor?: string;
     ref?: React.Ref<any>;

--- a/src/core/Overlay/Wrapper.tsx
+++ b/src/core/Overlay/Wrapper.tsx
@@ -87,10 +87,10 @@ function Wrapper({
     setWindowSize(layoutSize.height);
   };
 
-  const handleClose = () => {
+  const handleClose = React.useCallback(() => {
     setOverlayItem(null);
     overlayConfig.onClose ? overlayConfig.onClose(false) : null;
-  };
+  }, [overlayConfig, setOverlayItem]);
 
   useEffect(() => {
     if (isSlideAnimation) {
@@ -148,7 +148,7 @@ function Wrapper({
         }
       };
     },
-    [overlayConfig, overlayItem]
+    [overlayConfig, overlayItem, handleClose]
   );
 
   const placeOverlayItem = () => {
@@ -175,20 +175,26 @@ function Wrapper({
   };
 
   overlayItem ? fadeIn() : fadeOut();
-  const isOverlayModal = overlayItem && overlayConfig.accessibilityViewIsModal;
+
+  const isOverlayOpen = !!overlayItem;
+  const isModal = isOverlayOpen && overlayConfig.accessibilityViewIsModal;
 
   return (
     <Animated.View
+      accessibilityLabel={
+        isOverlayOpen ? overlayConfig.accessibilityLabel : undefined
+      }
       // iOS
-      accessibilityViewIsModal={isOverlayModal}
+      accessibilityViewIsModal={isModal}
       // Web
-      aria-modal={isOverlayModal}
+      aria-modal={isModal}
+      // To support Z gesture escape on iOS
       onAccessibilityEscape={handleClose}
       // Web. aria-* will be deprecated in future versions
       // @ts-ignore
-      accessibilityModal={isOverlayModal}
+      accessibilityModal={isModal}
       // @ts-ignore
-      accessibilityRole={isOverlayModal ? 'dialog' : undefined}
+      accessibilityRole={isModal ? 'dialog' : undefined}
       style={[overlayStyle.wrapper, { opacity: fadeValue }]}
       pointerEvents={
         overlayItem

--- a/src/core/Overlay/types.ts
+++ b/src/core/Overlay/types.ts
@@ -25,6 +25,8 @@ export type IOverlayConfig = {
   motionPreset?: 'slide' | 'fade' | 'none';
   onClose?: Function;
   closeOnPress?: boolean;
+  isKeyboardDismissable?: boolean;
+  accessibilityViewIsModal?: boolean;
 };
 
 export type IuseOverlayProps = () => {

--- a/src/core/Overlay/types.ts
+++ b/src/core/Overlay/types.ts
@@ -26,6 +26,7 @@ export type IOverlayConfig = {
   onClose?: Function;
   closeOnPress?: boolean;
   isKeyboardDismissable?: boolean;
+  accessibilityLabel?: string;
   accessibilityViewIsModal?: boolean;
 };
 


### PR DESCRIPTION
This PR enhances web accessibility for Modals
1. Added isKeyboardDismissable in overlayConfig. To allow usage of Escape key to close the dialog.
2. Added aria-modal prop to prevent screenreader from reading outside content.
3. Added accessibilityLabel and role="dialog" to Modal

- Tested using VoiceOver
