### PR TITLE
fix: firefox input component

### DIFF
--- a/src/components/primitives/Input/InputBase.tsx
+++ b/src/components/primitives/Input/InputBase.tsx
@@ -126,6 +126,7 @@ const InputBase = (
           }
         : {})}
       ref={mergeRefs([ref, _ref, wrapperRef])}
+      style={{ outline: 'none' }}
     />
   );
 };

--- a/src/components/primitives/Input/InputBase.tsx
+++ b/src/components/primitives/Input/InputBase.tsx
@@ -126,7 +126,7 @@ const InputBase = (
           }
         : {})}
       ref={mergeRefs([ref, _ref, wrapperRef])}
-      style={{ outline: 'none' }}
+      style={Platform.OS === 'web' ? { outline: 'none' } : {}}
     />
   );
 };


### PR DESCRIPTION
## Summary
The Input component rendered in Firefox is not perfect. The default outline of React Native `TextInput` was not hiding in Firefox browser.
