### PR TITLE
fix(input): #3874 use defined input left and right elements in states

### DIFF
--- a/src/components/primitives/Input/Input.tsx
+++ b/src/components/primitives/Input/Input.tsx
@@ -13,7 +13,18 @@ const Input = (props: IInputProps, ref: any) => {
     nativeID: props.nativeID,
   });
 
-  if (props.InputLeftElement || props.InputRightElement)
+  if (
+    props.InputLeftElement ||
+    props.InputRightElement ||
+    props._hover?.InputLeftElement ||
+    props._hover?.InputRightElement ||
+    props._focus?.InputLeftElement ||
+    props._focus?.InputRightElement ||
+    props._disabled?.InputLeftElement ||
+    props._disabled?.InputRightElement ||
+    props._invalid?.InputLeftElement ||
+    props._invalid?.InputRightElement
+  )
     return <InputAdvanced {...props} ref={ref} inputProps={inputProps} />;
   else return <InputBase {...props} ref={ref} inputProps={inputProps} />;
 };

--- a/src/components/primitives/Input/InputAdvanced.tsx
+++ b/src/components/primitives/Input/InputAdvanced.tsx
@@ -9,8 +9,8 @@ import { mergeRefs } from '../../../utils';
 
 const InputAdvance = (
   {
-    InputLeftElement,
-    InputRightElement,
+    InputLeftElement: BaseInputLeftElement,
+    InputRightElement: BaseInputRightElement,
     onFocus,
     onBlur,
     inputProps,
@@ -61,6 +61,20 @@ const InputAdvance = (
 
   const _ref = React.useRef(null);
   const { isHovered } = useHover({}, _ref);
+
+  const InputLeftElement =
+    (isHovered && _hover.InputLeftElement) ||
+    (isFocused && _focus.InputLeftElement) ||
+    (isDisabled && _disabled.InputLeftElement) ||
+    (isInvalid && _invalid.InputLeftElement) ||
+    BaseInputLeftElement;
+
+  const InputRightElement =
+    (isHovered && _hover.InputRightElement) ||
+    (isFocused && _focus.InputRightElement) ||
+    (isDisabled && _disabled.InputRightElement) ||
+    (isInvalid && _invalid.InputRightElement) ||
+    BaseInputRightElement;
 
   return (
     <Box


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Pull request to solve issue #3874 - set InputLeftElement and InputRightElement in _disabled, _focus, _hover or _invalid are not read

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Fix _disabled, _invalid, _focus and _hover InputLeftElement and InputRightElement props

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

In `RNBareExample` app I have checked that 

```
 <Input
          placeholder="Type something"
          _focus={{
            InputLeftElement: <Box bgColor="#111" w={10} h={10} />,
          }}
        />
```

displays a black square on the left when I have focus on input and 

```
 <Input
          placeholder="Type something"
          isInvalid
          _invalid={{
            InputRightElement: <Box bgColor="#111" w={10} h={10} />,
          }}
        />
```

displays a black square on the right