### PR TITLE
Feature/#4513

### DIFF
--- a/example/storybook/stories/components/composites/Actionsheet/CustomSlideDuration.tsx
+++ b/example/storybook/stories/components/composites/Actionsheet/CustomSlideDuration.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Button, Actionsheet, useDisclose, Box, Text } from 'native-base';
+
+export function Example() {
+  const { isOpen, onOpen, onClose } = useDisclose();
+  return (
+    <>
+      <Button onPress={onOpen}>Actionsheet</Button>
+      <Actionsheet
+        isOpen={isOpen}
+        onClose={onClose}
+        slideDuration={1000}
+        hideDragIndicator
+      >
+        <Actionsheet.Content borderTopRadius="0">
+          <Box w="100%" h={60} px={4} justifyContent="center">
+            <Text fontSize="16" color="gray.500" _dark={{ color: 'gray.300' }}>
+              Albums
+            </Text>
+          </Box>
+          <Actionsheet.Item>Delete</Actionsheet.Item>
+          <Actionsheet.Item>Share</Actionsheet.Item>
+          <Actionsheet.Item>Play</Actionsheet.Item>
+          <Actionsheet.Item>Favourite</Actionsheet.Item>
+          <Actionsheet.Item>Cancel</Actionsheet.Item>
+        </Actionsheet.Content>
+      </Actionsheet>
+    </>
+  );
+}

--- a/example/storybook/stories/components/composites/Actionsheet/index.tsx
+++ b/example/storybook/stories/components/composites/Actionsheet/index.tsx
@@ -7,6 +7,7 @@ import { Example as Usage } from './Usage';
 import { Example as Composition } from './Composition';
 import { Example as DisableOverlay } from './DisableOverlay';
 import { Example as CustomBackdrop } from './CustomBackdrop';
+import { Example as CustomSlideDuration } from './CustomSlideDuration';
 
 storiesOf('Actionsheet', module)
   .addDecorator(withKnobs)
@@ -15,4 +16,5 @@ storiesOf('Actionsheet', module)
   .add('Icon', () => <Icon />)
   .add('DisableOverlay', () => <DisableOverlay />)
   .add('Composition', () => <Composition />)
-  .add('Custom Backdrop', () => <CustomBackdrop />);
+  .add('Custom Backdrop', () => <CustomBackdrop />)
+  .add('Custom Slide Duration', () => <CustomSlideDuration />);

--- a/src/components/composites/Actionsheet/Actionsheet.tsx
+++ b/src/components/composites/Actionsheet/Actionsheet.tsx
@@ -6,7 +6,12 @@ import { ActionSheetContext } from './ActionSheetContext';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 
 const Actionsheet = (
-  { children, hideDragIndicator = false, ...props }: IActionsheetProps,
+  {
+    children,
+    slideDuration = 200,
+    hideDragIndicator = false,
+    ...props
+  }: IActionsheetProps,
   ref: any
 ) => {
   const {
@@ -27,6 +32,7 @@ const Actionsheet = (
       justifyContent="flex-end"
       //@ts-ignore - internal use only
       animationPreset="slide"
+      slideDuration={slideDuration}
       {...resolvedProps}
       overlayVisible={disableOverlay ? false : true}
       closeOnOverlayClick={disableOverlay ? false : true}

--- a/src/components/composites/Actionsheet/types.tsx
+++ b/src/components/composites/Actionsheet/types.tsx
@@ -25,6 +25,11 @@ export interface IActionsheetProps extends IBoxProps<IActionsheetProps> {
    * Props applied on Overlay.
    */
   _backdrop?: any;
+  /**
+   * slide animation duration
+   * @default 200
+   */
+  slideDuration?: number;
 }
 
 export interface IActionsheetContentProps

--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -27,6 +27,9 @@ const Modal = (
     backdropVisible = true,
     //@ts-ignore - internal purpose only
     animationPreset = 'fade',
+    entryDuration = 200,
+    exitDuration = 150,
+    slideDuration = 200,
     ...rest
   }: IModalProps,
   ref: any
@@ -83,8 +86,8 @@ const Modal = (
     >
       <ModalContext.Provider value={contextValue}>
         <Fade
-          exitDuration={150}
-          entryDuration={200}
+          exitDuration={exitDuration}
+          entryDuration={entryDuration}
           in={visible}
           style={StyleSheet.absoluteFill}
         >
@@ -98,7 +101,7 @@ const Modal = (
           )}
         </Fade>
         {animationPreset === 'slide' ? (
-          <Slide in={visible} overlay={false} duration={200}>
+          <Slide in={visible} overlay={false} duration={slideDuration}>
             <FocusScope
               contain={visible}
               autoFocus={visible && !initialFocusRef}
@@ -109,8 +112,8 @@ const Modal = (
           </Slide>
         ) : (
           <Fade
-            exitDuration={100}
-            entryDuration={200}
+            exitDuration={exitDuration}
+            entryDuration={entryDuration}
             in={visible}
             style={StyleSheet.absoluteFill}
           >

--- a/src/components/composites/Modal/types.ts
+++ b/src/components/composites/Modal/types.ts
@@ -65,6 +65,21 @@ export interface IModalProps extends IBoxProps<IModalProps> {
    * @default "fade"
    */
   animationPreset?: 'fade' | 'slide';
+  /**
+   * Sets the fade entry duration
+   * @default 200
+   */
+  entryDuration?: number;
+  /**
+   * Sets the fade exit duration
+   * @default 150
+   */
+  exitDuration?: number;
+  /**
+   * Sets the slide animation duration
+   * @default 200
+   */
+  slideDuration?: number;
 }
 
 export type IModalComponentType = ((


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR addresses the inability to alter animation durations on both Modal and ActionSheet components. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS/Android/Web] [Added] - entryDuration/exitDuration/slideDuration props added to Modal/ActionSheet to allow for customization of these properties.

## Test Plan

yarn example start -> navigator -> select 'CustomSlideDuration' story under 'ActionSheet'.
