### PR TITLE
fix: menu clicks and talkback not focusing elements

### DIFF
--- a/src/core/Overlay/Wrapper.tsx
+++ b/src/core/Overlay/Wrapper.tsx
@@ -196,24 +196,20 @@ function Wrapper({
       // @ts-ignore
       accessibilityRole={isModal ? 'dialog' : undefined}
       style={[overlayStyle.wrapper, { opacity: fadeValue }]}
-      pointerEvents={
-        overlayItem
-          ? overlayConfig.disableOverlay
-            ? 'box-none'
-            : 'auto'
-          : 'none'
-      }
+      pointerEvents={'box-none'}
     >
-      <TouchableWithoutFeedback
-        accessibilityLabel="Close Overlay"
-        onPress={() => {
-          if (overlayConfig.closeOnPress) {
-            handleClose();
-          }
-        }}
-      >
-        <View style={overlayStyle.background} />
-      </TouchableWithoutFeedback>
+      {isOverlayOpen && !overlayConfig.disableOverlay && (
+        <TouchableWithoutFeedback
+          accessibilityLabel="Close Overlay"
+          onPress={() => {
+            if (overlayConfig.closeOnPress) {
+              handleClose();
+            }
+          }}
+        >
+          <View style={overlayStyle.background} />
+        </TouchableWithoutFeedback>
+      )}
       {/* Added box-none instead of none to fix Web modal not able to get clicked inside Modal.Body */}
       <View
         pointerEvents="box-none"

--- a/src/core/Popover/Wrapper.tsx
+++ b/src/core/Popover/Wrapper.tsx
@@ -98,16 +98,18 @@ function Wrapper({
   return (
     <Animated.View
       style={[providerStyle.wrapper, { opacity: fadeValue }]}
-      pointerEvents={popoverItem ? 'auto' : 'none'}
+      pointerEvents="box-none"
     >
-      <TouchableWithoutFeedback
-        onPress={() => {
-          setPopoverItem(null);
-          popoverConfig.onClose && popoverConfig.onClose();
-        }}
-      >
-        <View style={providerStyle.wrapper} />
-      </TouchableWithoutFeedback>
+      {popoverItem && (
+        <TouchableWithoutFeedback
+          onPress={() => {
+            setPopoverItem(null);
+            popoverConfig.onClose && popoverConfig.onClose();
+          }}
+        >
+          <View style={providerStyle.wrapper} />
+        </TouchableWithoutFeedback>
+      )}
       <View
         style={{
           position: 'absolute',


### PR DESCRIPTION
This PR fixes
- Components not accessible via Talkback.
- Menu item is not clickable on Android.