### PR TITLE
fix: radio checkbox theme decoupling

### DIFF
--- a/src/components/primitives/Checkbox/Checkbox.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.tsx
@@ -18,6 +18,7 @@ import {
   useIsPressed,
 } from '../../primitives/Pressable/Pressable';
 import SizedIcon from './SizedIcon';
+import { Stack } from '../Stack';
 
 const Checkbox = (
   {
@@ -113,7 +114,7 @@ const CheckboxComponent = React.memo(
       icon,
       _interactionBox,
       _icon,
-      // destructuring pressable props and passing it manually
+      _stack,
       onPress,
       onPressIn,
       onPressOut,
@@ -142,6 +143,9 @@ const CheckboxComponent = React.memo(
       ...stylingProps.layout,
       ...stylingProps.flexbox,
       ...stylingProps.position,
+      ...stylingProps.background,
+      ...stylingProps.padding,
+      ...stylingProps.border,
       '_text',
     ]);
 
@@ -182,7 +186,7 @@ const CheckboxComponent = React.memo(
           // focusRingProps.onBlur
         )}
       >
-        <Box {...layoutProps}>
+        <Stack {...layoutProps} {..._stack}>
           <Center>
             {/* Interaction Wrapper */}
             <Box {..._interactionBox} />
@@ -193,7 +197,7 @@ const CheckboxComponent = React.memo(
           </Center>
           {/* Label */}
           {combinedProps.children}
-        </Box>
+        </Stack>
       </Pressable>
     );
   }

--- a/src/components/primitives/Checkbox/Checkbox.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../primitives/Pressable/Pressable';
 import SizedIcon from './SizedIcon';
 import { Stack } from '../Stack';
+import { wrapStringChild } from '../../../utils/wrapStringChild';
 
 const Checkbox = (
   {
@@ -115,6 +116,7 @@ const CheckboxComponent = React.memo(
       _interactionBox,
       _icon,
       _stack,
+      _text,
       onPress,
       onPressIn,
       onPressOut,
@@ -143,9 +145,6 @@ const CheckboxComponent = React.memo(
       ...stylingProps.layout,
       ...stylingProps.flexbox,
       ...stylingProps.position,
-      ...stylingProps.background,
-      ...stylingProps.padding,
-      ...stylingProps.border,
       '_text',
     ]);
 
@@ -196,7 +195,7 @@ const CheckboxComponent = React.memo(
             </Center>
           </Center>
           {/* Label */}
-          {combinedProps.children}
+          {wrapStringChild(combinedProps.children, _text)}
         </Stack>
       </Pressable>
     );

--- a/src/components/primitives/Checkbox/Checkbox.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.tsx
@@ -185,13 +185,7 @@ const CheckboxComponent = React.memo(
         <Box {...layoutProps}>
           <Center>
             {/* Interaction Wrapper */}
-            <Box
-              {..._interactionBox}
-              p={5}
-              w="100%"
-              height="100%"
-              zIndex={-1}
-            />
+            <Box {..._interactionBox} />
             {/* Checkbox */}
             <Center {...nonAccessibilityProps}>
               <SizedIcon icon={icon} _icon={_icon} isChecked={isChecked} />

--- a/src/components/primitives/Checkbox/Checkbox.web.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.web.tsx
@@ -140,11 +140,7 @@ const CheckboxComponent = React.memo(
 
     const component = React.useMemo(() => {
       return (
-        <Box
-          {...layoutProps}
-          opacity={isDisabled ? 0.4 : 1}
-          cursor={isDisabled ? 'not-allowed' : 'pointer'}
-        >
+        <Box {...layoutProps}>
           <Center>
             {/* Interaction Box */}
             <Box
@@ -181,7 +177,6 @@ const CheckboxComponent = React.memo(
       _interactionBox,
       icon,
       isChecked,
-      isDisabled,
       isFocusVisible,
       isHovered,
       layoutProps,

--- a/src/components/primitives/Checkbox/Checkbox.web.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.web.tsx
@@ -15,6 +15,7 @@ import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 import { extractInObject, stylingProps } from '../../../theme/tools/utils';
 import { combineContextAndProps } from '../../../utils';
 import SizedIcon from './SizedIcon';
+import { Stack } from '../Stack';
 
 const Checkbox = (
   {
@@ -119,6 +120,7 @@ const CheckboxComponent = React.memo(
       icon,
       _interactionBox,
       _icon,
+      _stack,
       ...resolvedProps
     } = usePropsResolution('Checkbox', combinedProps, {
       isInvalid,
@@ -135,12 +137,15 @@ const CheckboxComponent = React.memo(
       ...stylingProps.layout,
       ...stylingProps.flexbox,
       ...stylingProps.position,
+      ...stylingProps.background,
+      ...stylingProps.padding,
+      ...stylingProps.border,
       '_text',
     ]);
 
     const component = React.useMemo(() => {
       return (
-        <Box {...layoutProps}>
+        <Stack {...layoutProps} {..._stack}>
           <Center>
             {/* Interaction Box */}
             <Box
@@ -170,17 +175,18 @@ const CheckboxComponent = React.memo(
           </Center>
           {/* Label */}
           {resolvedProps?.children}
-        </Box>
+        </Stack>
       );
     }, [
       _icon,
+      _stack,
       _interactionBox,
       icon,
       isChecked,
       isFocusVisible,
       isHovered,
-      layoutProps,
       nonLayoutProps,
+      layoutProps,
       isHoveredProp,
       isFocusVisibleProp,
       resolvedProps?.children,

--- a/src/components/primitives/Checkbox/Checkbox.web.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.web.tsx
@@ -149,10 +149,6 @@ const CheckboxComponent = React.memo(
             {/* Interaction Box */}
             <Box
               {..._interactionBox}
-              style={{
-                // @ts-ignore - only for web"
-                transition: 'height 200ms, width 200ms',
-              }}
               h={
                 isFocusVisible ||
                 isFocusVisibleProp ||
@@ -169,8 +165,6 @@ const CheckboxComponent = React.memo(
                   ? '200%'
                   : '0%'
               }
-              pointerEvents="none"
-              zIndex={-1}
             />
             {/* Checkbox */}
             <Center {...nonLayoutProps}>

--- a/src/components/primitives/Checkbox/Checkbox.web.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.web.tsx
@@ -16,6 +16,7 @@ import { extractInObject, stylingProps } from '../../../theme/tools/utils';
 import { combineContextAndProps } from '../../../utils';
 import SizedIcon from './SizedIcon';
 import { Stack } from '../Stack';
+import { wrapStringChild } from '../../../utils/wrapStringChild';
 
 const Checkbox = (
   {
@@ -121,6 +122,7 @@ const CheckboxComponent = React.memo(
       _interactionBox,
       _icon,
       _stack,
+      _text,
       ...resolvedProps
     } = usePropsResolution('Checkbox', combinedProps, {
       isInvalid,
@@ -137,15 +139,11 @@ const CheckboxComponent = React.memo(
       ...stylingProps.layout,
       ...stylingProps.flexbox,
       ...stylingProps.position,
-      ...stylingProps.background,
-      ...stylingProps.padding,
-      ...stylingProps.border,
       '_text',
     ]);
-
     const component = React.useMemo(() => {
       return (
-        <Stack {...layoutProps} {..._stack}>
+        <Stack {..._stack} {...layoutProps}>
           <Center>
             {/* Interaction Box */}
             <Box
@@ -174,12 +172,14 @@ const CheckboxComponent = React.memo(
             </Center>
           </Center>
           {/* Label */}
-          {resolvedProps?.children}
+          {/* {resolvedProps?.children} */}
+          {wrapStringChild(resolvedProps?.children, _text)}
         </Stack>
       );
     }, [
       _icon,
       _stack,
+      _text,
       _interactionBox,
       icon,
       isChecked,

--- a/src/components/primitives/Checkbox/CheckboxGroup.tsx
+++ b/src/components/primitives/Checkbox/CheckboxGroup.tsx
@@ -5,6 +5,7 @@ import { useFormControlContext } from '../../composites/FormControl';
 import type { ICheckboxGroupProps, ICheckboxContext } from './types';
 import Box from '../Box';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
+import { usePropsResolution } from '../../../hooks/useThemeProps';
 
 export const CheckboxGroupContext = createContext<ICheckboxContext | null>(
   null
@@ -14,6 +15,7 @@ function CheckboxGroup(
   { size, _checkbox, colorScheme, ...props }: ICheckboxGroupProps,
   ref?: any
 ) {
+  const resolvedProps = usePropsResolution('CheckboxGroup', props);
   const { children } = props;
   const state = useCheckboxGroupState(props);
   const { groupProps } = useCheckboxGroup(
@@ -36,7 +38,7 @@ function CheckboxGroup(
         state,
       }}
     >
-      <Box alignItems="flex-start" {...groupProps} {...props} ref={ref}>
+      <Box {...resolvedProps} {...groupProps} {...props} ref={ref}>
         {children}
       </Box>
     </CheckboxGroupContext.Provider>

--- a/src/components/primitives/Checkbox/types.tsx
+++ b/src/components/primitives/Checkbox/types.tsx
@@ -5,6 +5,7 @@ import type { IFormControlContext } from '../../composites/FormControl';
 import type { IBoxProps } from '../Box';
 import type { IIconProps } from '../Icon';
 import type { ResponsiveValue } from '../../../components/types';
+import type { IStackProps } from '../../primitives/Stack';
 
 export type ICheckboxValue = string;
 
@@ -115,6 +116,10 @@ export interface ICheckboxProps extends IBoxProps<ICheckboxProps> {
    * You can style interaction box around the checkbox using this.
    */
   _interactionBox?: Omit<ICheckboxProps, '_interactionBox'>;
+  /**
+   * Props to be passed to the Stack used inside.
+   */
+  _stack?: IStackProps;
   /**
    * Function called when the state of the checkbox changes.
    */

--- a/src/components/primitives/Radio/Radio.tsx
+++ b/src/components/primitives/Radio/Radio.tsx
@@ -2,7 +2,7 @@ import React, { memo, forwardRef } from 'react';
 import { Pressable, IPressableProps } from '../Pressable';
 import { Center } from '../../composites/Center';
 import Box from '../Box';
-import { HStack } from '../Stack';
+import { Stack } from '../Stack';
 import { usePropsResolution } from '../../../hooks/useThemeProps';
 import { wrapStringChild } from '../../../utils/wrapStringChild';
 import type { IRadioProps } from './types';
@@ -121,7 +121,7 @@ const RadioComponent = memo(
             // focusRingProps.onBlur
           )}
         >
-          <HStack {..._stack}>
+          <Stack {..._stack}>
             <Center>
               {/* Interaction Wrapper */}
               <Box {..._interactionBox} />
@@ -130,13 +130,13 @@ const RadioComponent = memo(
                 {icon && sizedIcon && isChecked ? (
                   sizedIcon()
                 ) : (
-                  <CircleIcon {..._icon} opacity={isChecked ? 1 : 0} />
+                  <CircleIcon {..._icon} />
                 )}
               </Center>
             </Center>
             {/* Label */}
             {wrapStringChild(children, _text)}
-          </HStack>
+          </Stack>
         </Pressable>
       );
     }

--- a/src/components/primitives/Radio/Radio.tsx
+++ b/src/components/primitives/Radio/Radio.tsx
@@ -130,7 +130,7 @@ const RadioComponent = memo(
                 {icon && sizedIcon && isChecked ? (
                   sizedIcon()
                 ) : (
-                  <CircleIcon {..._icon} />
+                  <CircleIcon {..._icon} opacity={isChecked ? 1 : 0} />
                 )}
               </Center>
             </Center>

--- a/src/components/primitives/Radio/Radio.tsx
+++ b/src/components/primitives/Radio/Radio.tsx
@@ -124,7 +124,7 @@ const RadioComponent = memo(
           <HStack {..._stack}>
             <Center>
               {/* Interaction Wrapper */}
-              <Box position="absolute" zIndex={-1} {..._interactionBox} />
+              <Box {..._interactionBox} />
               {/* radio */}
               <Center {...resolvedProps}>
                 {icon && sizedIcon && isChecked ? (

--- a/src/components/primitives/Radio/Radio.web.tsx
+++ b/src/components/primitives/Radio/Radio.web.tsx
@@ -1,6 +1,6 @@
 import React, { memo, forwardRef } from 'react';
 import Box from '../Box';
-import { HStack } from '../Stack';
+import { Stack } from '../Stack';
 import { Center } from '../../composites/Center';
 import { usePropsResolution } from '../../../hooks/useThemeProps';
 import { wrapStringChild } from '../../../utils/wrapStringChild';
@@ -62,19 +62,10 @@ const RadioComponent = memo(
         });
 
       const component = (
-        <HStack {..._stack} cursor={isDisabled ? 'not-allowed' : 'pointer'}>
+        <Stack {..._stack} cursor={isDisabled ? 'not-allowed' : 'pointer'}>
           <Center>
             {/* Interaction Box */}
-            <Box
-              position="absolute"
-              zIndex={-1}
-              pointerEvents="none"
-              {..._interactionBox}
-              style={{
-                // @ts-ignore - only for web"
-                transition: 'height 200ms, width 200ms',
-              }}
-            />
+            <Box {..._interactionBox} />
             {/* Radio */}
             <Center {...resolvedProps}>
               {icon && sizedIcon && isChecked ? (
@@ -85,7 +76,7 @@ const RadioComponent = memo(
             </Center>
           </Center>
           {wrapStringChild(children, _text)}
-        </HStack>
+        </Stack>
       );
       //TODO: refactor for responsive prop
       if (useHasResponsiveProps(props)) {

--- a/src/components/primitives/Radio/Radio.web.tsx
+++ b/src/components/primitives/Radio/Radio.web.tsx
@@ -71,7 +71,7 @@ const RadioComponent = memo(
               {icon && sizedIcon && isChecked ? (
                 sizedIcon()
               ) : (
-                <CircleIcon {..._icon} />
+                <CircleIcon {..._icon} opacity={isChecked ? 1 : 0} />
               )}
             </Center>
           </Center>

--- a/src/components/primitives/Radio/Radio.web.tsx
+++ b/src/components/primitives/Radio/Radio.web.tsx
@@ -62,7 +62,7 @@ const RadioComponent = memo(
         });
 
       const component = (
-        <Stack {..._stack} cursor={isDisabled ? 'not-allowed' : 'pointer'}>
+        <Stack {..._stack}>
           <Center>
             {/* Interaction Box */}
             <Box {..._interactionBox} />
@@ -71,7 +71,7 @@ const RadioComponent = memo(
               {icon && sizedIcon && isChecked ? (
                 sizedIcon()
               ) : (
-                <CircleIcon {..._icon} opacity={isChecked ? 1 : 0} />
+                <CircleIcon {..._icon} />
               )}
             </Center>
           </Center>

--- a/src/components/primitives/Radio/RadioGroup.tsx
+++ b/src/components/primitives/Radio/RadioGroup.tsx
@@ -5,14 +5,14 @@ import type { IRadioContext, IRadioGroupProps } from './types';
 import { useRadioGroupState } from '@react-stately/radio';
 import { useRadioGroup } from '@react-native-aria/radio';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
+import { usePropsResolution } from '../../../hooks/useThemeProps';
 
 export const RadioContext = React.createContext<IRadioContext>(
   {} as IRadioContext
 );
 const RadioWrapper = memo((props: any) => {
-  return (
-    <Stack alignItems="flex-start" {...props.radioGroupProps} {...props} />
-  );
+  const resolvedProps = usePropsResolution('RadioGroup', props);
+  return <Stack {...resolvedProps} {...props.radioGroupProps} {...props} />;
 });
 
 const RadioGroup = (
@@ -43,7 +43,6 @@ const RadioGroup = (
     []
   );
 
-  // console.log(radioGroupState);
   //TODO: refactor for responsive prop
   if (useHasResponsiveProps({ ...props, size, colorScheme })) {
     return null;

--- a/src/components/primitives/Radio/types.tsx
+++ b/src/components/primitives/Radio/types.tsx
@@ -59,7 +59,7 @@ export interface IRadioProps extends IBoxProps<IRadioProps> {
    */
   wrapperRef?: any;
   /**
-   * Props to be passed to the HStack used inside.
+   * Props to be passed to the Stack used inside.
    */
   _stack?: IStackProps;
 }

--- a/src/theme/components/checkbox-group.ts
+++ b/src/theme/components/checkbox-group.ts
@@ -1,0 +1,9 @@
+const baseStyle = () => {
+  return {
+    alignItems: 'flex-start',
+  };
+};
+
+export default {
+  baseStyle,
+};

--- a/src/theme/components/checkbox.ts
+++ b/src/theme/components/checkbox.ts
@@ -14,6 +14,14 @@ const baseStyle = (props: Record<string, any>) => {
     _web: {
       cursor: 'pointer',
     },
+    _stack: {
+      direction: 'row',
+      alignItems: 'center',
+      space: 2,
+      _web: {
+        cursor: props.isDisabled ? 'not-allowed' : 'pointer',
+      },
+    },
     _text: {
       ml: 2,
       color: mode('darkText', 'lightText')(props),

--- a/src/theme/components/checkbox.ts
+++ b/src/theme/components/checkbox.ts
@@ -18,6 +18,14 @@ const baseStyle = (props: Record<string, any>) => {
     _interactionBox: {
       position: 'absolute',
       borderRadius: 'full',
+      p: 5,
+      w: '100%',
+      h: '100%',
+      zIndex: -1,
+      _web: {
+        transition: 'height 200ms, width 200ms',
+        pointerEvents: 'none',
+      },
     },
     _hover: {
       _interactionBox: {

--- a/src/theme/components/checkbox.ts
+++ b/src/theme/components/checkbox.ts
@@ -10,7 +10,10 @@ const baseStyle = (props: Record<string, any>) => {
     borderRadius: 'sm',
     borderColor: mode('muted.300', 'muted.600')(props),
     bg: mode('muted.50', 'muted.700')(props), // matching background color
-
+    opacity: 1,
+    _web: {
+      cursor: 'pointer',
+    },
     _text: {
       ml: 2,
       color: mode('darkText', 'lightText')(props),
@@ -45,6 +48,9 @@ const baseStyle = (props: Record<string, any>) => {
     _disabled: {
       _interactionBox: {
         bg: 'transparent',
+      },
+      _web: {
+        cursor: 'not-allowed',
       },
       opacity: 0.4,
     },

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -24,6 +24,7 @@ import Button, { ButtonGroup } from './button';
 import Card from './card';
 import Center from './center';
 import Checkbox from './checkbox';
+import CheckboxGroup from './checkbox-group';
 import Box from './box';
 import FlatList from './flatList';
 import KeyboardAvoidingView from './keyboardAvoidingView';
@@ -76,6 +77,7 @@ import PinInput from './pin-input';
 import Pressable from './pressable';
 import Progress from './progress';
 import Radio from './radio';
+import RadioGroup from './radio-group';
 import { Skeleton, SkeletonText } from './skeleton';
 import Spinner from './spinner';
 import Stat from './stat';
@@ -133,6 +135,7 @@ export default {
   Card,
   Center,
   Checkbox,
+  CheckboxGroup,
   CircularProgress,
   Code,
   Container,
@@ -182,6 +185,7 @@ export default {
   ...PopoverComponentTheme,
   Progress,
   Radio,
+  RadioGroup,
   ScaleFade,
   Select,
   SelectItem,

--- a/src/theme/components/radio-group.ts
+++ b/src/theme/components/radio-group.ts
@@ -1,0 +1,9 @@
+const baseStyle = () => {
+  return {
+    alignItems: 'flex-start',
+  };
+};
+
+export default {
+  baseStyle,
+};

--- a/src/theme/components/radio.ts
+++ b/src/theme/components/radio.ts
@@ -29,7 +29,6 @@ const baseStyle = (props: Record<string, any>) => {
     },
     _icon: {
       color: mode(`${colorScheme}.600`, `${colorScheme}.200`)(props), // matching background color
-      opacity: props.isChecked ? 1 : 0,
     },
     _hover: {
       _interactionBox: {

--- a/src/theme/components/radio.ts
+++ b/src/theme/components/radio.ts
@@ -10,13 +10,19 @@ const baseStyle = (props: Record<string, any>) => {
     bg: mode('muted.50', 'muted.700')(props), // matching background color
 
     _stack: {
-      flexDirection: 'row',
+      direction: 'row',
       alignItems: 'center',
       space: 2,
     },
     _interactionBox: {
       borderRadius: 'full',
       size: 3,
+      position: 'absolute',
+      zIndex: -1,
+      _web: {
+        transition: 'height 200ms, width 200ms',
+        pointerEvents: 'none',
+      },
     },
     _icon: {
       color: mode(`${colorScheme}.600`, `${colorScheme}.200`)(props), // matching background color

--- a/src/theme/components/radio.ts
+++ b/src/theme/components/radio.ts
@@ -13,6 +13,9 @@ const baseStyle = (props: Record<string, any>) => {
       direction: 'row',
       alignItems: 'center',
       space: 2,
+      _web: {
+        cursor: props.isDisabled ? 'not-allowed' : 'pointer',
+      },
     },
     _interactionBox: {
       borderRadius: 'full',
@@ -26,6 +29,7 @@ const baseStyle = (props: Record<string, any>) => {
     },
     _icon: {
       color: mode(`${colorScheme}.600`, `${colorScheme}.200`)(props), // matching background color
+      opacity: props.isChecked ? 1 : 0,
     },
     _hover: {
       _interactionBox: {


### PR DESCRIPTION
## Summary
- Completed theme decoupling for radio and checkbox component, added two new theme files for `RadioGroup` and `CheckboxGroup`.
- Added `_stack` prop in checkbox component
- This PR will also fix issue [#4670](https://github.com/GeekyAnts/NativeBase/issues/4670)