### PR TITLE
Fix/api ref icon button

### DIFF
--- a/example/storybook/stories/components/composites/IconButton/Basic.tsx
+++ b/example/storybook/stories/components/composites/IconButton/Basic.tsx
@@ -1,12 +1,26 @@
 import React from 'react';
-import { IconButton, Icon } from 'native-base';
+import { IconButton, Icon, VStack } from 'native-base';
 import { AntDesign } from '@expo/vector-icons';
 
 export const Example = () => {
   return (
-    <IconButton
-      variant="solid"
-      icon={<Icon size="md" as={<AntDesign name="search1" />} color="white" />}
-    />
+    <VStack space={4}>
+      <IconButton
+        colorScheme="red"
+        variant="solid"
+        icon={<Icon as={AntDesign} name="search1" />}
+        _icon={{
+          color: 'amber.100',
+        }}
+      />
+      <IconButton
+        colorScheme="emerald"
+        variant="outline"
+        _icon={{
+          as: AntDesign,
+          name: 'home',
+        }}
+      />
+    </VStack>
   );
 };

--- a/example/storybook/stories/components/composites/IconButton/SVGIcon.tsx
+++ b/example/storybook/stories/components/composites/IconButton/SVGIcon.tsx
@@ -1,23 +1,51 @@
 import React from 'react';
-import { IconButton, Icon } from 'native-base';
+import { IconButton, Icon, VStack } from 'native-base';
 import { Path, Circle } from 'react-native-svg';
 
 export const Example = () => {
   return (
-    <IconButton
-      variant="solid"
-      onPress={() => console.log('IconButton pressed')}
-      icon={
-        <Icon viewBox="0 0 200 200" color="blue.300" size={10} strokeWidth="10">
-          <Path
-            fill="blue.300"
-            stroke="red.300"
+    <VStack space={4}>
+      {/* Suggested */}
+      <IconButton
+        variant="solid"
+        onPress={() => console.log('IconButton pressed')}
+        _icon={{
+          viewBox: '0 0 200 200',
+          color: 'blue.300',
+          size: 10,
+          strokeWidth: '10',
+        }}
+      >
+        <Path
+          fill="blue.300"
+          stroke="red.300"
+          strokeWidth="10"
+          d="M 100, 100 m -75, 0 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0"
+        />
+        <Circle cx="100" cy="100" r="50" fill="pink.200" />
+      </IconButton>
+
+      {/* Alternatively */}
+      <IconButton
+        variant="solid"
+        onPress={() => console.log('IconButton pressed')}
+        icon={
+          <Icon
+            viewBox="0 0 200 200"
+            color="blue.300"
+            size={10}
             strokeWidth="10"
-            d="M 100, 100 m -75, 0 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0"
-          />
-          <Circle cx="100" cy="100" r="50" fill="pink.200" />
-        </Icon>
-      }
-    />
+          >
+            <Path
+              fill="blue.300"
+              stroke="red.300"
+              strokeWidth="10"
+              d="M 100, 100 m -75, 0 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0"
+            />
+            <Circle cx="100" cy="100" r="50" fill="pink.200" />
+          </Icon>
+        }
+      />
+    </VStack>
   );
 };

--- a/example/storybook/stories/components/composites/IconButton/Sizes.tsx
+++ b/example/storybook/stories/components/composites/IconButton/Sizes.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { HStack, IconButton, Icon, Box } from 'native-base';
+import { HStack, IconButton, Box } from 'native-base';
+import { MaterialIcons } from '@expo/vector-icons';
 export const Example = () => {
   return (
     <HStack space={2}>
@@ -8,7 +9,10 @@ export const Example = () => {
           <IconButton
             size={size}
             variant="solid"
-            icon={<Icon name={'menu'} color="white" size={size} />}
+            _icon={{
+              as: MaterialIcons,
+              name: 'menu',
+            }}
           />
         </Box>
       ))}

--- a/example/storybook/stories/components/composites/IconButton/Variant.tsx
+++ b/example/storybook/stories/components/composites/IconButton/Variant.tsx
@@ -1,21 +1,18 @@
 import React from 'react';
-import { HStack, IconButton, Icon } from 'native-base';
+import { HStack, IconButton } from 'native-base';
 import { AntDesign } from '@expo/vector-icons';
 export const Example = () => {
   return (
     <HStack space={4}>
       {['outline', 'solid', 'ghost'].map((variant: any) => (
         <IconButton
+          colorScheme="amber"
           key={variant}
           variant={variant}
-          icon={
-            <Icon
-              size={4}
-              name="search1"
-              as={AntDesign}
-              color={variant === 'solid' ? 'white' : 'primary.500'}
-            />
-          }
+          _icon={{
+            as: AntDesign,
+            name: 'search1',
+          }}
         />
       ))}
     </HStack>

--- a/example/storybook/stories/components/primitives/Button/index.tsx
+++ b/example/storybook/stories/components/primitives/Button/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { withKnobs } from '@storybook/addon-knobs';
-import { Example as ButtonGroup } from './ButtonGroup';
 import { Example as WithRef } from './WithRef';
 import { Example as Sizes } from './sizes';
 import { Example as Basic } from './basic';
@@ -19,6 +18,5 @@ storiesOf('Button', module)
   .add('Sizes', () => <Sizes />)
   .add('Loading', () => <Loading />)
   .add('Icons', () => <Icons />)
-  .add('ButtonGroup', () => <ButtonGroup />)
   .add('Composition', () => <Composition />)
   .add('WithRef', () => <WithRef />);

--- a/src/components/composites/IconButton/index.tsx
+++ b/src/components/composites/IconButton/index.tsx
@@ -1,21 +1,27 @@
 import React, { memo, forwardRef } from 'react';
-import { Button, IButtonProps } from '../../primitives/Button';
+import { Pressable } from '../../primitives/Pressable';
+import { Icon } from '../../primitives/Icon';
 import { usePropsResolution } from '../../../hooks/useThemeProps';
+import type { IIconButtonProps } from './types';
 
-export interface IIconButtonProps extends IButtonProps {
-  /**
-   * The icon to be used. Refer to the Icon section of the docs for the available icon options.
-   */
-  icon: JSX.Element;
-}
+const IconButton = (
+  { icon, children, ...props }: IIconButtonProps,
+  ref: any
+) => {
+  const { _icon, ...resolvedProps } = usePropsResolution('IconButton', props);
+  let clonedIcon;
+  if (icon) {
+    clonedIcon = React.cloneElement(icon, {
+      ..._icon,
+    });
+  }
 
-const IconButton = ({ icon, ...props }: IIconButtonProps, ref: any) => {
-  const newProps = usePropsResolution('IconButton', props);
   return (
-    <Button ref={ref} {...newProps}>
-      {icon}
-    </Button>
+    <Pressable ref={ref} {...resolvedProps}>
+      {clonedIcon || <Icon {..._icon}>{children}</Icon>}
+    </Pressable>
   );
 };
 
 export default memo(forwardRef(IconButton));
+export type { IIconButtonProps };

--- a/src/components/composites/IconButton/types.ts
+++ b/src/components/composites/IconButton/types.ts
@@ -1,0 +1,45 @@
+import type { IPressableProps } from '../../primitives/Pressable';
+import type { IIconProps } from '../../primitives/Icon';
+import type { ResponsiveValue } from '../../types';
+
+export interface IIconButtonProps
+  extends Omit<IPressableProps, 'children' | 'color'>,
+    Omit<
+      IIconProps,
+      | 'delayLongPress'
+      | 'disabled'
+      | 'hitSlop'
+      | 'onLongPress'
+      | 'onPress'
+      | 'onPressIn'
+      | 'onPressOut'
+      | 'style'
+      | 'size'
+    > {
+  /**
+   * The color of the radio when it's checked. This should be one of the color keys in the theme (e.g."green", "red").
+   * @default 'primary'
+   */
+  colorScheme?: string;
+  /**
+   * The variant of the button style to use.
+   * @default 'ghost'
+   */
+  variant?: ResponsiveValue<'ghost' | 'outline' | 'solid' | 'unstyled'>;
+  /**
+   * The size of the button.
+   */
+  size?: ResponsiveValue<'sm' | 'md' | 'lg'>;
+  /**
+   * If true, the button will be disabled.
+   */
+  isDisabled?: boolean;
+  /**
+   * The icon to be used. Refer to the Icon section of the docs for the available icon options.
+   */
+  icon?: JSX.Element;
+  /**
+   * Props to be passed to the icon used inside of IconButton.
+   */
+  _icon?: IIconProps;
+}

--- a/src/theme/components/icon-button.ts
+++ b/src/theme/components/icon-button.ts
@@ -1,10 +1,128 @@
-const baseStyle = {
-  borderRadius: 'md',
+import { Dict, mode, transparentize } from './../tools';
+import { Platform } from 'react-native';
+
+const baseStyle = (props: any) => {
+  const { primary } = props.theme.colors;
+  const focusRing =
+    Platform.OS === 'web'
+      ? { boxShadow: `${primary[400]} 0px 0px 0px 3px` }
+      : {};
+
+  return {
+    borderRadius: 'lg',
+    _web: {
+      cursor: props.isDisabled
+        ? 'not-allowed'
+        : props.isLoading
+        ? 'default'
+        : 'pointer',
+    },
+    _focusVisible: {
+      style: props.variant !== 'unstyled' ? { ...focusRing } : {},
+    },
+    _disabled: {
+      opacity: 0.5,
+    },
+  };
+};
+
+function variantGhost(props: Dict) {
+  const { colorScheme } = props;
+  return {
+    bg: 'transparent',
+    _web: {
+      outlineWidth: 0,
+    },
+    _hover: {
+      bg: transparentize(
+        mode(`${colorScheme}.200`, `${colorScheme}.500`)(props),
+        0.5
+      )(props.theme),
+    },
+    _focusVisible: {
+      bg: transparentize(
+        mode(`${colorScheme}.200`, `${colorScheme}.500`)(props),
+        0.5
+      )(props.theme),
+    },
+    _pressed: {
+      bg: transparentize(
+        mode(`${colorScheme}.200`, `${colorScheme}.500`)(props),
+        0.6
+      )(props.theme),
+    },
+  };
+}
+
+function variantOutline(props: Dict) {
+  const { colorScheme } = props;
+  return {
+    border: '1px solid',
+    borderColor: `${colorScheme}.500`,
+    _icon: {
+      color: `${colorScheme}.500`,
+    },
+    _web: {
+      outlineWidth: 0,
+    },
+    _hover: {
+      bg: transparentize(
+        mode(`${colorScheme}.200`, `${colorScheme}.500`)(props),
+        0.5
+      )(props.theme),
+    },
+    _focusVisible: {
+      bg: transparentize(
+        mode(`${colorScheme}.200`, `${colorScheme}.500`)(props),
+        0.5
+      )(props.theme),
+    },
+    _pressed: {
+      bg: transparentize(
+        mode(`${colorScheme}.200`, `${colorScheme}.500`)(props),
+        0.6
+      )(props.theme),
+    },
+  };
+}
+
+function variantSolid(props: Dict) {
+  const { colorScheme } = props;
+  return {
+    bg: mode(`${colorScheme}.500`, `${colorScheme}.400`)(props),
+    _web: {
+      outlineWidth: 0,
+    },
+    _disabled: {
+      bg: mode(`muted.300`, `muted.500`)(props),
+    },
+    _hover: {
+      bg: mode(`${colorScheme}.600`, `${colorScheme}.500`)(props),
+    },
+    _pressed: {
+      bg: mode(`${colorScheme}.700`, `${colorScheme}.600`)(props),
+    },
+    _icon: {
+      color: mode('gray.50', 'gray.800')(props),
+    },
+  };
+}
+
+function variantUnstyled() {
+  return {};
+}
+
+const variants = {
+  ghost: variantGhost,
+  outline: variantOutline,
+  solid: variantSolid,
+  unstyled: variantUnstyled,
 };
 
 const defaultProps = {
   variant: 'ghost',
   size: 'md',
+  colorScheme: 'primary',
 };
 
 const sizes = {
@@ -21,6 +139,7 @@ const sizes = {
 
 export default {
   baseStyle,
+  variants,
   sizes,
   defaultProps,
 };


### PR DESCRIPTION
Updated Internal working of Icon Button but replacing **Button** with **Pressable**. Now, IconButton looks more like Icon and the api feels more intuitive.

Fix:
- Icons of IconButton will now respond to **colors** change on `variant` and `colorScheme`.