### PR TITLE
Slider: make screen readers recognize correctly

### DIFF
--- a/src/components/primitives/Slider/SliderThumb.tsx
+++ b/src/components/primitives/Slider/SliderThumb.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import { Platform } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import { useSliderThumb } from '@react-native-aria/slider';
 import { VisuallyHidden } from '@react-aria/visually-hidden';
 import { useToken } from '../../../hooks';
@@ -54,6 +54,7 @@ function SliderThumb(props: ISliderThumbProps, ref: any) {
       orientation === 'vertical'
         ? [{ translateY: parseInt(thumbAbsoluteSize) / 2 }]
         : [{ translateX: -parseInt(thumbAbsoluteSize) / 2 }],
+    position: orientation === 'vertical' ? 'absolute' : undefined,
   };
 
   thumbStyles.transform.push({
@@ -64,22 +65,44 @@ function SliderThumb(props: ISliderThumbProps, ref: any) {
     return null;
   }
 
+  const styles = StyleSheet.create({
+    wrapperHorizontal: {
+      width: '100%',
+    },
+    wrapperVertical: {
+      alignItems: 'center',
+      height: '100%',
+      width: thumbSize,
+    },
+  });
+
   return (
     <Box
+      accessible
+      {...inputProps}
       position="absolute"
-      {...thumbProps}
-      {...resolvedProps}
-      ref={ref}
-      style={[thumbStyles, props.style]}
-      // {...(isReadOnly && _readOnly)}
-      // {...(isDisabled && _disabled)}
+      pointerEvents="box-none"
+      style={
+        orientation !== 'vertical'
+          ? styles.wrapperHorizontal
+          : styles.wrapperVertical
+      }
     >
-      {props.children}
-      {Platform.OS === 'web' && (
-        <VisuallyHidden>
-          <input ref={inputRef} {...inputProps} />
-        </VisuallyHidden>
-      )}
+      <Box
+        {...thumbProps}
+        {...resolvedProps}
+        ref={ref}
+        style={[thumbStyles, props.style]}
+        // {...(isReadOnly && _readOnly)}
+        // {...(isDisabled && _disabled)}
+      >
+        {props.children}
+        {Platform.OS === 'web' && (
+          <VisuallyHidden>
+            <input ref={inputRef} {...inputProps} />
+          </VisuallyHidden>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/src/components/primitives/Slider/SliderTrack.tsx
+++ b/src/components/primitives/Slider/SliderTrack.tsx
@@ -44,6 +44,8 @@ const SliderTrack = ({ children, ...props }: ISliderTrackProps, ref?: any) => {
 
   return (
     <Pressable
+      accessible={false}
+      importantForAccessibility={'no-hide-descendants'}
       onLayout={onTrackLayout}
       ref={ref}
       {...trackProps}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Since `SliderTrack` is Pressable, screen readers focus on SliderTrack instead of SliderThumb. However, SliderTrack has no control over slider values.
This PR connects react-native-aria's inputProps to SliderThumb and allows screen readers to access the slider.

In addition to this PR, the issue also need to fix https://github.com/GeekyAnts/react-native-aria/pull/23 due to a bug in the behavior of react-native-aria.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Allow screen readers to correctly recognize the state of Slider components

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

### Android: Before
https://user-images.githubusercontent.com/40130327/137680442-59d51d92-cdc9-4b81-89fb-f8a1d41d3477.mp4

### Android: Fixed
https://user-images.githubusercontent.com/40130327/137680458-33397227-877e-445b-a1f6-299e879e528c.mp4

### iOS: Before
https://user-images.githubusercontent.com/40130327/137680381-ffa50dfe-77ea-4673-a99e-bdb56ba3b73f.mp4

### iOS: Fixed
https://user-images.githubusercontent.com/40130327/137680364-103f1519-3339-4620-98f1-02debcd0d3e6.mp4


