### PR TITLE
[FIX] Invalid prop flex of type string supplied to StyleSheet box, ex…

### DIFF
--- a/src/components/primitives/Box/index.tsx
+++ b/src/components/primitives/Box/index.tsx
@@ -89,6 +89,9 @@ const Box = ({ children, ...props }: IBoxProps, ref: any) => {
       );
     }
   }
+
+  if (safeAreaProps?.flex?.base) { safeAreaProps.flex = 1 }
+
   return (
     <StyledBox ref={ref} {...safeAreaProps}>
       {React.Children.map(children, (child) => {

--- a/src/hooks/useThemeProps/usePropsResolution.tsx
+++ b/src/hooks/useThemeProps/usePropsResolution.tsx
@@ -162,7 +162,7 @@ export const usePropsResolutionWithComponentTheme = (
 
   const incomingWithDefaultProps = merge(
     {},
-    componentTheme.defaultProps || {},
+    componentTheme?.defaultProps || {},
     cleanIncomingProps
   );
   // STEP 2: flatten them
@@ -199,7 +199,7 @@ export const usePropsResolutionWithComponentTheme = (
   let componentBaseStyle = {},
     flattenBaseStyle,
     baseSpecificityMap;
-  if (componentTheme.baseStyle) {
+  if (componentTheme?.baseStyle) {
     componentBaseStyle =
       typeof componentTheme.baseStyle !== 'function'
         ? componentTheme.baseStyle


### PR DESCRIPTION
## Summary

Error on `➜  NativeBase git:(master) vim src/components/primitives/Box/index.tsx`
Due to flex being passed wrong data. It makes Box brake on iPad.

<img width="1409" alt="image" src="https://user-images.githubusercontent.com/1785392/138145510-65f51666-22fa-41a3-bbdc-dccc84e561dc.png">

## Changelog

Box now receives correct parameter when called on iPad.

[CATEGORY] [TYPE] - Message

## Test Plan

* Use Box on iPad, it brakes, use this branch it fixes.
* console.log `safeAreaProps` on src/components/primitives/Box/index.tsx:93 to see wrong argument being passed
