### PR TITLE
fix: radio size getting passed to wrapper

### DIFF
--- a/example/storybook/stories/components/composites/Fab/Kitchensink-Basic.tsx
+++ b/example/storybook/stories/components/composites/Fab/Kitchensink-Basic.tsx
@@ -6,7 +6,6 @@ export const Example = () => {
   return (
     <NativeBaseProvider>
       <Box position="relative" h={100} w="100%">
-
         <Fab
           position="absolute"
           size="sm"

--- a/example/storybook/stories/components/composites/Fab/Kitchensink-Placement.tsx
+++ b/example/storybook/stories/components/composites/Fab/Kitchensink-Placement.tsx
@@ -4,7 +4,6 @@ import { AntDesign } from '@expo/vector-icons';
 
 export const Example = () => {
   return (
-
     <NativeBaseProvider>
       <Box h={400} w="100%">
         <Fab

--- a/src/components/primitives/Radio/Radio.tsx
+++ b/src/components/primitives/Radio/Radio.tsx
@@ -10,7 +10,7 @@ import { mergeRefs } from '../../../utils';
 import { CircleIcon } from '../Icon/Icons';
 
 const Radio = (
-  { icon, children, wrapperRef, ...props }: IRadioProps,
+  { icon, children, wrapperRef, size, ...props }: IRadioProps,
   ref: any
 ) => {
   const contextState = React.useContext(RadioContext);
@@ -28,6 +28,7 @@ const Radio = (
   } = usePropsResolution('Radio', {
     ...contextState,
     ...props,
+    size,
   });
 
   const inputRef = React.useRef(null);


### PR DESCRIPTION
Radio in iOS and Android was passing size to Wrapper which was applied as height and width. This PR fixes the size issue.