### PR TITLE
Modal: Makes the component under the modal out of focus

### DIFF
--- a/src/components/primitives/Overlay/Overlay.tsx
+++ b/src/components/primitives/Overlay/Overlay.tsx
@@ -45,7 +45,7 @@ export function Overlay({
 
   // Since OverlayContainer mounts children in NativeBaseProvider  using Context, we need to pass the context by wrapping children
   return (
-    <OverlayContainer>
+    <OverlayContainer accessibilityViewIsModal>
       <ExitAnimationContext.Provider value={{ exited, setExited }}>
         {children}
       </ExitAnimationContext.Provider>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fixes an issue where screen readers could access components under modals on iOS.
For Android, we use the `Modal` component, so this issue does not occur.

This PR affects components such as `AlertDialog` and `ActionSheet`.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Modal: Makes the component under the modal out of focus

## Test Plan

### Before
https://user-images.githubusercontent.com/40130327/137688581-f1ee7b34-8103-4bdc-a481-14620b952069.mp4

### Fixed
https://user-images.githubusercontent.com/40130327/137688595-5ff1ca68-705c-48a8-aa41-2bb0eeb91103.mp4


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
