### PR TITLE
Update Select.tsx

### DIFF
--- a/src/components/primitives/Select/Select.tsx
+++ b/src/components/primitives/Select/Select.tsx
@@ -80,6 +80,7 @@ const Select = ({ wrapperRef, ...props }: ISelectProps, ref: any) => {
     (child: any) => {
       return {
         label: child.props.label,
+        selectedLabel: child.props.label,
         value: child.props.value,
       };
     }
@@ -129,7 +130,7 @@ const Select = ({ wrapperRef, ...props }: ISelectProps, ref: any) => {
     <Input
       aria-hidden={true}
       importantForAccessibility="no"
-      value={selectedItem?.label}
+      value={selectedItem?.selectedLabel ?? selectedItem?.label}
       placeholder={placeholder}
       editable={false}
       focusable={false}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I was attempting to style the label prop for Select.Item as such...to do something like this...

![Screenshot_20211031_010158](https://user-images.githubusercontent.com/963657/139554060-911e7806-ac6c-4b72-bc55-2648de0b6a08.jpg)


```
        <Select
          selectedValue={selectedAsset}
          color="blue.700"
          onValueChange={val => setSelectedAsset(val)}
          variant="native"
          minWidth="200"
          placeholder="Choose Asset">
          {Object.keys(balances).map((asset, idx) => {
            const key = `${asset}_${idx}`
            return (
              <Select.Item
                leftIcon={<TickerLogos name={asset} size={30} />}
                key={key}
                label={
                  <Box pl={5} flexDirection="row" width={width}>
                    <Text flex={1}>{asset}</Text>
                    <Text flex={1}>
                      {balances[asset].balanceAvailableDisplay}
                    </Text>
                  </Box>
                }
                selectedLabel={asset}
                value={asset}
              />
            )
          })}
        </Select>
```

However, an error occurred since <Select> uses the "label" prop from <Select.Item> as it's value (<Select> is merely an <Input> underneath the hood -- as you know) and expects a `string`.  In order to further expand the capabilities of <Select> with full backwards compatibility, I added an optional prop to <Select.Item> called "selectLabel" which will be displayed as the value for <Select> instead of "label" if the prop "selectLabel" is not undefined.  Otherwise, it will display what is in the "label" prop.

## Changelog

Added an extra prop to itemsList and changed the Input value to display "selectLabel" prop if not undefined, else just display the normal "label" props.

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
