### PR TITLE
fix: "out of place" props from Menu example

### DIFF
--- a/example/storybook/stories/components/composites/Menu/MenuPositions.tsx
+++ b/example/storybook/stories/components/composites/Menu/MenuPositions.tsx
@@ -32,6 +32,7 @@ export function Example() {
           bg: 'cyan.600',
           endIcon: <CheckIcon size={4} />,
         }}
+        accessibilityLabel="Select a position for Menu"
       >
         <Select.Item label="auto" value="auto" />
         <Select.Item label="Top Left" value="top left" />

--- a/example/storybook/stories/components/composites/Menu/MenuPositions.tsx
+++ b/example/storybook/stories/components/composites/Menu/MenuPositions.tsx
@@ -27,8 +27,6 @@ export function Example() {
       <Select
         selectedValue={position}
         mx={{ base: 0, md: 'auto' }}
-        accessibilityLabel="Select your favorite programming language"
-        placeholder="Select your favorite programming language"
         onValueChange={(nextValue) => setPosition(nextValue)}
         _selectedItem={{
           bg: 'cyan.600',

--- a/example/storybook/stories/components/composites/Popover/PopoverPositions.tsx
+++ b/example/storybook/stories/components/composites/Popover/PopoverPositions.tsx
@@ -28,8 +28,7 @@ export function Example() {
       <Select
         selectedValue={position}
         mx={{ base: 0, md: 'auto' }}
-        accessibilityLabel="Select your favorite programming language"
-        placeholder="Select your favorite programming language"
+        accessibilityLabel="Select a position for Popover"
         onValueChange={(nextValue) => setPosition(nextValue)}
         _selectedItem={{
           bg: 'cyan.600',

--- a/example/storybook/stories/components/composites/Tooltip/TooltipPositions.tsx
+++ b/example/storybook/stories/components/composites/Tooltip/TooltipPositions.tsx
@@ -14,8 +14,7 @@ export function Example() {
       <Select
         selectedValue={position}
         mx={{ base: 0, md: 'auto' }}
-        accessibilityLabel="Select your favorite programming language"
-        placeholder="Select your favorite programming language"
+        accessibilityLabel="Select a position for Tooltip"
         onValueChange={(nextValue) => setPosition(nextValue)}
         _selectedItem={{
           bg: 'cyan.600',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The `Select` component has `accessibilityLabel` and `placeholder` props directly copied and pasted from the [Select component example.](https://github.com/GeekyAnts/NativeBase/blob/master/example/storybook/stories/components/primitives/Select/Basic.tsx) The props are unnecessary since the example is to demonstrate the Menu component, not the Select component. Also the content of the props are "out of place", since the example is not about selecting a programming language.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Removed] - Remove `accessibilityLabel` and `placeholder` props from `Select` component in Menu Example

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

It was directly tested from the snack player.