### PR TITLE
Fix Radio error message when not in Group

### DIFF
--- a/src/components/primitives/Radio/Radio.tsx
+++ b/src/components/primitives/Radio/Radio.tsx
@@ -9,7 +9,11 @@ import { RadioContext } from './RadioGroup';
 import { mergeRefs } from '../../../utils';
 import { CircleIcon } from '../Icon/Icons';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
-import { composeEventHandlers, combineContextAndProps } from '../../../utils';
+import {
+  composeEventHandlers,
+  combineContextAndProps,
+  isEmptyObj,
+} from '../../../utils';
 import { extractInObject, stylingProps } from '../../../theme/tools/utils';
 import {
   useHover,
@@ -32,7 +36,7 @@ const Radio = ({ icon, wrapperRef, size, ...props }: IRadioProps, ref: any) => {
   } = combineContextAndProps(contextState, props);
 
   const inputRef = React.useRef(null);
-  const { inputProps } = useRadio(props, contextState.state, inputRef);
+  const { inputProps } = useRadio(props, contextState.state ?? {}, inputRef);
   const { disabled: isDisabled, checked: isChecked } = inputProps;
 
   const {
@@ -83,6 +87,10 @@ const Radio = ({ icon, wrapperRef, size, ...props }: IRadioProps, ref: any) => {
     '_text',
   ]);
 
+  if (isEmptyObj(contextState)) {
+    console.error('Error: Radio must be wrapped inside a Radio.Group');
+    return <></>;
+  }
   return (
     <Pressable
       {...pressableProps}

--- a/src/components/primitives/Radio/Radio.web.tsx
+++ b/src/components/primitives/Radio/Radio.web.tsx
@@ -11,7 +11,7 @@ import { RadioContext } from './RadioGroup';
 import { useFocusRing } from '@react-native-aria/focus';
 import { CircleIcon } from '../Icon/Icons';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
-import { combineContextAndProps } from '../../../utils';
+import { combineContextAndProps, isEmptyObj } from '../../../utils';
 import { extractInObject, stylingProps } from '../../../theme/tools/utils';
 
 const Radio = (
@@ -30,7 +30,7 @@ const Radio = (
   const inputRef = React.useRef(null);
   const { inputProps } = useRadio(
     { ...props, 'aria-label': props.accessibilityLabel, children },
-    contextState.state,
+    contextState.state ?? {},
     inputRef
   );
   const { disabled: isDisabled, checked: isChecked } = inputProps;
@@ -104,6 +104,12 @@ const Radio = (
   if (useHasResponsiveProps(props)) {
     return null;
   }
+
+  if (isEmptyObj(contextState)) {
+    console.error('Error: Radio must be wrapped inside a Radio.Group');
+    return <></>;
+  }
+
   return (
     <Box
       // @ts-ignore - RN web supports accessibilityRole="label"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,3 +18,4 @@ export type { IAccessibilityProps } from './accessibilityTypes';
 export { ariaAttr } from './accessibilityUtils';
 export { createContext } from './createContext';
 export { useKeyboardBottomInset } from './useKeyboardBottomInset';
+export { isEmptyObj } from './isEmptyObj';

--- a/src/utils/isEmptyObj.ts
+++ b/src/utils/isEmptyObj.ts
@@ -1,0 +1,6 @@
+export function isEmptyObj(obj: Object) {
+  for (var _x in obj) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Add an Error message prompting user to Add Radio.Group whenever Radio is used.