### PR TITLE
fix: actionsheet backdrop fix

### DIFF
--- a/example/storybook/stories/components/composites/Actionsheet/CustomBackdrop.tsx
+++ b/example/storybook/stories/components/composites/Actionsheet/CustomBackdrop.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Button, Divider, Actionsheet, useDisclose } from 'native-base';
+
+export function Example() {
+  const { isOpen, onOpen, onClose } = useDisclose();
+  return (
+    <>
+      <Button onPress={onOpen}>Actionsheet</Button>
+
+      <Actionsheet
+        isOpen={isOpen}
+        onClose={onClose}
+        _backdrop={{ bg: 'red.100', opacity: 0.8 }}
+      >
+        <Actionsheet.Content>
+          <Divider borderColor="gray.300" />
+          <Actionsheet.Item _text={{ color: 'blue.500' }}>
+            Save
+          </Actionsheet.Item>
+          <Divider borderColor="gray.300" />
+          <Actionsheet.Item _text={{ color: 'blue.500' }}>
+            Delete
+          </Actionsheet.Item>
+        </Actionsheet.Content>
+      </Actionsheet>
+    </>
+  );
+}

--- a/example/storybook/stories/components/composites/Actionsheet/index.tsx
+++ b/example/storybook/stories/components/composites/Actionsheet/index.tsx
@@ -6,6 +6,7 @@ import { Example as Icon } from './Icon';
 import { Example as Usage } from './Usage';
 import { Example as Composition } from './Composition';
 import { Example as DisableOverlay } from './DisableOverlay';
+import { Example as CustomBackdrop } from './CustomBackdrop';
 
 storiesOf('Actionsheet', module)
   .addDecorator(withKnobs)
@@ -13,4 +14,5 @@ storiesOf('Actionsheet', module)
   .add('Usage', () => <Usage />)
   .add('Icon', () => <Icon />)
   .add('DisableOverlay', () => <DisableOverlay />)
-  .add('Composition', () => <Composition />);
+  .add('Composition', () => <Composition />)
+  .add('Custom Backdrop', () => <CustomBackdrop />);

--- a/example/storybook/stories/components/composites/Modal/CustomBackdrop.tsx
+++ b/example/storybook/stories/components/composites/Modal/CustomBackdrop.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Button, Modal } from 'native-base';
+import { useState } from 'react';
+
+export const Example = () => {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <Button onPress={() => setShowModal(true)}>Button</Button>
+      <Modal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        overlayVisible={false}
+        _backdrop={{ opacity: 0.8, bg: 'pink.100' }}
+      >
+        <Modal.Content maxWidth="400px">
+          <Modal.CloseButton />
+          <Modal.Header>Modal Title</Modal.Header>
+          <Modal.Body>
+            Sit nulla est ex deserunt exercitation anim occaecat. Nostrud
+            ullamco deserunt aute id consequat veniam incididunt duis in sint
+            irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit
+            officia tempor esse quis. Sunt ad dolore quis aute consequat. Magna
+            exercitation reprehenderit magna aute tempor cupidatat consequat
+            elit dolor adipisicing. Mollit dolor eiusmod sunt ex incididunt
+            cillum quis. Velit duis sit officia eiusmod Lorem aliqua enim
+            ullamco deserunt aute id consequat veniam incididunt duis in sint
+            irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit
+            officia tempor esse quis. Sunt ad dolore quis aute consequat. Magna
+            exercitation reprehenderit magna aute tempor cupidatat consequat
+            elit dolor adipisicing. Mollit dolor eiusmod sunt ex incididunt
+            cillum quis. Velit duis sit officia eiusmod Lorem aliqua enim
+            exercitation reprehenderit magna aute tempor cupidatat consequat
+            elit dolor adipisicing. Mollit dolor eiusmod sunt ex incididunt
+            cillum quis. Velit duis sit officia eiusmod Lorem aliqua enim
+            ullamco deserunt aute id consequat veniam incididunt duis in sint
+            irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit
+            officia tempor esse quis. Sunt ad dolore quis aute consequat. Magna
+            exercitation reprehenderit magna aute tempor cupidatat consequat
+            elit dolor adipisicing. Mollit dolor eiusmod sunt ex incididunt
+            cillum quis. Velit duis sit officia eiusmod Lorem aliqua enim
+          </Modal.Body>
+          <Modal.Footer>
+            <Button.Group variant="ghost" space={2}>
+              <Button>LEARN MORE</Button>
+              <Button
+                onPress={() => {
+                  setShowModal(false);
+                }}
+              >
+                ACCEPT
+              </Button>
+            </Button.Group>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal>
+    </>
+  );
+};

--- a/example/storybook/stories/components/composites/Modal/index.tsx
+++ b/example/storybook/stories/components/composites/Modal/index.tsx
@@ -8,6 +8,7 @@ import { Example as ModalRefEg } from './ModalRefEg';
 import { Example as MultipleModal } from './MultipleModal';
 import { Example as Size } from './Size';
 import { Example as ModalPlacement } from './ModalPlacement';
+import { Example as CustomBackdrop } from './CustomBackdrop';
 
 storiesOf('Modal', module)
   .addDecorator(withKnobs)
@@ -17,4 +18,5 @@ storiesOf('Modal', module)
   .add('Modal Ref Examples', () => <ModalRefEg />)
   .add('Modal Placement', () => <ModalPlacement />)
   .add('Modal with Keyboard Avoid view', () => <ModalWithAvoidKeyboard />)
-  .add('Modal Size Examples', () => <Size />);
+  .add('Modal Size Examples', () => <Size />)
+  .add('Modal Custom Backdrop', () => <CustomBackdrop />);

--- a/src/components/composites/Actionsheet/types.tsx
+++ b/src/components/composites/Actionsheet/types.tsx
@@ -21,6 +21,7 @@ export interface IActionsheetProps extends IBoxProps {
    * @default false
    */
   hideDragIndicator?: boolean;
+  _backdrop?: any;
 }
 
 export interface IActionsheetContentProps extends IBoxProps {}

--- a/src/components/composites/Actionsheet/types.tsx
+++ b/src/components/composites/Actionsheet/types.tsx
@@ -15,12 +15,14 @@ export interface IActionsheetProps extends IBoxProps {
    * @default false
    */
   disableOverlay?: boolean;
-
   /**
    * If true, hides the drag indicator.
    * @default false
    */
   hideDragIndicator?: boolean;
+  /**
+   * Props applies on Overlay.
+   */
   _backdrop?: any;
 }
 

--- a/src/components/composites/Actionsheet/types.tsx
+++ b/src/components/composites/Actionsheet/types.tsx
@@ -21,7 +21,7 @@ export interface IActionsheetProps extends IBoxProps {
    */
   hideDragIndicator?: boolean;
   /**
-   * Props applies on Overlay.
+   * Props applied on Overlay.
    */
   _backdrop?: any;
 }

--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -23,14 +23,19 @@ const Modal = (
     closeOnOverlayClick = true,
     isKeyboardDismissable = true,
     overlayVisible = true,
+    backdropVisible = true,
     //@ts-ignore - internal purpose only
     animationPreset = 'fade',
     ...rest
   }: IModalProps,
   ref: any
 ) => {
+  console.log(overlayVisible, rest, 'in MODQAL');
   const bottomInset = useKeyboardBottomInset();
-  const { contentSize, ...restThemeProps } = usePropsResolution('Modal', rest);
+  const { contentSize, _backdrop, ...restThemeProps } = usePropsResolution(
+    'Modal',
+    rest
+  );
 
   const [visible, setVisible] = useControllableState({
     value: isOpen,
@@ -74,11 +79,12 @@ const Modal = (
           in={visible}
           style={StyleSheet.absoluteFill}
         >
-          {overlayVisible && (
+          {overlayVisible && backdropVisible && (
             <Backdrop
               onPress={() => {
                 closeOnOverlayClick && handleClose();
               }}
+              {..._backdrop}
             />
           )}
         </Fade>

--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -30,7 +30,6 @@ const Modal = (
   }: IModalProps,
   ref: any
 ) => {
-  console.log(overlayVisible, rest, 'in MODQAL');
   const bottomInset = useKeyboardBottomInset();
   const { contentSize, _backdrop, ...restThemeProps } = usePropsResolution(
     'Modal',

--- a/src/components/composites/Modal/types.ts
+++ b/src/components/composites/Modal/types.ts
@@ -46,6 +46,12 @@ export interface IModalProps extends IBoxProps {
    * @default true
    */
   overlayVisible?: boolean;
+  /**
+   * If true, a backdrop element is visible
+   * @default true
+   */
+  backdropVisible?: boolean;
+  _backdrop?: any;
 }
 
 export type IModalComponentType = ((

--- a/src/components/composites/Modal/types.ts
+++ b/src/components/composites/Modal/types.ts
@@ -52,7 +52,7 @@ export interface IModalProps extends IBoxProps {
    */
   backdropVisible?: boolean;
   /**
-   * Props applies on Overlay.
+   * Props applied on Overlay.
    */
   _backdrop?: any;
 }

--- a/src/components/composites/Modal/types.ts
+++ b/src/components/composites/Modal/types.ts
@@ -51,6 +51,9 @@ export interface IModalProps extends IBoxProps {
    * @default true
    */
   backdropVisible?: boolean;
+  /**
+   * Props applies on Overlay.
+   */
   _backdrop?: any;
 }
 


### PR DESCRIPTION
Fix for below Github Issue
[https://github.com/GeekyAnts/NativeBase/issues/3884](url)

Added _backdrop prop in actionsheet and modal to apply styles to backrop(overlay)
Added backdropVisible(same as overlayVisible) to maintain consistency in prop names
(overlayVisible still works)
Added Example with custom backdrop
