### PR TITLE
feat: adding alias for heading tags

### DIFF
--- a/src/components/primitives/Heading/index.tsx
+++ b/src/components/primitives/Heading/index.tsx
@@ -10,7 +10,33 @@ const Heading = (props: IHeadingProps, ref: any) => {
   if (useHasResponsiveProps(props)) {
     return null;
   }
-  return <Text {...resolvedProps} ref={ref} />;
+
+  function getAccessibilityLevel() {
+    switch (props.as) {
+      case 'h2':
+        return 2;
+      case 'h3':
+        return 3;
+      case 'h4':
+        return 4;
+      case 'h5':
+        return 5;
+      case 'h6':
+        return 6;
+      default:
+        return 1;
+    }
+  }
+
+  return (
+    <Text
+      {...resolvedProps}
+      ref={ref}
+      // @ts-ignore
+      accessibilityRole="heading"
+      accessibilityLevel={getAccessibilityLevel()}
+    />
+  );
 };
 
 export default memo(forwardRef(Heading));

--- a/src/components/primitives/Heading/types.ts
+++ b/src/components/primitives/Heading/types.ts
@@ -8,4 +8,6 @@ export interface IHeadingProps extends ITextProps {
    * @default xl
    */
   size?: ResponsiveValue<ISizes | (string & {}) | number>;
+
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }

--- a/src/theme/components/heading.ts
+++ b/src/theme/components/heading.ts
@@ -31,6 +31,7 @@ const sizes = {
 
 const defaultProps = {
   size: 'lg',
+  as: 'h1',
 };
 
 export default {


### PR DESCRIPTION
To render Heading components as HTML heading tags(h1, h2, h3, etc) in web.