### PR TITLE
fix: 3783 input android padding top, bottom

### DIFF
--- a/src/theme/components/input.ts
+++ b/src/theme/components/input.ts
@@ -42,7 +42,8 @@ const baseStyle = (props: Record<string, any>) => {
       borderColor: 'primary.400',
     },
     _android: {
-      p: 3,
+      px: 4,
+      py: 3,
       _focus: {
         borderColor: 'primary.400',
       },


### PR DESCRIPTION
Fixes - https://github.com/GeekyAnts/NativeBase/issues/3783

## Issue description

In the current version, 
```
<Box px={2} p={4} />
```
Applied styles would be `paddingTop:4, paddingBottom:4, paddingLeft: 4, paddingRight: 4` 

In the new version, we're planning to make it such that more specific one wins so applied styles would be `paddingTop:4, paddingBottom:4, paddingLeft: 2, paddingRight: 2`. This is default behaviour in [react native and react native web](https://necolas.github.io/react-native-web/docs/styling/#how-it-works)

However, the above change is targeted in 3.1. In the meantime, this PR implements a patch to fix the issue for Input component.