### PR TITLE
fix: link _text not working from theme

### DIFF
--- a/src/components/primitives/Link/index.tsx
+++ b/src/components/primitives/Link/index.tsx
@@ -17,7 +17,6 @@ const Link = (
     onPress,
     isExternal,
     children,
-    _text,
     wrapperRef,
     ...props
   }: ILinkProps,
@@ -28,7 +27,7 @@ const Link = (
     ...stylingProps.position,
     ...stylingProps.layout,
   ]);
-  let { _hover, ...newProps } = usePropsResolution('Link', remProps);
+  let { _hover, _text, ...newProps } = usePropsResolution('Link', remProps);
   const _ref = React.useRef(null);
   const { isHovered } = useHover({}, _ref);
   const linkTextProps = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fixes https://github.com/GeekyAnts/NativeBase/issues/3851
Use _text from usePropResolution instead of incoming props.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

Fixes _text not working in Link component's baseStyle/variants
<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

