### PR TITLE
Fix V2 | Change removeEventLister to remove in ToastContainer

### DIFF
--- a/src/basic/ToastContainer.js
+++ b/src/basic/ToastContainer.js
@@ -5,7 +5,7 @@ import {
   Platform,
   Animated,
   ViewPropTypes,
-  PanResponder,
+  PanResponder
 } from 'react-native';
 import { connectStyle } from 'native-base-shoutem-theme';
 
@@ -19,7 +19,7 @@ import { Toast } from './Toast';
 const POSITION = {
   ABSOLUTE: 'absolute',
   BOTTOM: 'bottom',
-  TOP: 'top',
+  TOP: 'top'
 };
 
 class ToastContainer extends Component {
@@ -39,7 +39,7 @@ class ToastContainer extends Component {
       pan: new Animated.ValueXY({ x: 0, y: 0 }),
       keyboardHeight: 0,
       isKeyboardVisible: false,
-      modalVisible: false,
+      modalVisible: false
     };
 
     this.keyboardDidHide = this.keyboardDidHide.bind(this);
@@ -54,7 +54,7 @@ class ToastContainer extends Component {
             useNativeDriver: false
           }).start(() => this.closeToast('swipe'));
         }
-      },
+      }
     });
   }
 
@@ -64,8 +64,8 @@ class ToastContainer extends Component {
   }
 
   componentWillUnmount() {
-    Keyboard.removeListener('keyboardDidShow', this.keyboardDidShow);
-    Keyboard.removeListener('keyboardDidHide', this.keyboardDidHide);
+    this.keyboardDidShowSub && this.keyboardDidShowSub.remove();
+    this.keyboardDidShowSub && this.keyboardDidHideSub.remove();
   }
 
   getToastStyle() {
@@ -77,7 +77,7 @@ class ToastContainer extends Component {
       paddingHorizontal: Platform.OS === PLATFORM.IOS ? 20 : 0,
       top: this.state.position === POSITION.TOP ? 30 : undefined,
       bottom:
-        this.state.position === POSITION.BOTTOM ? this.getTop() : undefined,
+        this.state.position === POSITION.BOTTOM ? this.getTop() : undefined
     };
   }
 
@@ -109,14 +109,14 @@ class ToastContainer extends Component {
   keyboardDidHide() {
     this.setState({
       keyboardHeight: 0,
-      isKeyboardVisible: false,
+      isKeyboardVisible: false
     });
   }
 
   keyboardDidShow(e) {
     this.setState({
       keyboardHeight: e.endCoordinates.height,
-      isKeyboardVisible: true,
+      isKeyboardVisible: true
     });
   }
 
@@ -151,12 +151,12 @@ class ToastContainer extends Component {
     Animated.timing(this.state.fadeAnim, {
       toValue: 1,
       duration: 200,
-      useNativeDriver: false,
+      useNativeDriver: false
     }).start();
   }
-  closeModal = (reason) => {
+  closeModal = reason => {
     this.setState({
-      modalVisible: false,
+      modalVisible: false
     });
     const { onClose } = this.state;
     if (onClose && typeof onClose === 'function') {
@@ -168,7 +168,7 @@ class ToastContainer extends Component {
     Animated.timing(this.state.fadeAnim, {
       toValue: 0,
       duration: 200,
-      useNativeDriver: false,
+      useNativeDriver: false
     }).start(() => {
       this.closeModal(reason);
       this.state.pan.setValue({ x: 0, y: 0 });
@@ -180,10 +180,10 @@ class ToastContainer extends Component {
       const { x, y } = this.state.pan;
       return (
         <Animated.View
-          {...this.state.swipeDisabled ? {} : this._panResponder.panHandlers}
+          {...(this.state.swipeDisabled ? {} : this._panResponder.panHandlers)}
           style={[
             this.getToastStyle(),
-            { transform: [{ translateX: x }, { translateY: y }] },
+            { transform: [{ translateX: x }, { translateY: y }] }
           ]}
         >
           <Toast
@@ -212,7 +212,7 @@ class ToastContainer extends Component {
 }
 
 ToastContainer.propTypes = {
-  ...ViewPropTypes,
+  ...ViewPropTypes
 };
 
 const StyledToastContainer = connectStyle(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
This PR solves an issue with the ToastContainer https://github.com/GeekyAnts/NativeBase/issues/4009. The Keyboard component calls `removeListener` which [has been deprecated](https://reactnative.dev/docs/0.65/keyboard#removelistener) in RN v0.65. 

It's been changed to use the `remove()` method on the event subscription as suggested in the documentation.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Fix red box message by using `remove` to unsubscribe the event 
