### PR TITLE
Exposing underlying Image properties on Avatar via _image

### DIFF
--- a/src/components/composites/Avatar/Avatar.tsx
+++ b/src/components/composites/Avatar/Avatar.tsx
@@ -1,12 +1,12 @@
-import React, { memo, forwardRef } from 'react';
-import { Box, Image, Text } from '../../primitives';
-import { usePropsResolution } from '../../../hooks/useThemeProps';
-import type { IAvatarProps } from './types';
+import React, { forwardRef, memo } from 'react';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
+import { usePropsResolution } from '../../../hooks/useThemeProps';
+import { Box, Image, Text } from '../../primitives';
+import type { IAvatarProps } from './types';
 
 const Avatar = ({ children, ...props }: IAvatarProps, ref: any) => {
   const [error, setError] = React.useState(false);
-  const { _text, source, style, ...resolvedProps } = usePropsResolution(
+  const { _image, _text, source, style, ...resolvedProps } = usePropsResolution(
     'Avatar',
     props
   );
@@ -51,6 +51,7 @@ const Avatar = ({ children, ...props }: IAvatarProps, ref: any) => {
             setError(true);
           }}
           ref={ref}
+          {..._image}
         />
       ) : (
         remainingChildren.length !== 0 && remainingChildren

--- a/src/components/composites/Avatar/types.tsx
+++ b/src/components/composites/Avatar/types.tsx
@@ -1,10 +1,12 @@
-import type { IBoxProps } from '../../primitives/Box';
-import type { ImageSourcePropType } from 'react-native';
 import type { MutableRefObject } from 'react';
+import type { ImageSourcePropType } from 'react-native';
 import type { ResponsiveValue } from '../../../components/types';
 import type { ISizes } from '../../../theme/base/sizes';
+import type { IBoxProps } from '../../primitives/Box';
+import type { IImageProps } from '../../primitives/Image';
 
 export interface IAvatarProps extends IBoxProps<IAvatarProps> {
+
   /**
    * The image source of the avatar.
    */
@@ -15,12 +17,16 @@ export interface IAvatarProps extends IBoxProps<IAvatarProps> {
    */
   size?: ResponsiveValue<ISizes | (string & {}) | number>;
   /**
+   * Props to be passed to Image
+   */
+  _image?: IImageProps;
+  /**
    * ref to be attached to Avatar wrapper
    */
   wrapperRef?: MutableRefObject<any>;
 }
 
-export interface IAvatarBadgeProps extends IBoxProps<IAvatarBadgeProps> {}
+export interface IAvatarBadgeProps extends IBoxProps<IAvatarBadgeProps> { }
 
 export interface IAvatarGroupProps extends IAvatarProps {
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
I have several use cases where I need to modify properties on the Avatars underlying image. This change adds _image to the avatar in a similar fashion to other cases e.g. _text
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Added] - Added `_image` property to Avatar to expose the underlying image properties

## Test Plan
I've been using the patch successfully to drive underlying image tinting based on a focus property. I'm happy to add automated tests if someone can point me in the right direction. 

One area I'd question, and ask reviewsers to chime in on, is should the _image props allow override of all props provided by the avatar or are there some that should never be overiden? I.e. is `{..._image}
` placed correctly in the props order on the Image tag.