### PR TITLE
Fix/3817 fab portal

### DIFF
--- a/src/components/composites/Fab/Fab.tsx
+++ b/src/components/composites/Fab/Fab.tsx
@@ -4,21 +4,28 @@ import type { IFabProps } from './types';
 import { usePropsResolution } from '../../../hooks/useThemeProps';
 import { OverlayContainer } from '@react-native-aria/overlays';
 
-const Fab = ({ label, icon, ...props }: IFabProps, ref: any) => {
+const Fab = (
+  { label, icon, renderInPortal = true, ...props }: IFabProps,
+  ref: any
+) => {
   const themeProps = usePropsResolution('FAB', props);
   const { placement, placementProps, ...newProps } = themeProps;
 
-  return (
-    <OverlayContainer>
-      <Button
-        {...placementProps[placement]}
-        ref={ref}
-        startIcon={icon}
-        {...newProps}
-      >
-        {label}
-      </Button>
-    </OverlayContainer>
+  const fabComponent = (
+    <Button
+      {...placementProps[placement]}
+      ref={ref}
+      startIcon={icon}
+      {...newProps}
+    >
+      {label}
+    </Button>
+  );
+
+  return renderInPortal ? (
+    <OverlayContainer>{fabComponent}</OverlayContainer>
+  ) : (
+    fabComponent
   );
 };
 

--- a/src/components/composites/Fab/types.tsx
+++ b/src/components/composites/Fab/types.tsx
@@ -14,4 +14,11 @@ export interface IFabProps extends IButtonProps {
    * Icon to be displayed in Fab
    */
   icon?: JSX.Element;
+  /**
+   * Determines whether the Fab should be rendered in a Portal.
+   * Refer this solution before using this prop
+   * https://github.com/GeekyAnts/NativeBase/issues/3817
+   * @default true
+   */
+  renderInPortal?: boolean;
 }


### PR DESCRIPTION
Attempts a workaround for https://github.com/GeekyAnts/NativeBase/issues/3826 and https://github.com/GeekyAnts/NativeBase/issues/3817

In some cases, we might want to control the placement of fab and prevent being rendered in Portal. For such cases, this PR adds a prop named `renderInPortal` which defaults to `true` for backward compatibility. Passing false to this prop will render the FAB button where it's defined.