### PR TITLE
fix: info toast long title

### DIFF
--- a/src/components/composites/Toast/Toast.tsx
+++ b/src/components/composites/Toast/Toast.tsx
@@ -271,15 +271,15 @@ export const ToastProvider = ({ children }: { children: any }) => {
           <Alert
             maxWidth="100%"
             alignSelf="center"
+            flexDirection="row"
             status={status ?? 'info'}
             variant={variant as any}
             accessibilityLiveRegion={accessibilityLiveRegion}
             {...rest}
           >
-            <VStack space={1} flexShrink={1} w="100%">
+            <VStack space={1} flexShrink={1}>
               <HStack
                 flexShrink={1}
-                space={2}
                 alignItems="center"
                 justifyContent="space-between"
               >
@@ -289,6 +289,7 @@ export const ToastProvider = ({ children }: { children: any }) => {
                     fontSize="md"
                     fontWeight="medium"
                     color={getTextColor(variant ?? 'subtle')}
+                    flexShrink={1}
                   >
                     {title}
                   </Text>

--- a/src/components/composites/Toast/Toast.tsx
+++ b/src/components/composites/Toast/Toast.tsx
@@ -277,7 +277,7 @@ export const ToastProvider = ({ children }: { children: any }) => {
             accessibilityLiveRegion={accessibilityLiveRegion}
             {...rest}
           >
-            <VStack space={1} flexShrink={1}>
+            <VStack space={1} flexShrink={1} w="100%">
               <HStack
                 flexShrink={1}
                 alignItems="center"


### PR DESCRIPTION
## Summary
Info Icon and close button was going out of the screen for android and ios device when title of the info toast is long.


