### PR TITLE
Image: make voiceover recognize correctly

### DIFF
--- a/src/components/primitives/Image/index.tsx
+++ b/src/components/primitives/Image/index.tsx
@@ -76,6 +76,8 @@ const Image = (props: IImageProps, ref: any) => {
   return (
     <StyledImage
       source={renderedSource}
+      accessible={!!alt}
+      accessibilityRole="image"
       accessibilityLabel={alt}
       alt={alt}
       {...resolvedProps}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
VoiceOver cannot focus an Image because it is not `accessible`. Also, it does not have a roll.
This PR fixes the problem.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Image: make voiceover recognize correctly

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

### iOS: Before
https://user-images.githubusercontent.com/40130327/137686268-b8d590e4-3ee5-4648-bcce-de806a844a02.mp4

### iOS: Fixed
https://user-images.githubusercontent.com/40130327/137686108-c267a91f-8a80-4ab3-8dce-9719019c4853.mp4


