### PR TITLE
fix: remove heading fontfamily

### DIFF
--- a/src/theme/components/heading.ts
+++ b/src/theme/components/heading.ts
@@ -4,7 +4,6 @@ const baseStyle = (props: Record<string, any>) => {
   return {
     color: mode('muted.700', 'white')(props),
     fontWeight: 'bold',
-    fontFamily: 'heading',
     lineHeight: 'sm',
   };
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

removed font family from base style for `Heading` component. It was injecting the wrong font family in some cases.  For Example for nested `Heading`, it was injecting the wrong font-family for inner `Heading`.