### PR TITLE
fix: icon removed when no checked

### DIFF
--- a/src/components/primitives/Checkbox/Checkbox.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.tsx
@@ -9,7 +9,6 @@ import type { ICheckboxProps } from './types';
 import { useToggleState } from '@react-stately/toggle';
 import { CheckboxGroupContext } from './CheckboxGroup';
 import { useCheckbox, useCheckboxGroupItem } from '@react-native-aria/checkbox';
-import { CheckIcon } from '../Icon/Icons';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 import { composeEventHandlers, combineContextAndProps } from '../../../utils';
 import { extractInObject, stylingProps } from '../../../theme/tools/utils';
@@ -18,6 +17,7 @@ import {
   useFocus,
   useIsPressed,
 } from '../../primitives/Pressable/Pressable';
+import SizedIcon from './SizedIcon';
 
 const Checkbox = ({ wrapperRef, ...props }: ICheckboxProps, ref: any) => {
   const { hoverProps, isHovered } = useHover();
@@ -71,15 +71,6 @@ const Checkbox = ({ wrapperRef, ...props }: ICheckboxProps, ref: any) => {
       );
 
   const { checked: isChecked, disabled: isDisabled } = inputProps;
-
-  const sizedIcon = (icon: JSX.Element, _icon: any) =>
-    icon ? (
-      React.cloneElement(icon, {
-        ..._icon,
-      })
-    ) : (
-      <CheckIcon {..._icon} />
-    );
 
   const {
     icon,
@@ -150,7 +141,9 @@ const Checkbox = ({ wrapperRef, ...props }: ICheckboxProps, ref: any) => {
           {/* Interaction Wrapper */}
           <Box {..._interactionBox} p={5} w="100%" height="100%" zIndex={-1} />
           {/* Checkbox */}
-          <Center {...nonLayoutProps}>{sizedIcon(icon, _icon)}</Center>
+          <Center {...nonLayoutProps}>
+            <SizedIcon icon={icon} _icon={_icon} isChecked={isChecked} />
+          </Center>
         </Center>
         {/* Label */}
         {combinedProps.children}

--- a/src/components/primitives/Checkbox/Checkbox.web.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.web.tsx
@@ -11,10 +11,10 @@ import { CheckboxGroupContext } from './CheckboxGroup';
 import { useHover } from '@react-native-aria/interactions';
 import { useCheckbox, useCheckboxGroupItem } from '@react-native-aria/checkbox';
 import { useFocusRing } from '@react-native-aria/focus';
-import { CheckIcon } from '../Icon/Icons';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 import { extractInObject, stylingProps } from '../../../theme/tools/utils';
 import { combineContextAndProps } from '../../../utils';
+import SizedIcon from './SizedIcon';
 
 const Checkbox = ({ wrapperRef, ...props }: ICheckboxProps, ref: any) => {
   const formControlContext = useFormControlContext();
@@ -66,14 +66,6 @@ const Checkbox = ({ wrapperRef, ...props }: ICheckboxProps, ref: any) => {
       );
 
   const { checked: isChecked, disabled: isDisabled } = inputProps;
-  const sizedIcon = (icon: JSX.Element, _icon: any) =>
-    icon ? (
-      React.cloneElement(icon, {
-        ..._icon,
-      })
-    ) : (
-      <CheckIcon {..._icon} />
-    );
 
   const { focusProps, isFocusVisible } = useFocusRing();
 
@@ -133,7 +125,7 @@ const Checkbox = ({ wrapperRef, ...props }: ICheckboxProps, ref: any) => {
         {/* Checkbox */}
         <Center {...nonLayoutProps}>
           {/* {iconResolver()} */}
-          {sizedIcon(icon, _icon)}
+          <SizedIcon icon={icon} _icon={_icon} isChecked={isChecked} />
         </Center>
       </Center>
       {/* Label */}

--- a/src/components/primitives/Checkbox/SizedIcon.tsx
+++ b/src/components/primitives/Checkbox/SizedIcon.tsx
@@ -1,0 +1,26 @@
+import { Box, CheckIcon } from 'native-base';
+import React from 'react';
+
+const SizedIcon = ({
+  icon,
+  _icon,
+  isChecked,
+}: {
+  icon: JSX.Element;
+  _icon: any;
+  isChecked: boolean;
+}) => {
+  return isChecked ? (
+    icon ? (
+      React.cloneElement(icon, {
+        ..._icon,
+      })
+    ) : (
+      <CheckIcon {..._icon} />
+    )
+  ) : (
+    <Box {..._icon} />
+  );
+};
+
+export default SizedIcon;


### PR DESCRIPTION
## Summary
* Checkbox was using a similar component in both native and web platforms. Unified it under a single component.
* Replaced check icon with empty box of similar padding to make sure that the check mark was completely disappearing.
