### PR TITLE
Fix: AspectRatio example breaking Docs build

### DIFF
--- a/example/storybook/stories/components/composites/AspectRatio/Basic.tsx
+++ b/example/storybook/stories/components/composites/AspectRatio/Basic.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { AspectRatio, Box } from 'native-base';
 
-const Example = () => {
+export const Example = () => {
   return (
     <AspectRatio height={200} ratio={{ base: 4 / 3, md: 16 / 9 }}>
       <Box bg="red.400" />
     </AspectRatio>
   );
 };
-
-export default Example;

--- a/example/storybook/stories/components/composites/AspectRatio/EmbedImage.tsx
+++ b/example/storybook/stories/components/composites/AspectRatio/EmbedImage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AspectRatio, Image } from 'native-base';
-const Example = () => {
+export const Example = () => {
   return (
     <AspectRatio
       ratio={{ base: 3 / 4, md: 9 / 10 }}
@@ -17,4 +17,3 @@ const Example = () => {
     </AspectRatio>
   );
 };
-export default Example;

--- a/example/storybook/stories/components/composites/AspectRatio/index.tsx
+++ b/example/storybook/stories/components/composites/AspectRatio/index.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { withKnobs } from '@storybook/addon-knobs';
 import Wrapper from './../../Wrapper';
-import Basic from './Basic';
-import EmbedImage from './EmbedImage';
+import { Example as Basic } from './Basic';
+import { Example as EmbedImage } from './EmbedImage';
 
 storiesOf('AspectRatio', module)
   .addDecorator(withKnobs)


### PR DESCRIPTION
This PR fixes issue with docs build automation that is caused due to aspect ratio example.