### PR TITLE
feat: added overlay mode for button spinners

### DIFF
--- a/example/storybook/stories/components/primitives/Button/loading.tsx
+++ b/example/storybook/stories/components/primitives/Button/loading.tsx
@@ -29,6 +29,9 @@ export const Example = () => {
       <Button isLoading isLoadingText="Submitting" variant="outline">
         Button
       </Button>
+      <Button isLoading spinnerMode='overlay' isLoadingText="Submitting" variant="outline">
+        Button
+      </Button>
     </Stack>
   );
 };

--- a/src/components/primitives/Button/Button.tsx
+++ b/src/components/primitives/Button/Button.tsx
@@ -23,6 +23,7 @@ const Button = (
     leftIcon,
     endIcon,
     spinner,
+    spinnerMode = "inline",
     isDisabled,
     isLoading,
     isHovered: isHoveredProp,
@@ -127,17 +128,18 @@ const Button = (
       {...resolvedProps}
       accessibilityRole={props.accessibilityRole ?? 'button'}
     >
-      <HStack {..._stack}>
+      <HStack {..._stack} opacity={isLoading && spinnerMode === "overlay" ? 0 : undefined}>
         {startIcon && !isLoading ? startIcon : null}
-        {isLoading && spinnerPlacement === 'start' ? spinnerElement : null}
+        {isLoading && spinnerMode === "inline" && spinnerPlacement === 'start' ? spinnerElement : null}
         {boxChildren ? (
           <Box _text={_text}>
             {isLoading && isLoadingText ? isLoadingText : children}
           </Box>
         ) : null}
         {endIcon && !isLoading ? endIcon : null}
-        {isLoading && spinnerPlacement === 'end' ? spinnerElement : null}
+        {isLoading && spinnerMode === "inline" && spinnerPlacement === 'end' ? spinnerElement : null}
       </HStack>
+      {isLoading && spinnerMode === "overlay" && <Box position={"absolute"} top={0} left={0} right={0} bottom={0} justifyContent={"center"} alignItems={"center"}>{spinnerElement}</Box>}
     </Pressable>
   );
 };

--- a/src/components/primitives/Button/types.ts
+++ b/src/components/primitives/Button/types.ts
@@ -61,6 +61,10 @@ export interface IButtonProps extends IPressableProps<IButtonProps> {
    */
   spinner?: JSX.Element;
   /**
+   * If inline, show the spinner next the the contents of the button. If overlay, hide the contents of the button when loading, and show the spinner in the center.
+   */
+  spinnerMode?: "inline" | "overlay";
+  /**
    * If true, the button will be disabled.
    */
   isDisabled?: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This adds a property to buttons called `spinnerMode`, accepting the values `overlay` and `inline`. The value `inline` will let the spinner show up next to the button contents (nothing changed). When `overlay`, the contents of the  button are hidden, and the spinner is shown centered within the button.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

This will show a spinner within the button, without the contents of the button visible. The size of the button doesn't change..

```
<Button isLoading spinnerMode='overlay' isLoadingText="Submitting" variant="outline">
        Button
</Button>
```
