### PR TITLE
fix: toast overlap issue

### DIFF
--- a/src/components/composites/Toast/Toast.tsx
+++ b/src/components/composites/Toast/Toast.tsx
@@ -100,6 +100,7 @@ const CustomToast = () => {
               space={2}
               alignItems="center"
               justifyContent="center"
+              pointerEvents="box-none"
             >
               {
                 // @ts-ignore


### PR DESCRIPTION
## Summary
After calling `toast.show()` Toast provider overlaps screen elements and prevents onClick events to reach buttons etc. This was happening due to 100% width of `VStack` component in which `toasts` are added. 