### PR TITLE
Fix ILinearGradientProps "locations" key name

### DIFF
--- a/src/components/primitives/Box/types.ts
+++ b/src/components/primitives/Box/types.ts
@@ -13,7 +13,7 @@ export interface ILinearGradientProps {
     colors: Array<string>;
     start?: Array<number>;
     end?: Array<number>;
-    location?: Array<number>;
+    locations?: Array<number>;
   };
 }
 


### PR DESCRIPTION
Incorrect result:
```
linearGradient: {
    ...
    location: [0, 0.2, 1],
}
```

Correct result:
```
linearGradient: {
    ...
    locations: [0, 0.2, 1],
}
```

Refer to https://www.npmjs.com/package/react-native-linear-gradient

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

General Fixed - Fix `ILinearGradientProps` "locations" key name
