### PR TITLE
fix: v3 tabs not working on prod build

### DIFF
--- a/src/components/composites/Tabs/TabBar.tsx
+++ b/src/components/composites/Tabs/TabBar.tsx
@@ -3,7 +3,7 @@ import Box from '../../primitives/Box';
 import { TabsContext } from './Context';
 import type { ITabsContextProps, ITabBarProps } from './types';
 
-const TabBar = ({ tablistRef, tabListProps, ...props }: ITabBarProps) => {
+const TabBarImpl = ({ tablistRef, tabListProps, ...props }: ITabBarProps) => {
   const {
     tabBarStyle,
     align,
@@ -29,5 +29,8 @@ const TabBar = ({ tablistRef, tabListProps, ...props }: ITabBarProps) => {
     </>
   );
 };
+const TabBar = React.memo(TabBarImpl);
 
-export default React.memo(TabBar);
+TabBar.displayName = 'TabBar';
+
+export default TabBar;

--- a/src/components/composites/Tabs/TabViews.tsx
+++ b/src/components/composites/Tabs/TabViews.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 import Box from '../../primitives/Box';
 import type { ITabViewsProps } from './types';
 
-const TabViews = ({ children, ...props }: ITabViewsProps) => {
+const TabViewsImpl = ({ children, ...props }: ITabViewsProps) => {
   return <Box {...props}>{children}</Box>;
 };
 
-export default React.memo(TabViews);
+const TabViews = React.memo(TabViewsImpl);
+TabViews.displayName = 'TabViews';
+
+export default TabViews;

--- a/src/components/composites/Tabs/Tabs.tsx
+++ b/src/components/composites/Tabs/Tabs.tsx
@@ -18,10 +18,10 @@ const getTabsAndBars = (children: any) => {
 
   items.forEach((item: any) => {
     if (item.type) {
-      if (item.type.type.name === 'TabBar') {
+      if (item.type.displayName === 'TabBar') {
         bars = bars.concat(item.props.children);
         tabBarProps = item.props;
-      } else if (item.type.type.name === 'TabViews') {
+      } else if (item.type.displayName === 'TabViews') {
         views = views.concat(item.props.children);
         tabViewsProps = item.props;
       }
@@ -75,6 +75,7 @@ const Tabs = ({ children, ...props }: ITabsProps, ref: any) => {
         : undefined,
     selectedKey: props.index !== undefined ? props.index.toString() : undefined,
     onSelectionChange: (e: any) => onChange && onChange(parseInt(e)),
+    keyboardActivation: props.keyboardActivation,
   };
 
   // useTabsState needs collection children.

--- a/src/components/composites/Tabs/types.tsx
+++ b/src/components/composites/Tabs/types.tsx
@@ -15,6 +15,7 @@ export type ITabsProps = IBoxProps & {
   size?: 'sm' | 'md' | 'lg';
   variant?: string;
   onChange?: (index: number) => void;
+  keyboardActivation?: 'manual' | 'automatic';
 };
 
 export type ITabBarProps = IBoxProps & {


### PR DESCRIPTION
This PR fixes Tabs not working in Prod build. 
Issue:
We were relying on type.name attribute to generate collection components for React Stately which doesn't work on prod build due to minification. 

Solution:
This PR adds displayName property to fix it.

This PR also adds keyboardActivation prop, which is used very commonly, we were already supporting it, just the prop was not being passed.
