### PR TITLE
Update peer deps to make compatible with RN 0.63

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,9 +84,9 @@
     "visualize-bundle": "^1.4.0"
   },
   "peerDependencies": {
-    "react": "16.11.0",
+    "react": "^16.11.0",
     "react-dom": "*",
-    "react-native": "0.62.2",
+    "react-native": "0.62.2 || 0.63.2",
     "react-native-safe-area-context": "^3.1.9",
     "react-native-svg": "^12.1.0",
     "styled-components": "^5.2.1",


### PR DESCRIPTION
Without this change, `npm audit --fix` will not work in projects that use NB v3 and RN 0.63.x, introducing possible security vulnerabilities.