### PR TITLE
fix: add missing _checked property in Radio component

### DIFF
--- a/src/components/primitives/Radio/types.tsx
+++ b/src/components/primitives/Radio/types.tsx
@@ -28,6 +28,10 @@ export interface IRadioProps extends IBoxProps<IRadioProps> {
    */
   isInvalid?: boolean;
   /**
+   * Passed props will be applied on checked state.
+   */
+  _checked?: Omit<Partial<IRadioProps>, '_checked'>;
+  /**
    * 	The size (width and height) of the radio.
    */
 

--- a/src/components/primitives/Radio/types.tsx
+++ b/src/components/primitives/Radio/types.tsx
@@ -1,4 +1,4 @@
-import type { IBoxProps } from '../../primitives';
+import type { IBoxProps, IIconProps } from '../../primitives';
 import type { IFormControlContext } from '../../composites';
 import type { AccessibilityRole } from 'react-native';
 import type { RadioGroupState } from '@react-stately/radio';
@@ -31,6 +31,10 @@ export interface IRadioProps extends IBoxProps<IRadioProps> {
    * Passed props will be applied on checked state.
    */
   _checked?: Omit<Partial<IRadioProps>, '_checked'>;
+   /**
+   * Passed props will be applied to icon.
+   */
+  _icon?: IIconProps;
   /**
    * 	The size (width and height) of the radio.
    */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Add _checked property in radio component

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

_checked property is not defined in Radio/types.tsx file

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[TYPESCRIPT] [RADIO] - Add missing _checked property in type

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
