### PR TITLE
v3 fix for Actionsheet Animated.event()

### DIFF
--- a/src/components/composites/Actionsheet/Actionsheet.tsx
+++ b/src/components/composites/Actionsheet/Actionsheet.tsx
@@ -32,7 +32,7 @@ const Actionsheet = ({ children, ...props }: IActionsheetProps, ref: any) => {
       },
       onPanResponderMove: (e, gestureState) => {
         if (gestureState.dy > 0) {
-          Animated.event([null, { dy: pan.y }])(e, gestureState);
+          Animated.event([null, { dy: pan.y }], {useNativeDriver: false})(e, gestureState);
         }
       },
       onPanResponderRelease: (_e, gestureState) => {


### PR DESCRIPTION
Hi,

I discovered while using latest native-base v3 that when you trigger the animation for the Actionsheet component, the logs on Metro spam you with "Animated.event now requires a second argument for options". I believe that this PR should fix this. I couldn't test this though since the examples folder refused to work on my machine. I found this while using the Select component which makes use of the Actionsheet component.