### PR TITLE
v3 - Keyboard dismissable in popover and overlay

### DIFF
--- a/src/components/composites/Menu/MenuItem.tsx
+++ b/src/components/composites/Menu/MenuItem.tsx
@@ -21,6 +21,11 @@ export const MenuItem = React.memo(
       <TouchableItem
         {...touchProps}
         style={style}
+        disabled={props.isDisabled}
+        // TouchableHighlight doesn't announce disabled, even if disabled prop is set
+        accessibilityState={{
+          disabled: props.isDisabled,
+        }}
         onPress={(e: any) => {
           if (!props.isDisabled) {
             onPress && onPress(e);

--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -99,6 +99,10 @@ const Modal = (
       {...restProps}
       justifyContent={justifyContent ?? 'center'}
       alignItems={alignItems ?? 'center'}
+      onAccessibilityEscape={() => {
+        value.toggleVisible(false);
+        value.toggleOnClose(false);
+      }}
     >
       {newProps.closeOnOverlayClick === false ? <Box /> : <ModalOverlay />}
       {children}

--- a/src/core/Overlay/Wrapper.tsx
+++ b/src/core/Overlay/Wrapper.tsx
@@ -9,6 +9,7 @@ import {
 import { useFadeTransition } from '../../components/composites/Transitions/useFadeTransition';
 import isEqual from 'lodash/isEqual';
 import type { IOverlayConfig } from './types';
+import { useKeyboardDismissable } from '../../hooks';
 
 type OverlayWrapperType = {
   overlayItem: any;
@@ -127,29 +128,10 @@ function Wrapper({
     setOverlayItemposition,
   ]);
 
-  useEffect(
-    function closeOverlayOnEscapeEffectCallback() {
-      let escapeKeyListener: any = null;
-      if (Platform.OS === 'web') {
-        escapeKeyListener = (e: KeyboardEvent) => {
-          if (
-            e.key === 'Escape' &&
-            overlayConfig.isKeyboardDismissable &&
-            overlayItem
-          ) {
-            handleClose();
-          }
-        };
-        document.addEventListener('keydown', escapeKeyListener);
-      }
-      return () => {
-        if (Platform.OS === 'web') {
-          document.removeEventListener('keydown', escapeKeyListener);
-        }
-      };
-    },
-    [overlayConfig, overlayItem, handleClose]
-  );
+  useKeyboardDismissable({
+    enabled: !!overlayItem && overlayConfig.isKeyboardDismissable,
+    onClose: handleClose,
+  });
 
   const placeOverlayItem = () => {
     if (readyToAnimate && overlayItem) {

--- a/src/core/Overlay/types.ts
+++ b/src/core/Overlay/types.ts
@@ -25,6 +25,10 @@ export type IOverlayConfig = {
   motionPreset?: 'slide' | 'fade' | 'none';
   onClose?: Function;
   closeOnPress?: boolean;
+  /*
+    Determines if a popover can be closed using Escape key on web
+    Default: true
+  */
   isKeyboardDismissable?: boolean;
   accessibilityLabel?: string;
   accessibilityViewIsModal?: boolean;

--- a/src/core/Popover/Wrapper.tsx
+++ b/src/core/Popover/Wrapper.tsx
@@ -8,6 +8,7 @@ import {
 import { getCoordinates } from './../Popover/utils';
 import { useFadeTransition } from '../../components/composites/Transitions/useFadeTransition';
 import isEqual from 'lodash/isEqual';
+import { useKeyboardDismissable } from '../../hooks';
 
 type PopoverWrapperType = {
   popoverItem: any;
@@ -76,6 +77,16 @@ function Wrapper({
     }
   };
 
+  const handleClose = () => {
+    setPopoverItem(null);
+    popoverConfig.onClose && popoverConfig.onClose();
+  };
+
+  useKeyboardDismissable({
+    enabled: !!popoverItem && popoverConfig.isKeyboardDismissable,
+    onClose: handleClose,
+  });
+
   // DOC: Using this to get dimensions of trigger once it has been mounted.
   React.useEffect(() => {
     if (popoverConfig.triggerRef && popoverConfig.triggerRef.current) {
@@ -99,14 +110,10 @@ function Wrapper({
     <Animated.View
       style={[providerStyle.wrapper, { opacity: fadeValue }]}
       pointerEvents="box-none"
+      onAccessibilityEscape={handleClose}
     >
       {popoverItem && (
-        <TouchableWithoutFeedback
-          onPress={() => {
-            setPopoverItem(null);
-            popoverConfig.onClose && popoverConfig.onClose();
-          }}
-        >
+        <TouchableWithoutFeedback onPress={handleClose}>
           <View style={providerStyle.wrapper} />
         </TouchableWithoutFeedback>
       )}

--- a/src/core/Popover/types.ts
+++ b/src/core/Popover/types.ts
@@ -13,6 +13,11 @@ export type IPopoverConfig = {
   placeOverTriggerElement?: boolean;
   animationDuration?: number;
   parentComponentConfig?: any;
+  /*
+  Determines if a popover can be closed using Escape key on web
+  Default: true
+  */
+  isKeyboardDismissable?: boolean;
 };
 
 export type IPopoverProps = ViewProps &

--- a/src/core/hybrid-overlay/HybridProvider.tsx
+++ b/src/core/hybrid-overlay/HybridProvider.tsx
@@ -22,6 +22,7 @@ const HybridProvider = ({
     placeOverTriggerElement: undefined,
     onClose: null,
     animationDuration: 200,
+    isKeyboardDismissable: true,
   });
 
   // Overlay content
@@ -33,6 +34,7 @@ const HybridProvider = ({
     animationDuration: 400,
     closeOnPress: false,
     onClose: (_a: any) => {},
+    isKeyboardDismissable: true,
   });
 
   // Color-mode content

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,3 +10,4 @@ export { useToken } from './useToken';
 export { useSafeArea } from './useSafeArea';
 export { useContrastText } from './useContrastText';
 export { useScreenReaderEnabled } from './useScreenReaderEnabled';
+export { useKeyboardDismissable } from './useKeyboardDismissable';

--- a/src/hooks/useKeyboardDismissable.ts
+++ b/src/hooks/useKeyboardDismissable.ts
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Platform } from 'react-native';
+
+type IParams = {
+  enabled?: boolean;
+  onClose: () => void;
+};
+
+export const useKeyboardDismissable = ({ enabled, onClose }: IParams) => {
+  React.useEffect(
+    function closeOverlayOnEscapeEffectCallback() {
+      let escapeKeyListener: any = null;
+      if (Platform.OS === 'web') {
+        escapeKeyListener = (e: KeyboardEvent) => {
+          if (e.key === 'Escape' && enabled) {
+            onClose();
+          }
+        };
+        document.addEventListener('keydown', escapeKeyListener);
+      }
+      return () => {
+        if (Platform.OS === 'web') {
+          document.removeEventListener('keydown', escapeKeyListener);
+        }
+      };
+    },
+    [enabled, onClose]
+  );
+};


### PR DESCRIPTION
This PR adds 
- keyboard dismissable behavior to Popover and sets default behavior to true for overlays and popovers.
- onAccessibilityEscape action in modal and overlays. This enables escape using Z gesture on iOS.