### PR TITLE
Added disableDynamicWidth option to avoid screen orientation from propagating many state changes.

### DIFF
--- a/src/core/NativeBaseProvider.tsx
+++ b/src/core/NativeBaseProvider.tsx
@@ -16,7 +16,7 @@ import {
   NativeBaseConfigProvider,
 } from './NativeBaseContext';
 import { useToast } from '../components/composites/Toast';
-import { Platform, useWindowDimensions } from 'react-native';
+import { Platform, useWindowDimensions, Dimensions } from 'react-native';
 import {
   getClosestBreakpoint,
   platformSpecificSpaceUnits,
@@ -63,7 +63,7 @@ const NativeBaseProvider = (props: NativeBaseProviderProps) => {
     return theme;
   }, [config.enableRem, theme]);
 
-  const windowWidth = useWindowDimensions()?.width;
+  const windowWidth = theme.disableDynamicWidth ? Dimensions.get('window').width : useWindowDimensions()?.width;
 
   const currentBreakpoint = React.useMemo(
     () => getClosestBreakpoint(newTheme.breakpoints, windowWidth),

--- a/src/hooks/useThemeProps/useProps.tsx
+++ b/src/hooks/useThemeProps/useProps.tsx
@@ -1,6 +1,6 @@
 import get from 'lodash.get';
 import omit from 'lodash.omit';
-import { useWindowDimensions, Platform } from 'react-native';
+import { useWindowDimensions, Platform, Dimensions } from 'react-native';
 import { useNativeBase } from './../useNativeBase';
 import { omitUndefined, extractInObject } from './../../theme/tools/';
 import { filterShadowProps } from './../../utils/filterShadowProps';
@@ -41,7 +41,8 @@ export function useThemeProps(component: string, propsReceived: any) {
 
   const componentTheme = get(theme, `components.${component}`);
   // console.log('COMPONENT THEME = ', componentTheme);
-  const windowWidth = useWindowDimensions()?.width;
+  const windowWidth = theme.disableDynamicWidth ? Dimensions.get('window').width : useWindowDimensions()?.width;
+
 
   // To pass the component theme props and component props seperately
   return filterAndCalculateProps(

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -18,6 +18,7 @@ const config: ColorModeOptions = {
 
 const theme = {
   ...base,
+  disableDynamicWidth: false,
   components,
   config,
 };


### PR DESCRIPTION
## Summary

Screen orientation that changes the window's width will propagate breakpoint calculation + theme sizing.

This is expected: however, this can cause very laggy behavior if dynamic breakpoints/sizing is not necessary.

## Changelog

[Fixes][Performance] - Added `disableDynamicWidth` theme option to disable dynamic breakpoint calculation that can cause performance issues with screen orientation

## Test Plan

I've tested this on my local device and DOM updates are much faster when switching between landscape/portrait.
