### PR TITLE
fix visible props in modal

### DIFF
--- a/src/components/primitives/Overlay/Overlay.tsx
+++ b/src/components/primitives/Overlay/Overlay.tsx
@@ -46,7 +46,7 @@ export function Overlay({
       <ExitAnimationContext.Provider value={{ exited, setExited }}>
         <Modal
           transparent
-          visible={isOpen}
+          visible={isOpen?isOpen:false}
           onRequestClose={onRequestClose}
           animationType={animationPreset}
         >


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
on android device the Modal is opening by default caused by isOpen == undefined
 

## Changelog

 `visible={isOpen}` to `visible={isOpen?isOpen:false}`

 

## Test Plan
 test in android devices with useRNModalOnAndroid=true in IOverlayProps 
