### PR TITLE
Make `Modal` transition direction configurable

### DIFF
--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -27,6 +27,7 @@ const Modal = (
     backdropVisible = true,
     //@ts-ignore - internal purpose only
     animationPreset = 'fade',
+    transitionDirection = 'bottom',
     ...rest
   }: IModalProps,
   ref: any
@@ -98,7 +99,12 @@ const Modal = (
           )}
         </Fade>
         {animationPreset === 'slide' ? (
-          <Slide in={visible} overlay={false} duration={200}>
+          <Slide
+            in={visible}
+            overlay={false}
+            duration={200}
+            placement={transitionDirection}
+          >
             <FocusScope
               contain={visible}
               autoFocus={visible && !initialFocusRef}

--- a/src/components/composites/Modal/types.ts
+++ b/src/components/composites/Modal/types.ts
@@ -65,6 +65,10 @@ export interface IModalProps extends IBoxProps<IModalProps> {
    * @default "fade"
    */
   animationPreset?: 'fade' | 'slide';
+  /**
+   * Transition Direction of Modal
+   */
+  transitionDirection?: 'top' | 'bottom' | 'right' | 'left';
 }
 
 export type IModalComponentType = ((


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Make `Modal` able to slide from other direction.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

For some reason, we want `Modal` slide from other direction, i.e. `right`, like a drawer. Also we can build our own `Drawer` on top of `Modal` with this ability. 

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Added] - Add `transitionDirection` prop to `Modal`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
