### PR TITLE
Add `number` type to Spinner.size

### DIFF
--- a/src/components/primitives/Spinner/types.tsx
+++ b/src/components/primitives/Spinner/types.tsx
@@ -16,7 +16,7 @@ export type ISpinnerProps = ColorProps &
   customPositionProps &
   PositionProps & {
     style?: any | undefined;
-    size?: 'sm' | 'lg' | 'small' | 'large';
+    size?: 'sm' | 'lg' | 'small' | 'large' | number;
     accessibilityLabel?: string;
     // variant?:
     //   | 'custom'


### PR DESCRIPTION
Providing a number to `size` is supported. It can be used for specifying custom spinner sizes.