### PR TITLE
fix: typing color by custom themes

### DIFF
--- a/src/components/primitives/Box/types.ts
+++ b/src/components/primitives/Box/types.ts
@@ -1,10 +1,10 @@
 import type { ViewProps } from 'react-native';
 import type { StyledProps } from '../../../theme/types';
-import type { IColors } from '../../../theme/base/colors';
 import type {
   SafeAreaProps,
   PlatformProps,
   ResponsiveValue,
+  ColorType,
 } from '../../types';
 import type { ITextProps } from './../Text/types';
 
@@ -34,10 +34,12 @@ export interface IBoxProps<T = null>
    * For providing props to Text inside Box
    */
   _text?: ITextProps;
-  bg?: ResponsiveValue<IColors | (string & {}) | ILinearGradientProps>;
-  background?: ResponsiveValue<IColors | (string & {}) | ILinearGradientProps>;
-  bgColor?: ResponsiveValue<IColors | (string & {}) | ILinearGradientProps>;
+  bg?: ResponsiveValue<ColorType | (string & {}) | ILinearGradientProps>;
+  background?: ResponsiveValue<
+    ColorType | (string & {}) | ILinearGradientProps
+  >;
+  bgColor?: ResponsiveValue<ColorType | (string & {}) | ILinearGradientProps>;
   backgroundColor?: ResponsiveValue<
-    IColors | (string & {}) | ILinearGradientProps
+    ColorType | (string & {}) | ILinearGradientProps
   >;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Typing adjustment for custom themes

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Typing color by custom themes

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

When creating a custom theme, the color token was not received by auto complete
