### PR TITLE
Fix/3376 - Make drag indicator optional in actionsheet

### DIFF
--- a/src/components/composites/Actionsheet/ActionSheetContext.ts
+++ b/src/components/composites/Actionsheet/ActionSheetContext.ts
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const ActionSheetContext = React.createContext({
+  hideDragIndicator: false,
+});

--- a/src/components/composites/Actionsheet/Actionsheet.tsx
+++ b/src/components/composites/Actionsheet/Actionsheet.tsx
@@ -2,8 +2,12 @@ import React, { memo, forwardRef } from 'react';
 import { Modal } from '../../composites/Modal';
 import type { IActionsheetProps } from './types';
 import { usePropsResolution } from '../../../hooks';
+import { ActionSheetContext } from './ActionSheetContext';
 
-const Actionsheet = ({ children, ...props }: IActionsheetProps, ref: any) => {
+const Actionsheet = (
+  { children, hideDragIndicator = false, ...props }: IActionsheetProps,
+  ref: any
+) => {
   const { isOpen, disableOverlay, onClose, ...newProps } = usePropsResolution(
     'Actionsheet',
     props
@@ -21,7 +25,9 @@ const Actionsheet = ({ children, ...props }: IActionsheetProps, ref: any) => {
       closeOnOverlayClick={disableOverlay ? false : true}
       ref={ref}
     >
-      {children}
+      <ActionSheetContext.Provider value={{ hideDragIndicator }}>
+        {children}
+      </ActionSheetContext.Provider>
     </Modal>
   );
 };

--- a/src/components/composites/Actionsheet/ActionsheetContent.tsx
+++ b/src/components/composites/Actionsheet/ActionsheetContent.tsx
@@ -5,13 +5,18 @@ import { usePropsResolution } from '../../../hooks';
 import { Animated, PanResponder } from 'react-native';
 import { ModalContext } from '../Modal/Context';
 import Box from '../../primitives/Box';
+import { ActionSheetContext } from './ActionSheetContext';
 
 const ActionsheetContent = (
   { children, ...props }: IActionsheetContentProps,
   ref?: any
 ) => {
-  const newProps = usePropsResolution('ActionsheetContent', props);
+  const { _dragIndicator, ...newProps } = usePropsResolution(
+    'ActionsheetContent',
+    props
+  );
   const { handleClose } = React.useContext(ModalContext);
+  const { hideDragIndicator } = React.useContext(ActionSheetContext);
   let pan = React.useRef(new Animated.ValueXY()).current;
   let sheetHeight = React.useRef(0);
 
@@ -59,21 +64,30 @@ const ActionsheetContent = (
       }}
       pointerEvents="box-none"
     >
-      {/* To increase the draggable area */}
-      <Box py={5} {...panResponder.panHandlers} collapsable={false} />
+      {!hideDragIndicator ? (
+        <>
+          {/* To increase the draggable area */}
+          <Box py={5} {...panResponder.panHandlers} collapsable={false} />
+        </>
+      ) : null}
 
       <Modal.Content {...newProps} ref={ref} safeAreaBottom>
-        {/* Hack. Fix later. Add -2 negative margin to remove the padding added by ActionSheetContent */}
-        <Box
-          py={5}
-          mt={-2}
-          {...panResponder.panHandlers}
-          width="100%"
-          alignItems="center"
-          collapsable={false}
-        >
-          <Box bg="coolGray.400" height={1} width={9} borderRadius={2} />
-        </Box>
+        {!hideDragIndicator ? (
+          <>
+            {/* Hack. Fix later. Add -2 negative margin to remove the padding added by ActionSheetContent */}
+            <Box
+              py={5}
+              mt={-2}
+              {...panResponder.panHandlers}
+              width="100%"
+              alignItems="center"
+              collapsable={false}
+            >
+              <Box {..._dragIndicator} />
+            </Box>
+          </>
+        ) : null}
+
         {children}
       </Modal.Content>
     </Animated.View>

--- a/src/components/composites/Actionsheet/types.tsx
+++ b/src/components/composites/Actionsheet/types.tsx
@@ -15,6 +15,12 @@ export interface IActionsheetProps extends IBoxProps {
    * @default false
    */
   disableOverlay?: boolean;
+
+  /**
+   * If true, hides the drag indicator.
+   * @default false
+   */
+  hideDragIndicator?: boolean;
 }
 
 export interface IActionsheetContentProps extends IBoxProps {}

--- a/src/theme/components/actionsheet.ts
+++ b/src/theme/components/actionsheet.ts
@@ -13,6 +13,12 @@ export const ActionsheetContent = {
     p: 2,
     borderRadius: 'none',
     roundedTop: 10,
+    _dragIndicator: {
+      bg: 'coolGray.400',
+      height: 1,
+      width: 9,
+      borderRadius: 2,
+    },
   },
 };
 


### PR DESCRIPTION
Fixes https://github.com/GeekyAnts/NativeBase/issues/3776

This PR adds `hideDragIndicator` and `_dragIndicator` props for hiding and styling ActionSheet's drag indicator