### PR TITLE
Use 'Courier New' on iOS

### DIFF
--- a/src/components/composites/Code/index.tsx
+++ b/src/components/composites/Code/index.tsx
@@ -14,7 +14,7 @@ const Code = ({ ...props }: ICodeProps, ref?: any) => {
   return (
     <Box
       _text={{
-        fontFamily: Platform.OS === 'ios' ? 'Courier' : 'monospace',
+        fontFamily: Platform.OS === 'ios' ? 'Courier New' : 'monospace',
       }}
       {...newProps}
       ref={ref}

--- a/src/theme/components/code.ts
+++ b/src/theme/components/code.ts
@@ -5,7 +5,7 @@ const { variants, defaultProps } = Badge;
 
 const baseStyle = {
   _text: {
-    fontFamily: Platform.OS === 'ios' ? 'Courier' : 'monospace',
+    fontFamily: Platform.OS === 'ios' ? 'Courier New' : 'monospace',
     fontSize: 'sm',
   },
   borderRadius: 'sm',

--- a/src/theme/components/kbd.ts
+++ b/src/theme/components/kbd.ts
@@ -13,7 +13,7 @@ function baseStyle(props: Record<string, any>) {
     _text: {
       fontSize: 'sm',
       fontWeight: 'bold',
-      fontFamily: Platform.OS === 'ios' ? 'Courier' : 'monospace',
+      fontFamily: Platform.OS === 'ios' ? 'Courier New' : 'monospace',
     },
   };
 }


### PR DESCRIPTION
## Summary

The Courier font was removed in iOS 15. 'Courier New' is available since iPhone OS 3.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

- [iOS] [Fixed] - Use 'Courier New' font in `Code` and `Kbd` components

## Test Plan

```js
import { Code } from 'native-base'

<Code>App.tsx</Code>
```

## Workaround

Currently, you have to specify font family like so:

```js
<Code _text={{ fontFamily: 'Courier New' }}>App.tsx</Code>
```