### PR TITLE
fix: isDisabled disable radio in form control component

### DIFF
--- a/src/components/primitives/Radio/Radio.tsx
+++ b/src/components/primitives/Radio/Radio.tsx
@@ -20,6 +20,7 @@ import {
   useFocus,
   useIsPressed,
 } from '../../primitives/Pressable/Pressable';
+import { useFormControlContext } from '../../composites/FormControl';
 
 const RadioComponent = memo(
   forwardRef(
@@ -136,9 +137,10 @@ const Radio = (
   { icon, children, size, wrapperRef, ...props }: IRadioProps,
   ref: any
 ) => {
+  const formControlContext = useFormControlContext();
   const contextState = React.useContext(RadioContext);
 
-  const combinedProps = combineContextAndProps(contextState, props);
+  const combinedProps = combineContextAndProps(formControlContext, props);
 
   const inputRef = React.useRef(null);
   const radioState = useRadio(

--- a/src/components/primitives/Radio/Radio.web.tsx
+++ b/src/components/primitives/Radio/Radio.web.tsx
@@ -13,6 +13,7 @@ import { CircleIcon } from '../Icon/Icons';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 import { combineContextAndProps, isEmptyObj } from '../../../utils';
 import { extractInObject, stylingProps } from '../../../theme/tools/utils';
+import { useFormControlContext } from '../../composites/FormControl';
 
 const RadioComponent = memo(
   forwardRef(
@@ -118,9 +119,10 @@ const Radio = (
   { icon, children, wrapperRef, ...props }: IRadioProps,
   ref: any
 ) => {
+  const formControlContext = useFormControlContext();
   const contextState = React.useContext(RadioContext);
 
-  const combinedProps = combineContextAndProps(contextState, props);
+  const combinedProps = combineContextAndProps(formControlContext, props);
 
   const inputRef = React.useRef(null);
   const radioState = useRadio(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

isDisabled as prop in FormControl was not disabling radio button

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
