### PR TITLE
Fix/checkbox null child

### DIFF
--- a/example/storybook/stories/components/basic/KeyboardAvoidingView/Kitchensink-Basic.tsx
+++ b/example/storybook/stories/components/basic/KeyboardAvoidingView/Kitchensink-Basic.tsx
@@ -20,6 +20,7 @@ export const Example = () => {
     <KeyboardAvoidingView
       h={{ base: '600px', lg: 'auto' }}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={192}
     >
       {isLargeScreen ? (
         <Text>Please see the example in your mobile to observe the effect</Text>

--- a/example/storybook/stories/components/composites/Fab/Kitchensink-Basic.tsx
+++ b/example/storybook/stories/components/composites/Fab/Kitchensink-Basic.tsx
@@ -6,7 +6,6 @@ export const Example = () => {
   return (
     <NativeBaseProvider>
       <Box position="relative" h={100} w="100%">
-
         <Fab
           position="absolute"
           size="sm"

--- a/example/storybook/stories/components/composites/Fab/Kitchensink-Placement.tsx
+++ b/example/storybook/stories/components/composites/Fab/Kitchensink-Placement.tsx
@@ -4,7 +4,6 @@ import { AntDesign } from '@expo/vector-icons';
 
 export const Example = () => {
   return (
-
     <NativeBaseProvider>
       <Box h={400} w="100%">
         <Fab

--- a/src/components/primitives/Box/index.tsx
+++ b/src/components/primitives/Box/index.tsx
@@ -87,8 +87,8 @@ const Box = ({ children, ...props }: IBoxProps, ref: any) => {
     <StyledBox ref={ref} {...safeAreaProps}>
       {React.Children.map(children, (child) => {
         return typeof child === 'string' ||
-          (child.type === React.Fragment &&
-            typeof child.props.children === 'string') ? (
+          (child?.type === React.Fragment &&
+            typeof child.props?.children === 'string') ? (
           <Text {..._text}>{child}</Text>
         ) : (
           child


### PR DESCRIPTION
Fix for checkbox throwing type of null not defined error caused due to fix for React.Fragment support for text.