### PR TITLE
CheckBox: make screen readers recognize correctly

### DIFF
--- a/src/components/primitives/Checkbox/Checkbox.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.tsx
@@ -65,6 +65,9 @@ const Checkbox = ({ wrapperRef, ...props }: ICheckboxProps, ref: any) => {
   } = inputProps;
 
   const {
+    accessibilityLabel,
+    accessibilityRole,
+    accessibilityState,
     icon,
     _interactionBox,
     _icon,
@@ -107,7 +110,9 @@ const Checkbox = ({ wrapperRef, ...props }: ICheckboxProps, ref: any) => {
       // alignItems="flex-start"
       //some input props
       ref={mergeRefs([ref, wrapperRef])}
-      accessibilityRole="checkbox"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole={accessibilityRole}
+      accessibilityState={accessibilityState}
       onPressIn={composeEventHandlers(onPressIn, pressableProps.onPressIn)}
       onPressOut={composeEventHandlers(onPressOut, pressableProps.onPressOut)}
       // @ts-ignore - web only


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
The location to set the `accessibilityState` and `accessibilityLabel` of the `CheckBox` is incorrect. These should be in the parent's `Pressable`. Otherwise, VoiceOver will not be able to read the state and TalkBack will read it in the reverse order.

This PR corrects those deficiencies as much as possible by passing the state received from `react-native-aria` to the parent instead of the child's `Box`.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Allow screen readers to correctly recognize the state of CheckBox components

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I have confirmed by jest that there is no degradation.

### iOS:Before
VoiceOver doesn't announce the state of checkboxes.

https://user-images.githubusercontent.com/40130327/137502192-592217fe-3f8a-436c-a9d0-01dfa9530766.mp4 

### iOS:Fixed
VoiceOver read the state of checkboxes.

https://user-images.githubusercontent.com/40130327/137502343-ec718b13-aa90-4d65-855f-ab2d3e9769b3.mp4

### Android:Before
TalkBack reads the role twice.

https://user-images.githubusercontent.com/40130327/137502613-b1744616-620c-4e30-a0f0-2653615affa1.mp4

### Android:Fixed
TalkBack reads the role only once.

https://user-images.githubusercontent.com/40130327/137502627-8501ed1f-0fd7-4e2b-ada6-09e9ddfb7aea.mp4



