### PR TITLE
Generic useColorModeValue, avoids assign to any errs

### DIFF
--- a/src/core/color-mode/hooks.tsx
+++ b/src/core/color-mode/hooks.tsx
@@ -20,7 +20,7 @@ export const useColorMode = (): IColorModeContextProps => {
   return colorModeContext;
 };
 
-export function useColorModeValue(light: any, dark: any) {
+export function useColorModeValue<L, D>(light: L, dark: D): L | D {
   const { colorMode } = useColorMode();
   return colorMode === 'dark' ? dark : light;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When using stricter Typescript linting, the return value has implicit any type due to the input types being cast away. Since the return value is simple A | B, we can be more specific and not cast away any type info.

## Test Plan

![image](https://user-images.githubusercontent.com/637410/132022375-d9b20303-913b-43e1-b61d-cf8fef2a935e.png)

Willing to rebase / reword commit message if this change is desired. 

I hacked this into my own codebase like so:

```
import 'native-base'

declare module 'native-base' {
  export function useColorModeValue<L, D>(light: L, dark: D): L | D
}
```
