### PR TITLE
fix: remove checkbox group additional wrapper

### DIFF
--- a/src/components/primitives/Checkbox/CheckboxGroup.tsx
+++ b/src/components/primitives/Checkbox/CheckboxGroup.tsx
@@ -16,20 +16,18 @@ function CheckboxGroup(
   let { groupProps } = useCheckboxGroup(props, state);
   const formControlContext = useFormControlContext();
   return (
-    <Box ref={ref}>
-      <CheckboxGroupContext.Provider
-        value={{
-          size,
-          colorScheme,
-          ...formControlContext,
-          state,
-        }}
-      >
-        <Box alignItems="flex-start" {...groupProps} {...props}>
-          {children}
-        </Box>
-      </CheckboxGroupContext.Provider>
-    </Box>
+    <CheckboxGroupContext.Provider
+      value={{
+        size,
+        colorScheme,
+        ...formControlContext,
+        state,
+      }}
+    >
+      <Box alignItems="flex-start" {...groupProps} {...props} ref={ref}>
+        {children}
+      </Box>
+    </CheckboxGroupContext.Provider>
   );
 }
 


### PR DESCRIPTION
This PR removes an additional wrapper which was added to Checkbox group for historical reasons.  