### PR TITLE
usecallback in useDisclose functions

### DIFF
--- a/src/hooks/useDisclose.ts
+++ b/src/hooks/useDisclose.ts
@@ -2,15 +2,16 @@ import React from 'react';
 
 export function useDisclose(initState?: boolean) {
   const [isOpen, setIsOpen] = React.useState(initState || false);
-  const onOpen = () => {
+  const onOpen = React.useCallback(() => {
     setIsOpen(true);
-  };
-  const onClose = () => {
+  }, [])
+  const onClose = React.useCallback(() => {
     setIsOpen(false);
-  };
-  const onToggle = () => {
+  }, [])
+  const onToggle = React.useCallback(() => {
     setIsOpen(!isOpen);
-  };
+  }, [isOpen])
+
   return {
     isOpen,
     onOpen,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Modal and ActionSheet Rerenders even though they are memoized. This is because we are passing unmemoized functions as props. This PR aims to solve that.



