### PR TITLE
fix type of flatlist _contentContainerStyle prop

### DIFF
--- a/src/components/basic/FlatList/types.ts
+++ b/src/components/basic/FlatList/types.ts
@@ -9,5 +9,5 @@ export interface IFlatListProps<ItemT>
   /**
    * pass props to contentContainerStyle, and this also resolved NB tokens.
    */
-  _contentContainerStyle?: IFlatListProps<ItemT>;
+  _contentContainerStyle?: StyledProps;
 }


### PR DESCRIPTION
The expected type is a `StyledProps`, but the type of the `Flatlist` itself is being used.