### PR TITLE
fix: v3 remove pointer events from styled system config

### DIFF
--- a/src/utils/customProps/customExtra.ts
+++ b/src/utils/customProps/customExtra.ts
@@ -7,7 +7,6 @@ const config: Config = {
   appearance: true,
   visibility: true,
   userSelect: true,
-  pointerEvents: true,
   cursor: true,
   resize: true,
   objectFit: true,


### PR DESCRIPTION
This PR removes pointer-events from styled system Props. This was leading to a crash on mobile if pointer-events is passed to Box.