### PR TITLE
fix: <Link /> does not wrap a text when children is string or number

### DIFF
--- a/src/components/primitives/Link/index.tsx
+++ b/src/components/primitives/Link/index.tsx
@@ -55,22 +55,24 @@ const Link = (props: ILinkProps, ref: any) => {
           {children}
         </Box>
       ) : (
-        <Pressable
-          {...linkProps}
-          {...resolvedProps}
-          ref={ref}
-          flexDirection="row"
-        >
+        <>
           {React.Children.map(children, (child) =>
             typeof child === 'string' || typeof child === 'number' ? (
-              <Text {...resolvedProps._text} {...linkTextProps}>
+              <Text {...resolvedProps._text} {...linkTextProps} {...linkProps} {...resolvedProps} ref={ref}>
                 {child}
               </Text>
             ) : (
-              child
+              <Pressable
+                {...linkProps}
+                {...resolvedProps}
+                ref={ref}
+                flexDirection="row"
+              >
+                {child}
+              </Pressable>
             )
           )}
-        </Pressable>
+        </>
       )}
     </>
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

- A text wasn't wrapped when use `<Link />` with strings, so I fixed it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
