### PR TITLE
fix: keyboardAvoidingView example will only run on mobile

### DIFF
--- a/example/storybook/stories/components/basic/KeyboardAvoidingView/Basic.tsx
+++ b/example/storybook/stories/components/basic/KeyboardAvoidingView/Basic.tsx
@@ -1,11 +1,28 @@
 import React from 'react';
-import { Input, KeyboardAvoidingView, Text, Button, VStack } from 'native-base';
+import {
+  Input,
+  KeyboardAvoidingView,
+  Text,
+  Button,
+  VStack,
+  useBreakpointValue,
+} from 'native-base';
 import { Platform } from 'react-native';
 
 export const Example = () => {
+  const isLargeScreen = useBreakpointValue({
+    base: false,
+    sm: false,
+    md: false,
+    lg: true,
+  });
   return (
-    <KeyboardAvoidingView h={{ base: '600px', lg: 'auto' }}>
-      {Platform.OS === 'web' ? (
+    <KeyboardAvoidingView
+      h={{ base: '600px', lg: 'auto' }}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={192}
+    >
+      {isLargeScreen ? (
         <Text>Please see the example in your mobile to observe the effect</Text>
       ) : (
         <VStack p={6} flex={1} justifyContent="space-around">

--- a/example/storybook/stories/components/basic/KeyboardAvoidingView/Basic.tsx
+++ b/example/storybook/stories/components/basic/KeyboardAvoidingView/Basic.tsx
@@ -1,23 +1,11 @@
 import React from 'react';
-import {
-  Input,
-  KeyboardAvoidingView,
-  View,
-  Text,
-  Button,
-  VStack,
-  useBreakpointValue,
-} from 'native-base';
+import { Input, KeyboardAvoidingView, Text, Button, VStack } from 'native-base';
+import { Platform } from 'react-native';
+
 export const Example = () => {
-  const isLargeScreen = useBreakpointValue({
-    base: false,
-    sm: false,
-    md: false,
-    lg: true,
-  });
   return (
     <KeyboardAvoidingView h={{ base: '600px', lg: 'auto' }}>
-      {isLargeScreen ? (
+      {Platform.OS === 'web' ? (
         <Text>Please see the example in your mobile to observe the effect</Text>
       ) : (
         <VStack p={6} flex={1} justifyContent="space-around">
@@ -30,9 +18,7 @@ export const Example = () => {
             mb={9}
             mt="auto"
           />
-          <View bg="white" mt={3}>
-            <Button variant="solid">Submit</Button>
-          </View>
+          <Button variant="solid">Submit</Button>
         </VStack>
       )}
     </KeyboardAvoidingView>


### PR DESCRIPTION
Previously, isLargeScreen logic was applied to differentiate for web and mobile. But here, we don't want to show example on web platform. For that, using Platform property to detect the platform.