### PR TITLE
hot fixes:  add ref to input when passed in props

### DIFF
--- a/src/components/primitives/Input/Input.tsx
+++ b/src/components/primitives/Input/Input.tsx
@@ -20,8 +20,8 @@ const Input = (props: IInputProps, ref: any) => {
   }
 
   if (props.InputLeftElement || props.InputRightElement)
-    return <InputAdvanced {...props} ref={ref} inputProps={inputProps} />;
-  else return <InputBase {...props} ref={ref} inputProps={inputProps} />;
+    return <InputAdvanced {...props} ref={ref || props.ref} inputProps={inputProps} />;
+  else return <InputBase {...props} ref={ref || props.ref} inputProps={inputProps} />;
 };
 
 export default memo(forwardRef(Input));


### PR DESCRIPTION
Fixes: Issue https://github.com/GeekyAnts/NativeBase/issues/4140

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
- This fixes https://github.com/GeekyAnts/NativeBase/issues/4140
-  Added ref to input when passed in props
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
- Currently input refs can only be passed in as a second parameter and are not deconstructed from the props
- Making it problematic if refs are passed through props


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[GENERAL] [FIXED] - Fix ref not working when passed through props  in Input component
