### PR TITLE
fix: avatar badge conditional rendering type of null issue

### DIFF
--- a/src/components/composites/Avatar/Avatar.tsx
+++ b/src/components/composites/Avatar/Avatar.tsx
@@ -18,8 +18,8 @@ const Avatar = ({ wrapperRef, ...props }: IAvatarProps, ref: any) => {
   //  Pop Badge from children
   React.Children.map(children, (child, key) => {
     if (
-      typeof child.type === 'object' &&
-      child.type.displayName === 'AvatarBadge'
+      typeof child?.type === 'object' &&
+      child?.type.displayName === 'AvatarBadge'
     ) {
       Badge = child;
     } else {


### PR DESCRIPTION
This PR fixes https://github.com/GeekyAnts/NativeBase/issues/3836 

 - Passing null as child in Avatar was throwing error. 
 - Added a check for null child.
