### PR TITLE
Allow for inputProps.style to take effect

### DIFF
--- a/src/components/primitives/Input/InputBase.tsx
+++ b/src/components/primitives/Input/InputBase.tsx
@@ -138,7 +138,7 @@ const InputBase = (
           }
         : {})}
       ref={mergeRefs([ref, _ref, wrapperRef])}
-      style={Platform.OS === 'web' ? { outline: 'none' } : {}}
+      style={[Platform.OS === 'web' ? { outline: 'none' } : {}, inputProps.style]}
     />
   );
 };


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

`inputProps.style` is not passed into input but is a valid prop 

```js
    if (propStyle) {

// Gets placed here 
// useStyledSystemPropsResolver.ts
      return { style: [styleSheet.box, propStyle], dataSet };
    } else {
      return { style: styleSheet.box, dataSet };
    }

```

This will allow better flexibility for users to allow the parent component to have final say in the style when needed. 

For example: `{ "resize": "auto" }` for TextArea in web

