### PR TITLE
Replace Clipboard with @react-native-clipboard/clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,8 @@
     "lodash.omit": "^4.5.0",
     "lodash.omitby": "^4.6.0",
     "lodash.pick": "^4.4.0",
-    "tinycolor2": "^1.4.2"
+    "tinycolor2": "^1.4.2",
+    "@react-native-clipboard/clipboard":"^1.8.4"
   },
   "directories": {
     "example": "example",

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Clipboard } from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
 
 export function useClipboard() {
   const [hasCopied, setHasCopied] = React.useState(false);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

import {Clipboard} from 'react-native'; is Deprecated. Thus needs to be replaced with a community package

