### PR TITLE
Fix/typeahead

### DIFF
--- a/src/components/composites/Typeahead/Typeahead.tsx
+++ b/src/components/composites/Typeahead/Typeahead.tsx
@@ -212,14 +212,16 @@ function Option({ item, state }: { item: any; state: ComboBoxState<any> }) {
   );
 
   let backgroundColor = searchItemStyle.backgroundColor;
-  let opacity = 1;
+  let opacity = searchItemStyle.opacity ?? 0;
 
   if (isSelected) {
+    opacity = searchItemStyle._focus.opacity ?? opacity;
     backgroundColor = searchItemStyle._focus.backgroundColor;
   } else if (isFocused) {
+    opacity = searchItemStyle._focus.opacity ?? opacity;
     backgroundColor = searchItemStyle._focus.backgroundColor;
   } else if (isDisabled) {
-    opacity = 0.6;
+    opacity = searchItemStyle._focus.opacity ?? 0.6;
     backgroundColor = searchItemStyle._disabled.backgroundColor;
   }
 

--- a/src/components/composites/Typeahead/Typeahead.tsx
+++ b/src/components/composites/Typeahead/Typeahead.tsx
@@ -99,7 +99,6 @@ const ComboBoxImplementation = React.forwardRef(
         buttonRef: triggerRef,
         listBoxRef,
         popoverRef,
-        menuTrigger: 'input',
       },
       state
     );

--- a/src/components/composites/Typeahead/Typeahead.tsx
+++ b/src/components/composites/Typeahead/Typeahead.tsx
@@ -57,8 +57,8 @@ export const Typeahead = React.forwardRef(
           const optionKey = getOptionKey
             ? getOptionKey(item)
             : item.id !== undefined
-            ? item.id
-            : optionLabel;
+              ? item.id
+              : optionLabel;
 
           return (
             <Item textValue={optionLabel} key={optionKey}>
@@ -80,14 +80,14 @@ export const Typeahead = React.forwardRef(
 const ComboBoxImplementation = React.forwardRef(
   (props: IComboBoxProps, ref?: any) => {
     const [layoutProps] = extractInObject(props, layoutPropsList);
-    let state = useComboBoxState(props);
+    const state = useComboBoxState(props);
 
-    let triggerRef = React.useRef(null);
-    let inputRef = React.useRef(null);
-    let listBoxRef = React.useRef(null);
-    let popoverRef = React.useRef(null);
+    const triggerRef = React.useRef(null);
+    const inputRef = React.useRef(null);
+    const listBoxRef = React.useRef(null);
+    const popoverRef = React.useRef(null);
 
-    let {
+    const {
       buttonProps: triggerProps,
       inputProps,
       listBoxProps,
@@ -111,7 +111,7 @@ const ComboBoxImplementation = React.forwardRef(
       return props.toggleIcon;
     };
 
-    let { buttonProps } = useButton(triggerProps);
+    const { buttonProps } = useButton(triggerProps);
 
     return (
       <Box flexDirection="row" {...layoutProps} ref={ref}>
@@ -156,9 +156,9 @@ type IListBoxProps = {
 };
 
 function ListBoxPopup(props: IListBoxProps) {
-  let { popoverRef, listBoxRef, state, dropdownHeight, label } = props;
+  const { popoverRef, listBoxRef, state, dropdownHeight, label } = props;
 
-  let { listBoxProps } = useListBox(
+  const { listBoxProps } = useListBox(
     {
       label,
       autoFocus: state.focusStrategy,
@@ -194,12 +194,12 @@ function ListBoxPopup(props: IListBoxProps) {
 function Option({ item, state }: { item: any; state: ComboBoxState<any> }) {
   const searchItemStyle = useThemeProps('TypeAheadSearchItem', {});
 
-  let ref = React.useRef(null);
-  let isDisabled = state.disabledKeys.has(item.key);
-  let isSelected = state.selectionManager.isSelected(item.key);
-  let isFocused = state.selectionManager.focusedKey === item.key;
+  const ref = React.useRef(null);
+  const isDisabled = state.disabledKeys.has(item.key);
+  const isSelected = state.selectionManager.isSelected(item.key);
+  const isFocused = state.selectionManager.focusedKey === item.key;
 
-  let { optionProps } = useOption(
+  const { optionProps } = useOption(
     {
       key: item.key,
       isDisabled,

--- a/src/components/composites/Typeahead/types.ts
+++ b/src/components/composites/Typeahead/types.ts
@@ -16,6 +16,7 @@ export type ITypeaheadProps = IBoxProps & {
 };
 
 export type IComboBoxProps = {
+  menuTrigger?: 'focus' | 'input' | 'manual',
   items: any[];
   renderItem?: (item: any) => any;
   onInputChange?: (value: string) => void;


### PR DESCRIPTION
## Summary
Fix #4042 
Combobox takes an optional menuTrigger property.
Hardcoding the value limited the options available.

## Changelog
[General] [Added] - menuTrigger as an optional enum prop with values `focus`, `input` and `manual`

## Test Plan
Unfortunately, I was not able to run the test suite on my device. Testing seems to be already broken OR maybe there are more steps I need to take to get it to work.
![image](https://user-images.githubusercontent.com/3106368/133628772-ee2d3feb-58d6-406a-a3bc-9d27dc45d047.png)


I derived that Typeahead is an unreleased feature by looking at the changes in Docs for v3.0.7.
That said, I would love to help make a part of this project better.
