### PR TITLE
fix(Image): fix maximum update depth exceeded error

### DIFF
--- a/src/components/primitives/Image/index.tsx
+++ b/src/components/primitives/Image/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, memo, forwardRef, useCallback, useRef } from 'react';
+import React, {useState, memo, forwardRef, useCallback, useRef, useMemo, useEffect} from 'react';
 import { Image as RNImage } from 'react-native';
 import Text from '../Text';
 import { usePropsResolution } from '../../../hooks/useThemeProps';
@@ -20,27 +20,27 @@ const Image = (props: IImageProps, ref: any) => {
     ...resolvedProps
   } = usePropsResolution('Image', props);
 
-  const finalSource: any = useRef(null);
-  const getSource = useCallback(() => {
-    if (source) {
-      finalSource.current = source;
-    } else if (src) {
-      finalSource.current = { uri: src };
-    }
-    return finalSource.current;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [source?.uri, src]);
-
-  const [renderedSource, setSource] = useState(getSource());
   const [alternate, setAlternate] = useState(false);
   const [fallbackSourceFlag, setfallbackSourceFlag] = useState(true);
 
-  React.useEffect(() => {
-    setSource(getSource());
-    return () => {
-      finalSource.current = null;
-    };
-  }, [source?.uri, src, getSource]);
+  const getSource = useCallback(() => {
+    if (source) {
+      return source;
+    } else if (src) {
+      return { uri: src };
+    }
+    return undefined
+  }, [source, src])
+
+  const [renderedSource, setSource] = useState(getSource)
+
+  useEffect(() => {
+    const result = getSource()
+
+    if (result && JSON.stringify(result ?? {}) !== JSON.stringify(renderedSource ?? {})) {
+      setSource(result)
+    }
+  }, [getSource, renderedSource, setSource])
 
   const onImageLoadError = useCallback(
     (event: any) => {


### PR DESCRIPTION
## Summary

This PR fixes an issue where the `useEffect` hook in the image component runs recursively until React throws a `Maximum update depth exceeded error`.

 It solves the problem by refactoring the various hooks involved with determining, keeping in sync, and storing the image source. The most notable change is that `setSource` is only called when the source actually changes.

Note: JSON.stringify is used to compare the previous / next value because other methods of comparison are tricky due to the state being an object that many people will not remember to memo. 

## Changelog
PATCH FIX - fixed bug in the Image component causing some apps to run an infinite loop

## Test Plan
I honestly do not know how to test this one - perhaps there is a way to write a jest test that catches the `Maximum update depth exceeded error`?
