### PR TITLE
v3 - Toast and snackbar accessibility live region

### DIFF
--- a/example/storybook/stories/components/composites/Snackbar/Hook.tsx
+++ b/example/storybook/stories/components/composites/Snackbar/Hook.tsx
@@ -15,6 +15,7 @@ export default function () {
           setSnackbar(template, {
             accessibilityAnnouncement: 'Well done, we are proud of you.',
             autoHideDuration: 1000,
+            accessibilityLiveRegion: 'assertive',
           })
         }
       >
@@ -25,6 +26,7 @@ export default function () {
           setSnackbar(template, {
             placement: 'top',
             accessibilityAnnouncement: 'Well done, we are proud of you.',
+            accessibilityLiveRegion: 'polite',
           })
         }
       >

--- a/src/components/composites/Snackbar/Snackbar.tsx
+++ b/src/components/composites/Snackbar/Snackbar.tsx
@@ -8,6 +8,7 @@ const Snackbar = (
     children,
     autoHideDuration = 5000,
     accessibilityAnnouncement,
+    accessibilityLiveRegion = 'polite',
     ...props
   }: ISnackbarProps,
   ref: any
@@ -21,12 +22,17 @@ const Snackbar = (
   }, [isOpen, autoHideDuration]);
 
   React.useEffect(() => {
-    if (accessibilityAnnouncement && isOpen && Platform.OS !== 'web') {
+    if (accessibilityAnnouncement && isOpen && Platform.OS === 'ios') {
       AccessibilityInfo.announceForAccessibility(accessibilityAnnouncement);
     }
   }, [accessibilityAnnouncement, isOpen]);
   return (
-    <Slide in={isOpen} {...props} ref={ref}>
+    <Slide
+      in={isOpen}
+      {...props}
+      accessibilityLiveRegion={accessibilityLiveRegion}
+      ref={ref}
+    >
       {children}
     </Slide>
   );

--- a/src/components/composites/Toast/ToastItem.tsx
+++ b/src/components/composites/Toast/ToastItem.tsx
@@ -3,9 +3,22 @@ import Box from '../../primitives/Box';
 import Text from '../../primitives/Text';
 import type { IToastProps } from './types';
 import { useThemeProps } from '../../../hooks';
+import { AccessibilityInfo, Platform } from 'react-native';
 
-const ToastItem = ({ title, offset, ...props }: IToastProps) => {
+const ToastItem = ({
+  title,
+  accessibilityAnnouncement,
+  offset,
+  ...props
+}: IToastProps) => {
   let { _title, ...newProps } = useThemeProps('Toast', props);
+
+  React.useEffect(() => {
+    if (accessibilityAnnouncement && Platform.OS === 'ios') {
+      AccessibilityInfo.announceForAccessibility(accessibilityAnnouncement);
+    }
+  }, [accessibilityAnnouncement]);
+
   return (
     <Box ml={offset?.x} mt={offset?.y} {...newProps}>
       <Text {..._title}>{title}</Text>

--- a/src/components/composites/Toast/hooks.tsx
+++ b/src/components/composites/Toast/hooks.tsx
@@ -10,16 +10,28 @@ export const useToast = () => {
     title,
     duration = 2000,
     position = 'bottom',
+    accessibilityLiveRegion = 'polite',
+    accessibilityAnnouncement,
     offset,
     _title,
   }: IsetToastProps) => {
     setTimeout(() => {
       closeOverlay();
     }, duration);
-    setOverlay(<ToastItem title={title} _title={_title} offset={offset} />, {
-      position,
-      disableOverlay: true,
-    });
+
+    setOverlay(
+      <ToastItem
+        accessibilityLiveRegion={accessibilityLiveRegion}
+        accessibilityAnnouncement={accessibilityAnnouncement}
+        title={title}
+        _title={_title}
+        offset={offset}
+      />,
+      {
+        position,
+        disableOverlay: true,
+      }
+    );
   };
   return setToast;
 };

--- a/src/components/composites/Toast/types.tsx
+++ b/src/components/composites/Toast/types.tsx
@@ -7,4 +7,6 @@ export type IsetToastProps = {
   position?: 'top' | 'bottom' | 'center';
   offset?: { x: number; y: number };
   _title?: ITextProps;
+  accessibilityLiveRegion?: 'none' | 'polite' | 'assertive';
+  accessibilityAnnouncement?: string;
 };


### PR DESCRIPTION
This PR adds accessibilityLiveRegion prop to Toast and Snackbar. [accessibilityLiveregion](https://reactnative.dev/docs/accessibility#accessibilityliveregion-android) works only on Android and Web. 

This isn't mentioned in the doc but [accessibilityAnnouncement](https://reactnative.dev/docs/accessibilityinfo#announceforaccessibility) is iOS only.

So, we can use accessibilityLiveRegion for android+web and accessibilityAnnouncement for iOS.