### PR TITLE
fix: update IRadioGroupProps to have name as optional

### DIFF
--- a/src/components/primitives/Radio/types.tsx
+++ b/src/components/primitives/Radio/types.tsx
@@ -50,7 +50,7 @@ export interface IRadioGroupProps extends IBoxProps<IRadioGroupProps> {
   /**
    * The name of the input field in a radio (Useful for form submission).
    */
-  name: string;
+  name?: string;
   /**
    * The initial value of the radio group.
    */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

name is required and it should be optional 

when using with react-hook-form is can be optional  ex:
```js
      <Controller
        name={data.id}
        control={control}
        render={({ field: { value, onChange } }) => (
          <Radio.Group value={value} onChange={onChange}>
            {options?.map((option) => (
              <Radio key={option.aid} value={option.aid} my='1'>
                {option.label}
              </Radio>
            ))}
          </Radio.Group>
        )}
      />
    );
```
 the ``` Controller ``` component going to handle the name
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

update IRadioGroupProps to have ```name```  as optional

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - update ```IRadioGroupProps``` to have ```name```  as optional

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
