### PR TITLE
fix: select scroll and actionsheet flicker on swipe

### DIFF
--- a/example/storybook/stories/components/primitives/Select/SelectLongList.tsx
+++ b/example/storybook/stories/components/primitives/Select/SelectLongList.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import {
+  FormControl,
+  Select,
+  HStack,
+  Text,
+  Container,
+  CheckIcon,
+} from 'native-base';
+
+export const Example = () => {
+  const [value, setValue] = React.useState('1');
+  return (
+    <Container>
+      <FormControl>
+        <FormControl.Label>Select Item</FormControl.Label>
+        <Select
+          selectedValue={value}
+          minWidth={200}
+          accessibilityLabel="Select an option"
+          placeholder="Select an option"
+          onValueChange={(itemValue) => {
+            setValue(itemValue);
+          }}
+          _selectedItem={{
+            bg: 'teal.600',
+            endIcon: <CheckIcon size={5} />,
+          }}
+          mt={1}
+        >
+          <Select.Item label="Option 1" value="1" />
+          <Select.Item label="Option 2" value="2" />
+          <Select.Item label="Option 3" value="3" />
+          <Select.Item label="Option 4" value="4" />
+          <Select.Item label="Option 5" value="5" />
+          <Select.Item label="Option 6" value="6" />
+          <Select.Item label="Option 7" value="7" />
+          <Select.Item label="Option 8" value="8" />
+          <Select.Item label="Option 9" value="9" />
+          <Select.Item label="Option 10" value="10" />
+          <Select.Item label="Option 11" value="11" />
+          <Select.Item label="Option 12" value="12" />
+          <Select.Item label="Option 13" value="13" />
+          <Select.Item label="Option 14" value="14" />
+          <Select.Item label="Option 15" value="15" />
+          <Select.Item label="Option 16" value="16" />
+          <Select.Item label="Option 17" value="17" />
+          <Select.Item label="Option 18" value="18" />
+          <Select.Item label="Option 19" value="19" />
+          <Select.Item label="Option 20" value="20" />
+          <Select.Item label="Option 21" value="21" />
+        </Select>
+      </FormControl>
+
+      <HStack mt={3} alignItems="baseline">
+        <Text fontSize="md">Selected Values: </Text>
+        <Text fontSize="md" bold>
+          {value}
+        </Text>
+      </HStack>
+    </Container>
+  );
+};

--- a/example/storybook/stories/components/primitives/Select/index.tsx
+++ b/example/storybook/stories/components/primitives/Select/index.tsx
@@ -3,10 +3,12 @@ import { storiesOf } from '@storybook/react-native';
 import { withKnobs } from '@storybook/addon-knobs';
 import { Example as Basic } from './Basic';
 import { Example as FormControlled } from './FormControlled';
+import { Example as SelectLongList } from './SelectLongList';
 import Wrapper from './../../Wrapper';
 
 storiesOf('Select', module)
   .addDecorator(withKnobs)
   .addDecorator((getStory: any) => <Wrapper>{getStory()}</Wrapper>)
   .add('Basic', () => <Basic />)
-  .add('FormControlled', () => <FormControlled />);
+  .add('FormControlled', () => <FormControlled />)
+  .add('Select Long list', () => <SelectLongList />);

--- a/src/components/composites/Actionsheet/Actionsheet.tsx
+++ b/src/components/composites/Actionsheet/Actionsheet.tsx
@@ -2,61 +2,12 @@ import React, { memo, forwardRef } from 'react';
 import { Modal } from '../../composites/Modal';
 import type { IActionsheetProps } from './types';
 import { usePropsResolution } from '../../../hooks';
-import { Animated, PanResponder } from 'react-native';
 
 const Actionsheet = ({ children, ...props }: IActionsheetProps, ref: any) => {
   const { isOpen, disableOverlay, onClose, ...newProps } = usePropsResolution(
     'Actionsheet',
     props
   );
-  let pan = React.useRef(new Animated.ValueXY()).current;
-  let sheetHeight = React.useRef(0);
-
-  React.useEffect(() => {
-    if (!isOpen) {
-      // Reset value when modal close animation is completed
-      setTimeout(() => {
-        pan.setValue({
-          x: 0,
-          y: 0,
-        });
-      }, 250);
-    }
-  }, [isOpen, pan]);
-
-  const panResponder = React.useRef(
-    PanResponder.create({
-      onMoveShouldSetPanResponder: (_evt, gestureState) => {
-        // return true if user is swiping, return false if it's a single click
-        return gestureState.dx !== 0 || gestureState.dy !== 0;
-      },
-      onPanResponderMove: (e, gestureState) => {
-        if (gestureState.dy > 0) {
-          Animated.event([null, { dy: pan.y }], {
-            useNativeDriver: false,
-          })(e, gestureState);
-        }
-      },
-      onPanResponderRelease: (_e, gestureState) => {
-        // If sheet is dragged 1/4th of it's height, close it
-        if (sheetHeight.current / 4 - gestureState.dy < 0) {
-          Animated.timing(pan, {
-            toValue: { x: 0, y: sheetHeight.current },
-            duration: 150,
-            useNativeDriver: true,
-          }).start(() => {
-            onClose();
-          });
-        } else {
-          Animated.spring(pan, {
-            toValue: { x: 0, y: 0 },
-            overshootClamping: true,
-            useNativeDriver: true,
-          }).start();
-        }
-      },
-    })
-  ).current;
 
   return (
     <Modal
@@ -70,19 +21,7 @@ const Actionsheet = ({ children, ...props }: IActionsheetProps, ref: any) => {
       closeOnOverlayClick={disableOverlay ? false : true}
       ref={ref}
     >
-      <Animated.View
-        style={{
-          transform: [{ translateY: pan.y }],
-          width: '100%',
-        }}
-        onLayout={(event) => {
-          const { height } = event.nativeEvent.layout;
-          sheetHeight.current = height;
-        }}
-        {...panResponder.panHandlers}
-      >
-        {children}
-      </Animated.View>
+      {children}
     </Modal>
   );
 };

--- a/src/components/composites/Actionsheet/ActionsheetContent.tsx
+++ b/src/components/composites/Actionsheet/ActionsheetContent.tsx
@@ -51,17 +51,24 @@ const ActionsheetContent = (
       style={{
         transform: [{ translateY: pan.y }],
         width: '100%',
-        paddingTop: 40,
       }}
       onLayout={(event) => {
         const { height } = event.nativeEvent.layout;
         sheetHeight.current = height;
       }}
-      {...panResponder.panHandlers}
     >
+      {/* To increase the draggable area */}
+      <Box py={5} {...panResponder.panHandlers} />
+
       <Modal.Content {...newProps} ref={ref}>
         {/* Hack. Fix later. Add -2 negative margin to remove the padding added by ActionSheetContent */}
-        <Box py={5} mt={-2}>
+        <Box
+          py={5}
+          mt={-2}
+          {...panResponder.panHandlers}
+          width="100%"
+          alignItems="center"
+        >
           <Box bg="coolGray.400" height={1} width={9} borderRadius={2} />
         </Box>
         {children}

--- a/src/components/composites/Actionsheet/ActionsheetContent.tsx
+++ b/src/components/composites/Actionsheet/ActionsheetContent.tsx
@@ -60,6 +60,7 @@ const ActionsheetContent = (
       {...panResponder.panHandlers}
     >
       <Modal.Content {...newProps} ref={ref}>
+        {/* Hack. Fix later. Add -2 negative margin to remove the padding added by ActionSheetContent */}
         <Box py={5} mt={-2}>
           <Box bg="coolGray.400" height={1} width={9} borderRadius={2} />
         </Box>

--- a/src/components/composites/Actionsheet/ActionsheetContent.tsx
+++ b/src/components/composites/Actionsheet/ActionsheetContent.tsx
@@ -56,9 +56,10 @@ const ActionsheetContent = (
         const { height } = event.nativeEvent.layout;
         sheetHeight.current = height;
       }}
+      pointerEvents="box-none"
     >
       {/* To increase the draggable area */}
-      <Box py={5} {...panResponder.panHandlers} />
+      <Box py={5} {...panResponder.panHandlers} collapsable={false} />
 
       <Modal.Content {...newProps} ref={ref}>
         {/* Hack. Fix later. Add -2 negative margin to remove the padding added by ActionSheetContent */}
@@ -68,6 +69,7 @@ const ActionsheetContent = (
           {...panResponder.panHandlers}
           width="100%"
           alignItems="center"
+          collapsable={false}
         >
           <Box bg="coolGray.400" height={1} width={9} borderRadius={2} />
         </Box>

--- a/src/components/primitives/Select/Select.tsx
+++ b/src/components/primitives/Select/Select.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, memo } from 'react';
 import type { ISelectProps } from './types';
-import { Platform, View, Pressable, ScrollView } from 'react-native';
+import { Platform, View, Pressable } from 'react-native';
 import { Actionsheet } from '../../composites/Actionsheet';
 import Box from '../Box';
 import { Input } from '../Input';
@@ -13,6 +13,7 @@ import { useFormControl } from '../../composites/FormControl';
 import { extractInObject, stylingProps } from '../../../theme/tools/utils';
 import { ChevronDownIcon } from '../Icon/Icons';
 import type { IButtonProps } from '../Button/types';
+import { ScrollView } from '../../basic/ScrollView';
 
 const unstyledSelecWebtStyles = {
   width: '100%',
@@ -132,6 +133,8 @@ const Select = (
     />
   );
 
+  const handleClose = () => setIsOpen(false);
+
   return (
     <Box
       borderWidth={1}
@@ -174,9 +177,9 @@ const Select = (
           >
             <View pointerEvents="none">{commonInput}</View>
           </Pressable>
-          <Actionsheet isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          <Actionsheet isOpen={isOpen} onClose={handleClose}>
             <Actionsheet.Content {..._actionSheetContent}>
-              <ScrollView style={{ width: '100%' }}>
+              <ScrollView width="100%">
                 <SelectContext.Provider
                   value={{
                     onValueChange: setValue,

--- a/src/theme/components/actionsheet.ts
+++ b/src/theme/components/actionsheet.ts
@@ -12,6 +12,7 @@ export const ActionsheetContent = {
     alignItems: 'center',
     p: 2,
     borderRadius: 'none',
+    roundedTop: 10,
   },
 };
 


### PR DESCRIPTION
Fixes
- ActionSheet flickers when it's closed using a swipe gesture
- Select scroll behaviour when list of options is large

Features
- Added drag indicator line in ActionSheet. This is useful to indicate that the component is draggable.
- Added Select example with long list of options.