### PR TITLE
fix: v3 Form control accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "@react-native-aria/focus": "^0.2.4",
     "@react-native-aria/interactions": "^0.2.2",
     "@react-native-aria/listbox": "^0.2.4-alpha.0",
+    "@react-native-aria/utils": "^0.2.5",
     "@react-native-aria/radio": "^0.2.2",
     "@react-native-aria/tabs": "^0.2.3",
     "@react-native-picker/picker": "^1.9.11",

--- a/src/components/composites/FormControl/FormControl.tsx
+++ b/src/components/composites/FormControl/FormControl.tsx
@@ -1,32 +1,14 @@
 import React from 'react';
 import Box from '../../primitives/Box';
 import type { IFormControlProps } from './types';
+import { useFormControlProvider, FormControlContext } from './useFormControl';
 
-export const FormControlContext = React.createContext({});
+const FormControl = (props: IFormControlProps, ref: any) => {
+  const { htmlProps, ...context } = useFormControlProvider(props);
 
-const FormControl = (
-  {
-    children,
-    isInvalid,
-    isRequired,
-    isDisabled,
-    isReadOnly,
-    ...props
-  }: IFormControlProps,
-  ref: any
-) => {
   return (
-    <FormControlContext.Provider
-      value={{
-        isInvalid,
-        isRequired,
-        isDisabled,
-        isReadOnly,
-      }}
-    >
-      <Box width="100%" {...props} ref={ref}>
-        {children}
-      </Box>
+    <FormControlContext.Provider value={context}>
+      <Box width="100%" {...htmlProps} ref={ref} />
     </FormControlContext.Provider>
   );
 };

--- a/src/components/composites/FormControl/FormErrorMessage.tsx
+++ b/src/components/composites/FormControl/FormErrorMessage.tsx
@@ -1,24 +1,27 @@
 import React from 'react';
 import Box from '../../primitives/Box';
-import { FormControlContext } from './FormControl';
-import type {
-  IFormControlErrorMessageProps,
-  IFormControlContext,
-} from './types';
+import { useFormControlContext } from './useFormControl';
+import type { IFormControlErrorMessageProps } from './types';
 
 const FormErrorMessage = (
   { children, _disabled, ...props }: IFormControlErrorMessageProps,
   ref: any
 ) => {
-  const { isDisabled, isInvalid }: IFormControlContext = React.useContext(
-    FormControlContext
-  );
+  const formControlContext = useFormControlContext();
 
-  return isInvalid ? (
+  React.useEffect(() => {
+    formControlContext?.setHasFeedbackText(true);
+    return () => {
+      formControlContext?.setHasFeedbackText(false);
+    };
+  });
+
+  return formControlContext?.isInvalid ? (
     <Box
       _text={{ fontSize: 'xs', color: 'red.400' }}
+      nativeID={formControlContext?.helpTextId}
       {...props}
-      {...(isDisabled && _disabled)}
+      {...(formControlContext?.isDisabled && _disabled)}
       ref={ref}
     >
       {children}

--- a/src/components/composites/FormControl/FormHelperText.tsx
+++ b/src/components/composites/FormControl/FormHelperText.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Box from '../../primitives/Box';
 import { useColorModeValue } from '../../../core/color-mode/hooks';
-import { FormControlContext } from './FormControl';
-import type { IFormControlHelperTextProps, IFormControlContext } from './types';
+import { useFormControlContext } from './useFormControl';
+import type { IFormControlHelperTextProps } from './types';
 
 const FormHelperText = (
   {
@@ -14,9 +14,15 @@ const FormHelperText = (
   }: IFormControlHelperTextProps,
   ref: any
 ) => {
-  const { isInvalid, isDisabled }: IFormControlContext = React.useContext(
-    FormControlContext
-  );
+  const formControlContext = useFormControlContext();
+
+  React.useEffect(() => {
+    formControlContext?.setHasHelpText(true);
+    return () => {
+      formControlContext?.setHasHelpText(false);
+    };
+  });
+
   const mutedColor = useColorModeValue('gray.400', 'gray.500');
 
   return (
@@ -25,10 +31,11 @@ const FormHelperText = (
         fontSize: 'xs',
         color: color ?? mutedColor,
       }}
+      nativeID={formControlContext?.feedbackId}
       {...props}
       ref={ref}
-      {...(isInvalid && _invalid)}
-      {...(isDisabled && _disabled)}
+      {...(formControlContext?.isInvalid && _invalid)}
+      {...(formControlContext?.isDisabled && _disabled)}
     >
       {children}
     </Box>

--- a/src/components/composites/FormControl/FormLabel.tsx
+++ b/src/components/composites/FormControl/FormLabel.tsx
@@ -2,33 +2,55 @@ import React from 'react';
 import Box from '../../primitives/Box';
 import Text from '../../primitives/Text';
 import { useToken } from '../../../hooks';
-import { FormControlContext } from './FormControl';
-import type { IFormControlLabelProps, IFormControlContext } from './types';
+import { useFormControlContext } from './useFormControl';
+import type { IFormControlLabelProps } from './types';
+import { mergeRefs } from '../../../utils';
 
 const FormLabel = (
   { children, _disabled, _invalid, ...props }: IFormControlLabelProps,
   ref: any
 ) => {
-  const {
-    isInvalid,
-    isRequired,
-    isDisabled,
-  }: IFormControlContext = React.useContext(FormControlContext);
+  const formControlContext = useFormControlContext();
   const textColor = useToken('colors', 'red.300');
-  const requiredAsterisk = () => <Text color={textColor}>*</Text>;
+  const _ref = React.useRef<HTMLLabelElement>(null);
+  const requiredAsterisk = () => (
+    <Text
+      //@ts-ignore web only role
+      accessibilityRole="presentation"
+      aria-hidden
+      color={textColor}
+    >
+      *
+    </Text>
+  );
+
+  const mergedRef = mergeRefs([_ref, ref]);
+
+  React.useEffect(() => {
+    if (_ref.current) {
+      // RN web doesn't support htmlFor for Label element yet
+      if (props.htmlFor) {
+        _ref.current.htmlFor = props.htmlFor;
+      } else if (formControlContext?.nativeID) {
+        _ref.current.htmlFor = formControlContext.nativeID;
+      }
+    }
+  }, [formControlContext?.nativeID, props.htmlFor]);
 
   return (
     <Box
       flexDirection="row"
       justifyContent="flex-start"
       _text={{ fontSize: 'md' }}
+      accessibilityRole="label"
+      nativeID={formControlContext?.labelId}
       {...props}
-      ref={ref}
-      {...(isInvalid && _invalid)}
-      {...(isDisabled && _disabled)}
+      ref={mergedRef}
+      {...(formControlContext?.isInvalid && _invalid)}
+      {...(formControlContext?.isDisabled && _disabled)}
     >
       {children}
-      {isRequired && requiredAsterisk()}
+      {formControlContext?.isRequired && requiredAsterisk()}
     </Box>
   );
 };

--- a/src/components/composites/FormControl/FormLabel.tsx
+++ b/src/components/composites/FormControl/FormLabel.tsx
@@ -17,7 +17,7 @@ const FormLabel = (
     <Text
       //@ts-ignore web only role
       accessibilityRole="presentation"
-      aria-hidden
+      accessibilityHidden
       color={textColor}
     >
       *

--- a/src/components/composites/FormControl/index.tsx
+++ b/src/components/composites/FormControl/index.tsx
@@ -13,11 +13,17 @@ FormControlTemp.HelperText = FormControlHelperText;
 const FormControl = FormControlTemp as FormControlComponentType;
 
 export { FormControl };
-export { FormControlContext } from './FormControl';
+export {
+  FormControlContext,
+  useFormControl,
+  useFormControlProvider,
+  useFormControlContext,
+  IFormControlContext,
+} from './useFormControl';
+
 export type {
   IFormControlProps,
   IFormControlLabelProps,
   IFormControlErrorMessageProps,
   IFormControlHelperTextProps,
-  IFormControlContext,
 } from './types';

--- a/src/components/composites/FormControl/test/FormControl.test.tsx
+++ b/src/components/composites/FormControl/test/FormControl.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { FormControl, useFormControl } from '../index';
+import { TextInput } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { Wrapper } from '../../../../utils/test-utils';
+
+const Input = React.forwardRef((props: any, ref: any) => {
+  const inputProps = useFormControl(props);
+  return (
+    //@ts-ignore
+    <TextInput ref={ref} {...inputProps} />
+  );
+});
+
+it('passes a11y test in when required', async () => {
+  let { getByPlaceholderText } = render(
+    <Wrapper>
+      <FormControl nativeID="name" isRequired>
+        <FormControl.Label>Name</FormControl.Label>
+        <Input placeholder="Name" />
+        <FormControl.HelperText>Enter your name please!</FormControl.HelperText>
+        <FormControl.ErrorMessage>
+          Your name is invalid
+        </FormControl.ErrorMessage>
+      </FormControl>
+    </Wrapper>
+  );
+  const textInput = getByPlaceholderText('Name');
+  expect(textInput.props.accessibilityRequired).toBe(true);
+  expect(textInput.props.required).toBe(true);
+});
+
+it('passes a11y test in when invalid', async () => {
+  let { getByPlaceholderText } = render(
+    <Wrapper>
+      <FormControl nativeID="name" isInvalid>
+        <FormControl.Label>Name</FormControl.Label>
+        <Input placeholder="Name" />
+        <FormControl.HelperText>Enter your name please!</FormControl.HelperText>
+        <FormControl.ErrorMessage>
+          Your name is invalid
+        </FormControl.ErrorMessage>
+      </FormControl>
+    </Wrapper>
+  );
+  const textInput = getByPlaceholderText('Name');
+  expect(textInput.props.accessibilityInvalid).toBe(true);
+});
+
+it('passes a11y test in when readOnly', async () => {
+  let { getByPlaceholderText } = render(
+    <Wrapper>
+      <FormControl nativeID="name" isReadOnly>
+        <FormControl.Label>Name</FormControl.Label>
+        <Input placeholder="Name" />
+        <FormControl.HelperText>Enter your name please!</FormControl.HelperText>
+        <FormControl.ErrorMessage>
+          Your name is invalid
+        </FormControl.ErrorMessage>
+      </FormControl>
+    </Wrapper>
+  );
+  const textInput = getByPlaceholderText('Name');
+  expect(textInput.props.accessibilityReadOnly).toBe(true);
+  expect(textInput.props.readOnly).toBe(true);
+});
+
+it('passes a11y test in when disabled', async () => {
+  let { getByPlaceholderText } = render(
+    <Wrapper>
+      <FormControl nativeID="name" isDisabled>
+        <FormControl.Label>Name</FormControl.Label>
+        <Input placeholder="Name" />
+        <FormControl.HelperText>Enter your name please!</FormControl.HelperText>
+        <FormControl.ErrorMessage>
+          Your name is invalid
+        </FormControl.ErrorMessage>
+      </FormControl>
+    </Wrapper>
+  );
+  const textInput = getByPlaceholderText('Name');
+  expect(textInput.props.disabled).toBe(true);
+});
+
+it('passes a11y test when helper text is present', async () => {
+  let { getByPlaceholderText } = render(
+    <Wrapper>
+      <FormControl nativeID="name" isDisabled>
+        <FormControl.Label>Name</FormControl.Label>
+        <Input placeholder="Name" />
+        <FormControl.HelperText>Enter your name please!</FormControl.HelperText>
+      </FormControl>
+    </Wrapper>
+  );
+  const textInput = getByPlaceholderText('Name');
+  expect(textInput.props.accessibilityDescribedBy).toBe('name-helptext');
+  expect(textInput.props.accessibilityReadOnly).toBeUndefined();
+  expect(textInput.props.accessibilityInvalid).toBeUndefined();
+  expect(textInput.props.accessibilityRequired).toBeUndefined();
+});

--- a/src/components/composites/FormControl/test/FormControl.test.tsx
+++ b/src/components/composites/FormControl/test/FormControl.test.tsx
@@ -12,7 +12,7 @@ const Input = React.forwardRef((props: any, ref: any) => {
   );
 });
 
-it('passes a11y test in when required', async () => {
+it('a11y test in when required', async () => {
   let { getByPlaceholderText } = render(
     <Wrapper>
       <FormControl nativeID="name" isRequired>
@@ -30,7 +30,7 @@ it('passes a11y test in when required', async () => {
   expect(textInput.props.required).toBe(true);
 });
 
-it('passes a11y test in when invalid', async () => {
+it('a11y test in when invalid', async () => {
   let { getByPlaceholderText } = render(
     <Wrapper>
       <FormControl nativeID="name" isInvalid>
@@ -47,7 +47,7 @@ it('passes a11y test in when invalid', async () => {
   expect(textInput.props.accessibilityInvalid).toBe(true);
 });
 
-it('passes a11y test in when readOnly', async () => {
+it('a11y test in when readOnly', async () => {
   let { getByPlaceholderText } = render(
     <Wrapper>
       <FormControl nativeID="name" isReadOnly>
@@ -65,7 +65,7 @@ it('passes a11y test in when readOnly', async () => {
   expect(textInput.props.readOnly).toBe(true);
 });
 
-it('passes a11y test in when disabled', async () => {
+it('a11y test in when disabled', async () => {
   let { getByPlaceholderText } = render(
     <Wrapper>
       <FormControl nativeID="name" isDisabled>
@@ -82,7 +82,7 @@ it('passes a11y test in when disabled', async () => {
   expect(textInput.props.disabled).toBe(true);
 });
 
-it('passes a11y test when helper text is present', async () => {
+it('a11y test when helper text is present', async () => {
   let { getByPlaceholderText } = render(
     <Wrapper>
       <FormControl nativeID="name" isDisabled>
@@ -97,4 +97,29 @@ it('passes a11y test when helper text is present', async () => {
   expect(textInput.props.accessibilityReadOnly).toBeUndefined();
   expect(textInput.props.accessibilityInvalid).toBeUndefined();
   expect(textInput.props.accessibilityRequired).toBeUndefined();
+});
+
+it('sets htmlFor of FormLabel ref to nativeID of Input', async () => {
+  let ref: HTMLLabelElement;
+  const inputID = 'name';
+  let { getByPlaceholderText } = render(
+    <Wrapper>
+      <FormControl nativeID={inputID} isInvalid>
+        <FormControl.Label
+          //@ts-ignore
+          ref={(_ref) => (ref = _ref)}
+        >
+          Name
+        </FormControl.Label>
+        <Input placeholder="Name" />
+        <FormControl.HelperText>Enter your name please!</FormControl.HelperText>
+        <FormControl.ErrorMessage>
+          Your name is invalid
+        </FormControl.ErrorMessage>
+      </FormControl>
+    </Wrapper>
+  );
+  const textInput = getByPlaceholderText('Name');
+  //@ts-ignore
+  expect(textInput.props.nativeID).toBe(ref.htmlFor);
 });

--- a/src/components/composites/FormControl/types.tsx
+++ b/src/components/composites/FormControl/types.tsx
@@ -1,22 +1,19 @@
 import type { IBoxProps } from '../../primitives';
 
 export type IFormControlProps = IBoxProps & {
+  nativeID?: string;
   isInvalid?: boolean;
   isRequired?: boolean;
   isDisabled?: boolean;
   isReadOnly?: boolean;
 };
-export type IFormControlContext = {
-  isInvalid?: boolean;
-  isRequired?: boolean;
-  isDisabled?: boolean;
-  isReadOnly?: boolean;
-};
+
 export type IFormControlLabelProps = IFormControlProps & {
   style?: any;
   _disabled?: any;
   // _focus?: any;
   _invalid?: any;
+  htmlFor?: string;
 };
 export type IFormControlErrorMessageProps = IFormControlProps & {
   _disabled?: any;

--- a/src/components/composites/FormControl/useFormControl.tsx
+++ b/src/components/composites/FormControl/useFormControl.tsx
@@ -85,14 +85,14 @@ export function useFormControl(props: IFormControlProps) {
 
   return {
     ...cleanProps,
-    'nativeID': props.nativeID ?? field?.nativeID,
-    'disabled': props.isDisabled || field?.isDisabled,
-    'readOnly': props.isReadOnly || field?.isReadOnly,
-    'required': props.isRequired || field?.isRequired,
-    'aria-invalid': ariaAttr(props.isInvalid || field?.isInvalid),
-    'aria-required': ariaAttr(props.isRequired || field?.isRequired),
-    'aria-readonly': ariaAttr(props.isReadOnly || field?.isReadOnly),
-    'aria-describedby': ariaDescribedBy || undefined,
+    nativeID: props.nativeID ?? field?.nativeID,
+    disabled: props.isDisabled || field?.isDisabled,
+    readOnly: props.isReadOnly || field?.isReadOnly,
+    required: props.isRequired || field?.isRequired,
+    accessibilityInvalid: ariaAttr(props.isInvalid || field?.isInvalid),
+    accessibilityRequired: ariaAttr(props.isRequired || field?.isRequired),
+    accessibilityReadOnly: ariaAttr(props.isReadOnly || field?.isReadOnly),
+    accessibilityDescribedBy: ariaDescribedBy || undefined,
   };
 }
 

--- a/src/components/composites/FormControl/useFormControl.tsx
+++ b/src/components/composites/FormControl/useFormControl.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { useId } from '@react-aria/utils';
+import omit from 'lodash/omit';
+import type { IFormControlProps } from './types';
+import { ariaAttr } from '../../../utils';
+
+export type IFormControlContext = Omit<
+  ReturnType<typeof useFormControlProvider>,
+  'htmlProps'
+>;
+
+export const FormControlContext = React.createContext({});
+
+export function useFormControlProvider(props: IFormControlProps) {
+  const {
+    nativeID: idProp,
+    isRequired,
+    isInvalid,
+    isDisabled,
+    isReadOnly,
+    ...htmlProps
+  } = props;
+
+  const id = useId();
+  // Generate all the required ids
+  const nativeID = idProp || `field-${id}`;
+
+  const labelId = `${nativeID}-label`;
+  const feedbackId = `${nativeID}-feedback`;
+  const helpTextId = `${nativeID}-helptext`;
+
+  /**
+   * Track whether the `FormErrorMessage` has been rendered.
+   * We use this to append its id the the `aria-describedby` of the `input`.
+   */
+  const [hasFeedbackText, setHasFeedbackText] = React.useState(false);
+
+  /**
+   * Track whether the `FormHelperText` has been rendered.
+   * We use this to append its id the the `aria-describedby` of the `input`.
+   */
+  const [hasHelpText, setHasHelpText] = React.useState(false);
+
+  const context = {
+    isRequired: !!isRequired,
+    isInvalid: !!isInvalid,
+    isReadOnly: !!isReadOnly,
+    isDisabled: !!isDisabled,
+    hasFeedbackText,
+    setHasFeedbackText,
+    hasHelpText,
+    setHasHelpText,
+    nativeID,
+    labelId,
+    feedbackId,
+    helpTextId,
+    htmlProps,
+  };
+
+  return context;
+}
+
+/**
+ * React hook that provides the props that should be spread on to
+ * input fields (`input`, `select`, `textarea`, etc.).
+ *
+ * It provides a convenient way to control a form fields, validation
+ * and helper text.
+ */
+export function useFormControl(props: IFormControlProps) {
+  const field = useFormControlContext();
+  const describedBy: any[] = [];
+
+  // Error message must be described first in all scenarios.
+  if (field?.hasFeedbackText) describedBy.push(field?.feedbackId);
+  if (field?.hasHelpText) describedBy.push(field?.helpTextId);
+  const ariaDescribedBy = describedBy.join(' ');
+
+  const cleanProps = omit(props, [
+    'isInvalid',
+    'isDisabled',
+    'isReadOnly',
+    'isRequired',
+  ]);
+
+  return {
+    ...cleanProps,
+    'nativeID': props.nativeID ?? field?.nativeID,
+    'disabled': props.isDisabled || field?.isDisabled,
+    'readOnly': props.isReadOnly || field?.isReadOnly,
+    'required': props.isRequired || field?.isRequired,
+    'aria-invalid': ariaAttr(props.isInvalid || field?.isInvalid),
+    'aria-required': ariaAttr(props.isRequired || field?.isRequired),
+    'aria-readonly': ariaAttr(props.isReadOnly || field?.isReadOnly),
+    'aria-describedby': ariaDescribedBy || undefined,
+  };
+}
+
+export const useFormControlContext = () => {
+  return (React.useContext(
+    FormControlContext
+  ) as unknown) as IFormControlContext;
+};

--- a/src/components/composites/FormControl/useFormControl.tsx
+++ b/src/components/composites/FormControl/useFormControl.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useId } from '@react-aria/utils';
+import { useId } from '@react-native-aria/utils';
 import omit from 'lodash/omit';
 import type { IFormControlProps } from './types';
 import { ariaAttr } from '../../../utils';

--- a/src/components/composites/NumberInput/NumberInput.tsx
+++ b/src/components/composites/NumberInput/NumberInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useThemeProps } from '../../../hooks';
-import { FormControlContext, IFormControlContext } from '../FormControl';
+import { useFormControlContext } from '../FormControl';
 import type { INumberInputProps } from './types';
 import { NumberInputContext } from './Context';
 
@@ -14,9 +14,8 @@ const NumberInput = ({ children, ...props }: INumberInputProps) => {
     onChange,
     ...newProps
   } = useThemeProps('NumberInput', props);
-  const formControlContext: IFormControlContext = React.useContext(
-    FormControlContext
-  );
+  const formControlContext = useFormControlContext();
+
   const [numberInputValue, setNumberInputValue] = React.useState(
     parseInt(value || defaultValue, 10)
   );

--- a/src/components/composites/NumberInput/NumberInputStepper.tsx
+++ b/src/components/composites/NumberInput/NumberInputStepper.tsx
@@ -13,7 +13,7 @@ export const NBStepper = ({ children, ...props }: any) => {
     _active,
     _disabled,
     isDisabled,
-    ariaLabel,
+    accessibilityLabel,
     pressHandler,
     iconColor,
     ...newProps
@@ -24,7 +24,7 @@ export const NBStepper = ({ children, ...props }: any) => {
       disabled={disablitityCheck || isDisabled}
       onPress={pressHandler}
       accessible
-      accessibilityLabel={ariaLabel}
+      accessibilityLabel={accessibilityLabel}
     >
       <Box
         {...newProps}

--- a/src/components/composites/PinInput/PinInput.tsx
+++ b/src/components/composites/PinInput/PinInput.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { HStack } from '../../primitives/Stack';
 import { useThemeProps } from '../../../hooks';
 import type { IPinInputProps } from './types';
-import { FormControlContext, IFormControlContext } from '../FormControl';
+import { useFormControlContext } from '../FormControl';
 import { Platform } from 'react-native';
 import { PinInputContext } from './Context';
 import { themeTools } from '../../../theme';
@@ -26,9 +26,8 @@ const PinInput = ({ children, ...props }: IPinInputProps) => {
     onChange,
     ...newProps
   } = useThemeProps('PinInput', remProps);
-  const formControlContext: IFormControlContext = React.useContext(
-    FormControlContext
-  );
+  const formControlContext = useFormControlContext();
+
   const RefList: Array<any> = [];
   const setRefList = (ref: any, index: number) => {
     RefList[index] = ref;

--- a/src/components/primitives/Checkbox/Checkbox.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.tsx
@@ -7,10 +7,7 @@ import {
 import { mergeRefs } from './../../../utils';
 import { useThemeProps } from '../../../hooks';
 import { Center } from '../../composites/Center';
-import {
-  FormControlContext,
-  IFormControlContext,
-} from '../../composites/FormControl';
+import { useFormControlContext } from '../../composites/FormControl';
 import Box from '../Box';
 import Icon from '../Icon';
 import type { ICheckboxProps } from './types';
@@ -22,9 +19,7 @@ import { useCheckbox, useCheckboxGroupItem } from '@react-native-aria/checkbox';
 import { useFocusRing } from '@react-native-aria/focus';
 
 const Checkbox = ({ icon, ...props }: ICheckboxProps, ref: any) => {
-  const formControlContext: IFormControlContext = React.useContext(
-    FormControlContext
-  );
+  const formControlContext = useFormControlContext();
 
   const checkboxGroupContext = React.useContext(CheckboxGroupContext);
   const {

--- a/src/components/primitives/Checkbox/CheckboxGroup.tsx
+++ b/src/components/primitives/Checkbox/CheckboxGroup.tsx
@@ -1,10 +1,7 @@
 import React, { createContext } from 'react';
 import { useCheckboxGroupState } from '@react-stately/checkbox';
 import { useCheckboxGroup } from '@react-native-aria/checkbox';
-import {
-  FormControlContext,
-  IFormControlContext,
-} from '../../composites/FormControl';
+import { useFormControlContext } from '../../composites/FormControl';
 import type { ICheckboxGroupProps, ICheckboxContext } from './types';
 import Box from '../Box';
 
@@ -17,9 +14,7 @@ function CheckboxGroup(
   let { children } = props;
   let state = useCheckboxGroupState(props);
   let { groupProps } = useCheckboxGroup(props, state);
-  const formControlContext: IFormControlContext = React.useContext(
-    FormControlContext
-  );
+  const formControlContext = useFormControlContext();
   return (
     <CheckboxGroupContext.Provider
       value={{

--- a/src/components/primitives/Input/index.tsx
+++ b/src/components/primitives/Input/index.tsx
@@ -165,7 +165,8 @@ const Input = (
   let updatedBorderColor = borderColorFromProps;
   if (isHovered) updatedBorderColor = hoverBorderColor;
   else if (isFocused) updatedBorderColor = focusBorderColor;
-  else if (inputProps['aria-invalid']) updatedBorderColor = errorBorderColor;
+  else if (inputProps.accessibilityInvalid)
+    updatedBorderColor = errorBorderColor;
   const focusStyle = {
     shadow: 3,
     shadowColor: '#2563EB',

--- a/src/components/primitives/Input/index.tsx
+++ b/src/components/primitives/Input/index.tsx
@@ -26,10 +26,7 @@ import { InputRightAddon, InputGroup, InputLeftAddon } from './InputGroup';
 import { useThemeProps, useToken } from '../../../hooks';
 import { themeTools } from '../../../theme';
 import { useHover } from '@react-native-aria/interactions';
-import {
-  useFormControl,
-  useFormControlContext,
-} from '../../composites/FormControl';
+import { useFormControl } from '../../composites/FormControl';
 
 const StyledInput = styled(TextInput)<IInputProps>(
   flex,
@@ -78,8 +75,6 @@ const Input = (
   }: IInputProps,
   ref: any
 ) => {
-  const formControlContext = useFormControlContext();
-
   const inputProps = useFormControl({
     isDisabled: props.isDisabled,
     isInvalid: props.isInvalid,
@@ -113,6 +108,14 @@ const Input = (
   if (typeof placeholderColor !== 'string') {
     placeholderColor = placeholderTextColor;
   }
+
+  const inputThemeProps = {
+    isDisabled: inputProps.disabled,
+    isInvalid: inputProps.accessibilityInvalid,
+    isReadOnly: inputProps.accessibilityReadOnly,
+    isRequired: inputProps.required,
+  };
+
   const {
     borderColor: borderColorFromProps,
     fontSize,
@@ -122,7 +125,7 @@ const Input = (
     hoverBorderColor,
     borderBottomWidth,
     ...newProps
-  } = useThemeProps('Input', { ...formControlContext, ...props });
+  } = useThemeProps('Input', { ...props, ...inputThemeProps });
 
   const computedProps = {
     display: 'flex',
@@ -138,7 +141,6 @@ const Input = (
     'pb',
     'pl',
     'pr',
-    'nativeID',
   ]);
 
   const slideAnim = React.useRef(new Animated.Value(0)).current;
@@ -197,7 +199,7 @@ const Input = (
                 transform: [{ translateY: slideAnim, translateX: 4 }],
               }}
             >
-              <Flex {...newProps} nativeID={undefined} bg="transparent">
+              <Flex {...newProps} bg="transparent">
                 <Box
                   bg="transparent"
                   color={updatedBorderColor}

--- a/src/components/primitives/Input/types.ts
+++ b/src/components/primitives/Input/types.ts
@@ -45,7 +45,6 @@ export type IInputProps = ColorProps &
     isFullWidth?: boolean;
     focusBorderColor?: string;
     errorBorderColor?: string;
-    ariaLabel?: string;
     InputLeftElement?: JSX.Element | JSX.Element[];
     InputRightElement?: JSX.Element | JSX.Element[];
     type?: 'text' | 'password' | string;

--- a/src/components/primitives/Radio/RadioGroup.tsx
+++ b/src/components/primitives/Radio/RadioGroup.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import Box from '../Box';
-import {
-  FormControlContext,
-  IFormControlContext,
-} from '../../composites/FormControl';
+import { useFormControlContext } from '../../composites/FormControl';
 import type { IRadioContext, IRadioGroupProps } from './types';
 import { useRadioGroupState } from '@react-stately/radio';
 import { useRadioGroup } from '@react-native-aria/radio';
@@ -16,9 +13,7 @@ const RadioGroup = (
   { size, colorScheme, ...props }: IRadioGroupProps,
   ref: any
 ) => {
-  const formControlContext: IFormControlContext = React.useContext(
-    FormControlContext
-  );
+  const formControlContext = useFormControlContext();
 
   let state = useRadioGroupState(props);
   let { radioGroupProps } = useRadioGroup(

--- a/src/components/primitives/Select/Select.tsx
+++ b/src/components/primitives/Select/Select.tsx
@@ -28,10 +28,7 @@ import {
 } from '../../../utils/customProps';
 import { Platform } from 'react-native';
 import { useToken } from '../../../hooks/useToken';
-import {
-  FormControlContext,
-  IFormControlContext,
-} from '../../composites/FormControl';
+import { useFormControlContext } from '../../composites/FormControl';
 
 const StyledNativePicker = styled(RNPicker)<ISelectProps>(
   flex,
@@ -62,9 +59,8 @@ const Select = (
   }: ISelectProps,
   ref: any
 ) => {
-  const formControlContext: IFormControlContext = React.useContext(
-    FormControlContext
-  );
+  const formControlContext = useFormControlContext();
+
   const {
     variant,
     _item,

--- a/src/components/primitives/Slider/Slider.tsx
+++ b/src/components/primitives/Slider/Slider.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { PanResponder, Platform } from 'react-native';
-import {
-  FormControlContext,
-  IFormControlContext,
-} from '../../composites/FormControl';
+import { useFormControlContext } from '../../composites/FormControl';
 import Box from '../Box';
 import { useThemeProps } from '../../../hooks';
 import type { ISliderProps } from './types';
@@ -204,9 +201,7 @@ class NBSlider extends React.PureComponent<
 }
 
 const Slider = ({ ...props }: ISliderProps) => {
-  const formControlContext: IFormControlContext = React.useContext(
-    FormControlContext
-  );
+  const formControlContext = useFormControlContext();
   const newProps = useThemeProps('Slider', {
     ...formControlContext,
     ...props,

--- a/src/core/NativeBaseProvider.tsx
+++ b/src/core/NativeBaseProvider.tsx
@@ -8,6 +8,7 @@ import {
   SafeAreaProvider,
   initialWindowMetrics as defaultInitialWindowMetrics,
 } from 'react-native-safe-area-context';
+import { SSRProvider } from '@react-native-aria/utils';
 import { theme as defaultTheme, ITheme } from './../theme';
 import type { IColorModeProviderProps } from './color-mode';
 import HybridProvider from './hybrid-overlay/HybridProvider';
@@ -36,7 +37,7 @@ const NativeBaseProvider = (props: NativeBaseProviderProps) => {
           colorModeManager={colorModeManager}
           options={theme.config}
         >
-          {children}
+          <SSRProvider>{children}</SSRProvider>
         </HybridProvider>
       </SafeAreaProvider>
     </ThemeProvider>

--- a/src/core/Overlay/Wrapper.tsx
+++ b/src/core/Overlay/Wrapper.tsx
@@ -9,7 +9,7 @@ import {
 import { useFadeTransition } from '../../components/composites/Transitions/useFadeTransition';
 import isEqual from 'lodash/isEqual';
 import type { IOverlayConfig } from './types';
-import { useKeyboardDismissable } from '../../hooks';
+import { useKeyboardDismissable } from '../../hooks/useKeyboardDismissable';
 
 type OverlayWrapperType = {
   overlayItem: any;

--- a/src/utils/accessibilityUtils.ts
+++ b/src/utils/accessibilityUtils.ts
@@ -1,0 +1,2 @@
+export const ariaAttr = (condition: boolean | undefined) =>
+  condition ? true : undefined;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,5 +12,5 @@ export {
   canUseDom,
   mergeRefs,
 };
-
 export type { IAccessibilityProps } from './accessibilityTypes';
+export { ariaAttr } from './accessibilityUtils';

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -1,0 +1,15 @@
+import { NativeBaseProvider } from '../core/NativeBaseProvider';
+import * as React from 'react';
+
+export const Wrapper = ({ children }: any) => {
+  return (
+    <NativeBaseProvider
+      initialWindowMetrics={{
+        frame: { x: 0, y: 0, width: 0, height: 0 },
+        insets: { top: 0, left: 0, right: 0, bottom: 0 },
+      }}
+    >
+      {children}
+    </NativeBaseProvider>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2316,6 +2316,11 @@
   resolved "https://registry.yarnpkg.com/@react-native-aria/utils/-/utils-0.2.4.tgz#7b2ad211b648f861085ea98c963d2e8ac97d40dc"
   integrity sha512-dBzPTytIfRVRUSoqT/6J75lTNwCgGv2TdpvwM2pmFQxyj1GiembJI2S8qNGR9RX2R/584JLKLwIDlNXsF+qqXg==
 
+"@react-native-aria/utils@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@react-native-aria/utils/-/utils-0.2.5.tgz#db3979cf96b1ac09f990a0e6977bf1efda567db2"
+  integrity sha512-5YDAQa3j/85i3ZAHs0p4PMIGGSvjyKSLoUNtHAfVcuinvDyxiuirO2fhohOiSH5rGNN41a036yHayMfFh+t6wA==
+
 "@react-native-community/bob@^0.16.2":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@react-native-community/bob/-/bob-0.16.2.tgz#9102b0160e70084fa1b75403a80dec332647c950"


### PR DESCRIPTION
This PR improves FormControl and Input accessibility. Tested on VoiceOver and added testcases for the same.

  - `nativeID` passed to the form control will be passed to the form input directly. 
  - `FormLabel` will have `htmlFor` that points to the `nativeID` of the form input.
  - `FormErrorMessage` adds `aria-describedby` and `aria-invalid` pointing to
    the form input.
  - `FormHelperText` adds `aria-describedby` pointing to
    the form input.
  - `FormHelperText` adds/extends `aria-describedby` pointing to the form input.


