### PR TITLE
fix: infinite loop in Image component

### DIFF
--- a/example/storybook/stories/components/primitives/Image/Sizes.tsx
+++ b/example/storybook/stories/components/primitives/Image/Sizes.tsx
@@ -8,6 +8,7 @@ export function Example() {
         <VStack space={2} alignItems="center" safeAreaTop my={6}>
           {['xs', 'sm', 'md', 'lg', 'xl', '2xl'].map((size) => (
             <Image
+              key={size}
               size={size}
               resizeMode="cover"
               source={{

--- a/src/components/primitives/Image/index.tsx
+++ b/src/components/primitives/Image/index.tsx
@@ -28,7 +28,8 @@ const Image = (props: IImageProps, ref: any) => {
       finalSource.current = { uri: src };
     }
     return finalSource.current;
-  }, [source, src]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [source?.uri, src]);
 
   const [renderedSource, setSource] = useState(getSource());
   const [alternate, setAlternate] = useState(false);
@@ -39,7 +40,7 @@ const Image = (props: IImageProps, ref: any) => {
     return () => {
       finalSource.current = null;
     };
-  }, [source, src, getSource]);
+  }, [source?.uri, src, getSource]);
 
   const onImageLoadError = useCallback(
     (event: any) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fix infinite loop in Image component
[This fix](https://github.com/GeekyAnts/NativeBase/pull/4529) is causing infinite loop in Image component when source is changed.
You can see the error in the example of `Image/FallbackSupport` in storybook.
I found this issue when I was using Modal to display Image in react native by passing source via props when it is opened.

this is the error
```
Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
