### PR TITLE
fix: use system color mode

### DIFF
--- a/src/core/color-mode/hooks.tsx
+++ b/src/core/color-mode/hooks.tsx
@@ -6,6 +6,7 @@ import type {
 } from './types';
 import { HybridContext } from './../hybrid-overlay/Context';
 import type { IHybridContextProps } from './../hybrid-overlay/types';
+import { useColorScheme } from 'react-native';
 
 export const useColorMode = (): IColorModeContextProps => {
   const {
@@ -26,8 +27,15 @@ export function useColorModeValue(light: any, dark: any) {
 
 export function useModeManager(
   initialColorMode: ColorMode,
+  useSystemColorMode: boolean | undefined,
   colorModeManager?: StorageManager
 ) {
+  const systemColorMode = useColorScheme();
+
+  if (useSystemColorMode) {
+    initialColorMode = systemColorMode;
+  }
+
   const [colorMode, setRawMode] = useState<ColorMode>(initialColorMode);
   async function setColorMode(val: ColorMode) {
     if (colorModeManager) {
@@ -46,6 +54,13 @@ export function useModeManager(
       })();
     }
   }, [colorMode, initialColorMode, colorModeManager]);
+
+  // Set system color mode only when user has not passed a colorModeManager
+  useEffect(() => {
+    if (!colorModeManager && useSystemColorMode) {
+      setRawMode(systemColorMode);
+    }
+  }, [systemColorMode, colorModeManager, useSystemColorMode, setRawMode]);
 
   return { colorMode, setColorMode };
 }

--- a/src/core/color-mode/types.ts
+++ b/src/core/color-mode/types.ts
@@ -1,4 +1,4 @@
-export type ColorMode = 'light' | 'dark';
+export type ColorMode = 'light' | 'dark' | null | undefined;
 export interface StorageManager {
   get(init?: ColorMode): Promise<ColorMode | undefined>;
   set(value: ColorMode): void;

--- a/src/core/hybrid-overlay/HybridProvider.tsx
+++ b/src/core/hybrid-overlay/HybridProvider.tsx
@@ -10,12 +10,14 @@ const HybridProvider = ({
   options: {
     initialColorMode = 'light',
     accessibleColors: isTextColorAccessible = false,
+    useSystemColorMode,
   },
   colorModeManager,
 }: IColorModeProviderProps) => {
   // Color-mode content
   const { colorMode, setColorMode } = useModeManager(
     initialColorMode,
+    useSystemColorMode,
     colorModeManager
   );
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
This PR fixes https://github.com/GeekyAnts/NativeBase/issues/3927

- There are 3 ways to set the color mode.
1. using [initialColorMode](https://docs.nativebase.io/color-mode#default-color-mode)
2. using [colorModeManager](https://docs.nativebase.io/color-mode#persisting-the-color-mode)
3. using [useSystemColorMode](https://docs.nativebase.io/color-mode#default-color-mode) - (This is added in this PR)

This is how the priority is defined.
- When `initialColorMode` and `useSystemColorMode` is passed => `useSystemColorMode` wins
- When `useSystemColorMode` and `colorModeManager` is passed => `colorModeManager` wins i.e. app will start with system color mode but value returned from colorModeManager.get will override it.
- When `initialColorMode` and `colorModeManager` is passed => `colorModeManager` wins i.e. app will start with initial color mode but value returned from colorModeManager.get will override it.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General][Fixed] - useSystemColorMode prop in theme config

## Test Plan
- Tested with the above combinations in all the platforms.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

## Additional
- Expo users will have to set `userInterfaceStyleKey` to `automatic` as described [here](https://docs.expo.dev/versions/latest/sdk/appearance/#configuration) or else light mode will be used on iOS/Android.