### PR TITLE
Android accessibility fix and disabled style in button

### DIFF
--- a/example/storybook/stories/components/composites/Menu/Basic.tsx
+++ b/example/storybook/stories/components/composites/Menu/Basic.tsx
@@ -7,13 +7,13 @@ export function Example() {
     <Menu
       trigger={(triggerProps) => {
         return (
-          <Pressable {...triggerProps}>
+          <Pressable accessibilityLabel="More options menu" {...triggerProps}>
             <HamburgerIcon />
           </Pressable>
         );
       }}
     >
-      <Menu.Item>Aria</Menu.Item>
+      <Menu.Item>Arial</Menu.Item>
       <Menu.Item>Nunito Sans</Menu.Item>
       <Menu.Item isDisabled>Tahoma</Menu.Item>
       <Divider />

--- a/src/components/composites/Backdrop/index.tsx
+++ b/src/components/composites/Backdrop/index.tsx
@@ -10,6 +10,7 @@ const Backdrop = (props: IPressableProps) => {
       left={0}
       right={0}
       accessible={false}
+      importantForAccessibility="no"
       bg={props.bg || 'rgba(0, 0, 0, 0.3)'}
       {...props}
     ></Pressable>

--- a/src/components/composites/Menu/Menu.tsx
+++ b/src/components/composites/Menu/Menu.tsx
@@ -3,14 +3,14 @@ import type { IMenuProps } from './types';
 import Box from '../../primitives/Box';
 import { usePropsResolution } from '../../../hooks/useThemeProps';
 import { Popper } from '../Popper';
-import { ScrollView } from 'react-native';
-import { useControllableState, useKeyboardDismissable } from '../../../hooks';
+import { AccessibilityInfo, ScrollView } from 'react-native';
+import { useControllableState } from '../../../hooks';
 import { useMenuTrigger, useMenu, useMenuTypeahead } from './useMenu';
 import Backdrop from '../Backdrop';
-import { OverlayContainer } from '@react-native-aria/overlays';
 import { PresenceTransition } from '../Transitions';
 import { FocusScope } from '@react-native-aria/focus';
 import { MenuContext } from './MenuContext';
+import { Overlay } from '../../primitives/Overlay';
 
 const Menu = (
   {
@@ -60,15 +60,16 @@ const Menu = (
     );
   };
 
-  useKeyboardDismissable({
-    enabled: isOpen,
-    callback: handleClose,
-  });
+  React.useEffect(() => {
+    if (isOpen) {
+      AccessibilityInfo.announceForAccessibility('Popup window');
+    }
+  }, [isOpen]);
 
   return (
     <>
       {updatedTrigger()}
-      <OverlayContainer>
+      <Overlay isOpen={isOpen} onRequestClose={handleClose} useRNModalOnAndroid>
         <PresenceTransition visible={isOpen} {...transition}>
           <Popper
             triggerRef={triggerRef}
@@ -90,7 +91,7 @@ const Menu = (
             </Popper.Content>
           </Popper>
         </PresenceTransition>
-      </OverlayContainer>
+      </Overlay>
     </>
   );
 };

--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -1,19 +1,15 @@
 import React, { forwardRef, memo } from 'react';
-import { OverlayContainer } from '@react-native-aria/overlays';
 import { StyleSheet } from 'react-native';
 import Backdrop from '../Backdrop';
 import { Slide } from '../Transitions';
 import { FocusScope } from '@react-native-aria/focus';
-import {
-  useControllableState,
-  usePropsResolution,
-  useKeyboardDismissable,
-} from '../../../hooks';
+import { useControllableState, usePropsResolution } from '../../../hooks';
 import { ModalContext } from './Context';
 import Box from '../../primitives/Box';
 import type { IModalProps } from './types';
 import { Fade } from '../../composites/Transitions';
 import { useKeyboardBottomInset } from '../../../utils';
+import { Overlay } from '../../primitives/Overlay';
 
 const Modal = (
   {
@@ -44,10 +40,7 @@ const Modal = (
     },
   });
 
-  useKeyboardDismissable({
-    enabled: isKeyboardDismissable && visible,
-    callback: () => setVisible(false),
-  });
+  const handleClose = () => setVisible(false);
 
   let child = (
     <Box
@@ -61,10 +54,15 @@ const Modal = (
   );
 
   return (
-    <OverlayContainer>
+    <Overlay
+      isOpen={visible}
+      onRequestClose={handleClose}
+      isKeyboardDismissable={isKeyboardDismissable}
+      useRNModalOnAndroid
+    >
       <ModalContext.Provider
         value={{
-          handleClose: () => setVisible(false),
+          handleClose,
           contentSize,
           initialFocusRef,
           finalFocusRef,
@@ -79,7 +77,7 @@ const Modal = (
           {overlayVisible && (
             <Backdrop
               onPress={() => {
-                closeOnOverlayClick && setVisible(false);
+                closeOnOverlayClick && handleClose();
               }}
             />
           )}
@@ -111,7 +109,7 @@ const Modal = (
           </Fade>
         )}
       </ModalContext.Provider>
-    </OverlayContainer>
+    </Overlay>
   );
 };
 

--- a/src/components/composites/Popover/Popover.tsx
+++ b/src/components/composites/Popover/Popover.tsx
@@ -5,12 +5,12 @@ import { mergeRefs } from '../../../utils';
 import { useControllableState } from '../../../hooks';
 import { PopoverContext } from './PopoverContext';
 import Box from '../../primitives/Box';
-import { OverlayContainer } from '@react-native-aria/overlays';
 import Backdrop from '../Backdrop';
 import { FocusScope } from '@react-native-aria/focus';
 import { PresenceTransition } from '../Transitions';
 import { StyleSheet } from 'react-native';
 import { useId } from '@react-aria/utils';
+import { Overlay } from '../../primitives/Overlay';
 
 const Popover = (
   {
@@ -68,7 +68,7 @@ const Popover = (
   return (
     <Box ref={ref}>
       {updatedTrigger()}
-      <OverlayContainer>
+      <Overlay isOpen={isOpen} onRequestClose={handleClose} useRNModalOnAndroid>
         <PresenceTransition
           initial={{ opacity: 0 }}
           animate={{ opacity: 1, transition: { duration: 150 } }}
@@ -98,7 +98,7 @@ const Popover = (
             </PopoverContext.Provider>
           </Popper>
         </PresenceTransition>
-      </OverlayContainer>
+      </Overlay>
     </Box>
   );
 };

--- a/src/components/composites/Popper/Popper.tsx
+++ b/src/components/composites/Popper/Popper.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useOverlayPosition } from '@react-native-aria/overlays';
-import { Platform, StyleSheet, View, ViewStyle } from 'react-native';
+import { StyleSheet, View, ViewStyle } from 'react-native';
 import type {
   IPopperProps,
   IScrollContentStyle,
@@ -9,7 +9,7 @@ import type {
 } from './types';
 import { createContext } from '../../../utils';
 import Box, { IBoxProps } from '../../primitives/Box';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+// import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const defaultArrowHeight = 15;
 const defaultArrowWidth = 15;
@@ -51,7 +51,7 @@ const PopperContent = React.forwardRef(
       setOverlayRef,
     } = usePopperContext('PopperContent');
     const overlayRef = React.useRef(null);
-    const { top } = useSafeAreaInsets();
+    // const { top } = useSafeAreaInsets();
     const {
       overlayProps,
       rendered,
@@ -131,12 +131,12 @@ const PopperContent = React.forwardRef(
           overlay: {
             ...overlayProps.style,
             // To handle translucent android StatusBar
-            marginTop: Platform.select({ android: top, default: 0 }),
+            // marginTop: Platform.select({ android: top, default: 0 }),
             opacity: rendered ? 1 : 0,
             position: 'absolute',
           },
         }),
-      [rendered, overlayProps.style, top]
+      [rendered, overlayProps.style]
     );
 
     return (

--- a/src/components/composites/Transitions/PresenceTransition.tsx
+++ b/src/components/composites/Transitions/PresenceTransition.tsx
@@ -1,4 +1,5 @@
 import React, { memo, forwardRef } from 'react';
+import { ExitAnimationContext } from '../../primitives/Overlay/ExitAnimationContext';
 import { Transition } from './Transition';
 import type { IPresenceTransitionProps } from './types';
 
@@ -7,6 +8,9 @@ const PresenceTransition = (
   ref: any
 ) => {
   const [animationExited, setAnimationExited] = React.useState(true);
+
+  const { setExited } = React.useContext(ExitAnimationContext);
+
   if (!visible && animationExited) {
     return null;
   }
@@ -17,8 +21,10 @@ const PresenceTransition = (
       onTransitionComplete={(state) => {
         if (state === 'exited') {
           setAnimationExited(true);
+          setExited(true);
         } else {
           setAnimationExited(false);
+          setExited(false);
         }
         onTransitionComplete && onTransitionComplete(state);
       }}

--- a/src/components/composites/Transitions/PresenceTransition.tsx
+++ b/src/components/composites/Transitions/PresenceTransition.tsx
@@ -7,7 +7,7 @@ const PresenceTransition = (
   { visible = false, onTransitionComplete, ...rest }: IPresenceTransitionProps,
   ref: any
 ) => {
-  const [animationExited, setAnimationExited] = React.useState(true);
+  const [animationExited, setAnimationExited] = React.useState(!visible);
 
   const { setExited } = React.useContext(ExitAnimationContext);
 

--- a/src/components/composites/Transitions/Transition.tsx
+++ b/src/components/composites/Transitions/Transition.tsx
@@ -111,7 +111,6 @@ export const Transition = forwardRef(
             }),
           ]).start(() => {
             setAnimationState('entered');
-            onTransitionComplete && onTransitionComplete('entered');
           });
         }
       },
@@ -144,7 +143,6 @@ export const Transition = forwardRef(
             }),
           ]).start(() => {
             setAnimationState('exited');
-            onTransitionComplete && onTransitionComplete('exited');
           });
         }
       },
@@ -174,6 +172,14 @@ export const Transition = forwardRef(
         style,
       ];
     }, [animateValue, initial, animate, style]);
+
+    React.useEffect(() => {
+      if (animationState === 'exited') {
+        onTransitionComplete && onTransitionComplete('exited');
+      } else if (animationState === 'entered') {
+        onTransitionComplete && onTransitionComplete('entered');
+      }
+    }, [animationState, onTransitionComplete]);
 
     return (
       <Component

--- a/src/components/primitives/Button/Button.tsx
+++ b/src/components/primitives/Button/Button.tsx
@@ -68,7 +68,6 @@ const Button = (
       ref={ref}
       {...pressableProps}
       accessibilityRole={props.accessibilityRole ?? 'button'}
-      opacity={isDisabled || isLoading ? 0.5 : undefined}
     >
       {/* TODO : Replace Render props with Context Hook */}
       {({ isPressed, isHovered, isFocusVisible }: any) => {

--- a/src/components/primitives/Button/types.ts
+++ b/src/components/primitives/Button/types.ts
@@ -54,6 +54,11 @@ export interface IButtonProps extends IPressableProps {
    * Props to be passed to the HStack used inside of Button.
    */
   _stack?: IStackProps;
+
+  /**
+   * Props to be passed to the Button when state is disabled.
+   */
+  _disabled?: IButtonProps;
 }
 
 export interface IButtonGroupProps extends IStackProps {

--- a/src/components/primitives/Overlay/ExitAnimationContext.ts
+++ b/src/components/primitives/Overlay/ExitAnimationContext.ts
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export const ExitAnimationContext = React.createContext({
+  exited: true,
+  setExited: (_exited: boolean) => {},
+});

--- a/src/components/primitives/Overlay/Overlay.tsx
+++ b/src/components/primitives/Overlay/Overlay.tsx
@@ -1,0 +1,54 @@
+import { OverlayContainer } from '@react-native-aria/overlays';
+import React from 'react';
+import { Platform } from 'react-native';
+import { Modal } from 'react-native';
+import { useKeyboardDismissable } from '../../../hooks';
+import { ExitAnimationContext } from './ExitAnimationContext';
+
+interface IOverlayProps {
+  isOpen?: boolean;
+  children?: any;
+  // We use RN modal on android if needed as it supports shifting accessiblity focus to the opened view. IOS automatically shifts focus if an absolutely placed view appears in front.
+  useRNModalOnAndroid?: boolean;
+  onRequestClose?: any;
+  isKeyboardDismissable?: boolean;
+}
+
+export function Overlay({
+  children,
+  isOpen,
+  useRNModalOnAndroid = false,
+  isKeyboardDismissable = true,
+  onRequestClose,
+}: IOverlayProps) {
+  const [exited, setExited] = React.useState(!isOpen);
+
+  useKeyboardDismissable({
+    enabled: isOpen && isKeyboardDismissable,
+    callback: onRequestClose,
+  });
+
+  if (exited && !isOpen) {
+    return null;
+  }
+
+  // Android handles multiple Modal in RN and is better for accessibility as it shifts accessibility focus on mount, however it may not needed in case of tooltips, toast where one doesn't need to shift accessibility focus
+  if (Platform.OS === 'android' && useRNModalOnAndroid) {
+    return (
+      <ExitAnimationContext.Provider value={{ exited, setExited }}>
+        <Modal transparent visible={true} onRequestClose={onRequestClose}>
+          {children}
+        </Modal>
+      </ExitAnimationContext.Provider>
+    );
+  }
+
+  // Since OverlayContainer mounts children in NativeBaseProvider  using Context, we need to pass the context by wrapping children
+  return (
+    <OverlayContainer>
+      <ExitAnimationContext.Provider value={{ exited, setExited }}>
+        {children}
+      </ExitAnimationContext.Provider>
+    </OverlayContainer>
+  );
+}

--- a/src/components/primitives/Overlay/index.ts
+++ b/src/components/primitives/Overlay/index.ts
@@ -1,0 +1,1 @@
+export * from './Overlay';

--- a/src/components/primitives/Pressable/Pressable.tsx
+++ b/src/components/primitives/Pressable/Pressable.tsx
@@ -86,6 +86,7 @@ const Pressable = (
     _pressed,
     _focus,
     _focusVisible,
+    _disabled,
     ...themeProps
   } = usePropsResolution('Pressable', props);
   const { isFocusVisible, focusProps: focusRingProps }: any = useFocusRing();
@@ -114,6 +115,7 @@ const Pressable = (
       {...(isFocused && _focus)}
       {...(isFocusVisible && _focusVisible)}
       {...(isPressed && _pressed)}
+      {...(props.disabled && _disabled)}
     >
       {typeof children !== 'function'
         ? children

--- a/src/components/primitives/Pressable/types.ts
+++ b/src/components/primitives/Pressable/types.ts
@@ -59,6 +59,11 @@ export interface IPressableProps
   _focus?: IPressableProps;
 
   /**
+   * Style props to be applied when disabled
+   */
+  _disabled?: IPressableProps;
+
+  /**
    * Style props to be applied when focus visible. These styles will be only applied when user is interacting the app using a keyboard. (Web only)
    */
   _focusVisible?: IPressableProps;

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -31,6 +31,9 @@ const baseStyle = (props: any) => {
       space: 2,
       alignItems: 'center',
     },
+    _disabled: {
+      opacity: 0.5,
+    },
   };
 };
 


### PR DESCRIPTION
## Fixes
On talkback, the accessibility focus should shift to the first element when opened
https://user-images.githubusercontent.com/23293248/123375758-f5334f00-d5a6-11eb-997c-10534de92c07.mp4


## Features
- Add _disable style prop in button
- Added a single Overlay Component which will handle back button behavior and accessibility on Android.
- This Overlay component can be used for Modal, Menu, Popover or Drawer (in future)
- Fix backdrop stays mounted when clicked multiple times before the entry animation is completed.
