### PR TITLE
fix: added textAlign property for VStack

### DIFF
--- a/src/theme/styled-system.ts
+++ b/src/theme/styled-system.ts
@@ -102,6 +102,7 @@ export const layout = {
   overflowY: true,
   display: true,
   verticalAlign: true,
+  textAlign: true,
 } as const;
 
 export const flexbox = {


### PR DESCRIPTION
Use: Please check line no. 152 in https://github.com/GeekyAnts/nativebase-v3-examples/blob/master/example-apps/responsive-dashboard/src/screens/dashboard.tsx