### PR TITLE
fix: checkbox hover overlapping

### DIFF
--- a/src/components/primitives/Checkbox/Checkbox.web.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.web.tsx
@@ -132,6 +132,7 @@ const CheckboxComponent = React.memo(
           {...layoutProps}
           opacity={isDisabled ? 0.4 : 1}
           cursor={isDisabled ? 'not-allowed' : 'pointer'}
+          p={3}
         >
           <Center>
             {/* Interaction Box */}
@@ -143,7 +144,6 @@ const CheckboxComponent = React.memo(
               }}
               h={isFocusVisible || isHovered ? '200%' : '0%'}
               w={isFocusVisible || isHovered ? '200%' : '0%'}
-              pointerEvents="none"
               zIndex={-1}
             />
             {/* Checkbox */}


### PR DESCRIPTION
## Summary
The reason for this behaviour is due to the natural stacking order on the webpage. In DOM, the elements are rendered one over the other.  When they are very close to each other, on hovering the size of interaction box increases and overlap with other components making them inaccessible.

Possible Solutions:

- Add default `margin`/`padding` - Checkbox will never be too close and will avoid overlapping. 

- Disable `pointer-events` on interaction box - This will decrease the touchable area around checkbox, making it difficult to access. 

## Changelog

Added default `padding` to the Checkbox component, following the accessibility practices. 


