### PR TITLE
Bugfix: Input component - override _all_ bg props to transparent

### DIFF
--- a/src/components/primitives/Input/Input.tsx
+++ b/src/components/primitives/Input/Input.tsx
@@ -9,6 +9,12 @@ import { extractInObject, stylingProps } from '../../../theme/tools/utils';
 import { usePropsResolution } from '../../../hooks/useThemeProps';
 import { mergeRefs } from '../../../utils';
 
+type bgTransparentType = {[propName: string]: 'transparent'};
+const backgroundTransparentProps: bgTransparentType = stylingProps.background.reduce((bgProps, bgProp) => {
+  bgProps[bgProp] = 'transparent';
+  return bgProps;
+}, {} as bgTransparentType);
+
 const Input = (
   { isHovered: isHoveredProp, isFocused: isFocusedProp, ...props }: IInputProps,
   ref: any
@@ -97,7 +103,11 @@ const Input = (
           leftElement={leftElement}
           rightElement={rightElement}
           inputProps={inputProps}
-          bg="transparent"
+          // Background props are being passed to parent Box.
+          // In the event they have transparency, we need to reset the background
+          // of the input to transparent so it does not interfere
+          // (e.g., stacked translucent colors).
+          {...backgroundTransparentProps}
           {...baseInputProps}
           flex={1}
           disableFocusHandling


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When the Input component is passed `InputLeftElement`, `leftElement`, `InputRightElement`, or `rightElement`, the component returns the elements and InputBase wrapped in a Box with the layout props applied. As part of those layout props the background props are included. Since the background props are getting applied to the Box instead of the InputBase, the InputBase is provided `bg="transparent"` to override if the theme defines a background color with transparency since if both the parent and input receive a translucent background they will overlap and change the shade.

Below you can see a disabled component that applies a translucent color when disabled. You can see that the InputBase portion appears lighter than the icon area due to multiple transparencies on top of each other instead of just one.

![image](https://user-images.githubusercontent.com/99214770/155240326-9095008d-f1c5-425b-8dbc-5f4390fab05e.png)

This is caused by the fact that there is more than 1 background prop. All of them should be set to "transparent" to account for however the theme is defined.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - Input backgrounds only applied once (either the InputBase or the wrapping Box, if present).

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

<img width="678" alt="image" src="https://user-images.githubusercontent.com/99214770/155241837-537133ba-afa6-4dce-bfc4-864630acae24.png">

