### PR TITLE
Fix/alertdialog modal decouple

### DIFF
--- a/src/components/composites/AlertDialog/AlertDialog.tsx
+++ b/src/components/composites/AlertDialog/AlertDialog.tsx
@@ -79,13 +79,7 @@ const AlertDialog = (
           finalFocusRef,
         }}
       >
-        <Fade
-          exitDuration={150}
-          entryDuration={200}
-          in={visible}
-          style={StyleSheet.absoluteFill}
-          {..._backdropFade}
-        >
+        <Fade in={visible} style={StyleSheet.absoluteFill} {..._backdropFade}>
           {overlayVisible && backdropVisible && (
             <Backdrop
               onPress={() => {
@@ -96,7 +90,7 @@ const AlertDialog = (
           )}
         </Fade>
         {animationPreset === 'slide' ? (
-          <Slide overlay={false} in={visible} duration={200} {..._slide}>
+          <Slide in={visible} {..._slide}>
             <FocusScope
               contain={visible}
               autoFocus={visible && !initialFocusRef}
@@ -106,13 +100,7 @@ const AlertDialog = (
             </FocusScope>
           </Slide>
         ) : (
-          <Fade
-            exitDuration={100}
-            entryDuration={200}
-            in={visible}
-            style={StyleSheet.absoluteFill}
-            {..._fade}
-          >
+          <Fade in={visible} style={StyleSheet.absoluteFill} {..._fade}>
             <FocusScope
               contain={visible}
               autoFocus={visible && !initialFocusRef}

--- a/src/components/composites/AlertDialog/AlertDialog.tsx
+++ b/src/components/composites/AlertDialog/AlertDialog.tsx
@@ -25,7 +25,6 @@ const AlertDialog = (
     isKeyboardDismissable = true,
     overlayVisible = true,
     backdropVisible = true,
-    //@ts-ignore - internal purpose only
     animationPreset = 'fade',
     ...rest
   }: IAlertDialogProps,
@@ -36,6 +35,9 @@ const AlertDialog = (
     contentSize,
     _backdrop,
     _child,
+    _backdropFade,
+    _fade,
+    _slide,
     ...restThemeProps
   } = usePropsResolution('AlertDialog', rest);
 
@@ -84,6 +86,7 @@ const AlertDialog = (
           entryDuration={200}
           in={visible}
           style={StyleSheet.absoluteFill}
+          {..._backdropFade}
         >
           {overlayVisible && backdropVisible && (
             <Backdrop
@@ -95,7 +98,7 @@ const AlertDialog = (
           )}
         </Fade>
         {animationPreset === 'slide' ? (
-          <Slide overlay={false} in={visible} duration={200}>
+          <Slide overlay={false} in={visible} duration={200} {..._slide}>
             <FocusScope
               contain={visible}
               autoFocus={visible && !initialFocusRef}
@@ -110,6 +113,7 @@ const AlertDialog = (
             entryDuration={200}
             in={visible}
             style={StyleSheet.absoluteFill}
+            {..._fade}
           >
             <FocusScope
               contain={visible}

--- a/src/components/composites/AlertDialog/AlertDialog.tsx
+++ b/src/components/composites/AlertDialog/AlertDialog.tsx
@@ -27,16 +27,17 @@ const AlertDialog = (
     backdropVisible = true,
     //@ts-ignore - internal purpose only
     animationPreset = 'fade',
-
     ...rest
   }: IAlertDialogProps,
   ref: any
 ) => {
   const bottomInset = useKeyboardBottomInset();
-  const { contentSize, _backdrop, ...restThemeProps } = usePropsResolution(
-    'AlertDialog',
-    rest
-  );
+  const {
+    contentSize,
+    _backdrop,
+    _child,
+    ...restThemeProps
+  } = usePropsResolution('AlertDialog', rest);
 
   const [visible, setVisible] = useControllableState({
     value: isOpen,
@@ -48,16 +49,17 @@ const AlertDialog = (
 
   const handleClose = () => setVisible(false);
 
-  let child = (
+  const child = (
     <Box
       bottom={avoidKeyboard ? bottomInset + 'px' : undefined}
       {...restThemeProps}
+      {..._child}
       ref={ref}
-      pointerEvents="box-none"
     >
       {children}
     </Box>
   );
+
   //TODO: refactor for responsive prop
   if (useHasResponsiveProps(rest)) {
     return null;

--- a/src/components/composites/AlertDialog/AlertDialog.tsx
+++ b/src/components/composites/AlertDialog/AlertDialog.tsx
@@ -34,7 +34,6 @@ const AlertDialog = (
   const {
     contentSize,
     _backdrop,
-    _child,
     _backdropFade,
     _fade,
     _slide,
@@ -55,7 +54,6 @@ const AlertDialog = (
     <Box
       bottom={avoidKeyboard ? bottomInset + 'px' : undefined}
       {...restThemeProps}
-      {..._child}
       ref={ref}
     >
       {children}

--- a/src/components/composites/AlertDialog/AlertDialog.tsx
+++ b/src/components/composites/AlertDialog/AlertDialog.tsx
@@ -25,7 +25,7 @@ const AlertDialog = (
     isKeyboardDismissable = true,
     overlayVisible = true,
     backdropVisible = true,
-    animationPreset = 'fade',
+    animationPreset,
     ...rest
   }: IAlertDialogProps,
   ref: any

--- a/src/components/composites/AlertDialog/AlertDialogBody.tsx
+++ b/src/components/composites/AlertDialog/AlertDialogBody.tsx
@@ -1,19 +1,25 @@
 import React, { memo, forwardRef } from 'react';
 import Box, { IBoxProps } from '../../primitives/Box';
 import { usePropsResolution } from '../../../hooks';
-import { ScrollView } from 'react-native';
+import { ScrollView, IScrollViewProps } from '../../basic/ScrollView';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 
-const AlertDialogBody = (props: IBoxProps, ref?: any) => {
-  const newProps = usePropsResolution('AlertDialogBody', props);
+const AlertDialogBody = (
+  { children, ...props }: IBoxProps & { _scrollview?: IScrollViewProps },
+  ref?: any
+) => {
+  const { _scrollview, ...resolvedProps } = usePropsResolution(
+    'AlertDialogBody',
+    props
+  );
   //TODO: refactor for responsive prop
   if (useHasResponsiveProps(props)) {
     return null;
   }
   return (
-    <ScrollView>
-      <Box {...newProps} ref={ref}>
-        {props.children}
+    <ScrollView {..._scrollview}>
+      <Box {...resolvedProps} ref={ref}>
+        {children}
       </Box>
     </ScrollView>
   );

--- a/src/components/composites/AlertDialog/AlertDialogCloseButton.tsx
+++ b/src/components/composites/AlertDialog/AlertDialogCloseButton.tsx
@@ -7,8 +7,10 @@ import type { IButtonProps } from '../../primitives/Button';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 
 const AlertDialogCloseButton = (props: IButtonProps, ref?: any) => {
-  const newProps = usePropsResolution('AlertDialogCloseButton', props);
-  const { _icon, ...rest } = newProps;
+  const { _icon, ...rest } = usePropsResolution(
+    'AlertDialogCloseButton',
+    props
+  );
   const { handleClose } = React.useContext(AlertDialogContext);
   //TODO: refactor for responsive prop
   if (useHasResponsiveProps(props)) {

--- a/src/components/composites/AlertDialog/AlertDialogContent.tsx
+++ b/src/components/composites/AlertDialog/AlertDialogContent.tsx
@@ -5,7 +5,7 @@ import { AlertDialogContext } from './Context';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 
 const AlertDialogContent = (props: IBoxProps, ref?: any) => {
-  const { ...newProps } = usePropsResolution('AlertDialogContent', props);
+  const newProps = usePropsResolution('AlertDialogContent', props);
   const {
     contentSize,
     initialFocusRef,
@@ -13,7 +13,7 @@ const AlertDialogContent = (props: IBoxProps, ref?: any) => {
     handleClose,
   } = React.useContext(AlertDialogContext);
   React.useEffect(() => {
-    let finalRefVal = finalFocusRef ? finalFocusRef.current : null;
+    const finalRefVal = finalFocusRef ? finalFocusRef.current : null;
     if (initialFocusRef && initialFocusRef.current) {
       //@ts-ignore
       initialFocusRef.current.focus();

--- a/src/components/composites/AlertDialog/index.tsx
+++ b/src/components/composites/AlertDialog/index.tsx
@@ -6,7 +6,7 @@ import AlertDialogFooter from './AlertDialogFooter';
 import AlertDialogHeader from './AlertDialogHeader';
 import type { IAlertDialogComponentType } from './types';
 
-let AlertDialogTemp: any = AlertDialog;
+const AlertDialogTemp: any = AlertDialog;
 
 AlertDialogTemp.Content = AlertDialogContent;
 AlertDialogTemp.CloseButton = AlertDialogCloseButton;

--- a/src/components/composites/AlertDialog/types.ts
+++ b/src/components/composites/AlertDialog/types.ts
@@ -74,7 +74,8 @@ export interface IAlertDialogProps extends IBoxProps {
    */
   _slide?: ISlideProps;
   /**
-   * Prop applied to change Animation.
+   * Sets the animation type
+   * @default "fade"
    */
   animationPreset?: 'slide' | 'fade';
 }

--- a/src/components/composites/AlertDialog/types.ts
+++ b/src/components/composites/AlertDialog/types.ts
@@ -1,6 +1,7 @@
 import type { IBoxProps } from '../../primitives/Box';
 import type { IIconButtonProps } from '../IconButton';
 import type { MutableRefObject } from 'react';
+import type { IFadeProps, ISlideProps } from '../Transitions';
 
 export interface IAlertDialogProps extends IBoxProps {
   /**
@@ -60,6 +61,22 @@ export interface IAlertDialogProps extends IBoxProps {
    * Props applied on Overlay.
    */
   _backdrop?: any;
+  /**
+   * Props applied on Overlay Animation.
+   */
+  _backdropFade?: IFadeProps;
+  /**
+   * Props applied on Child Fade Animation.
+   */
+  _fade?: IFadeProps;
+  /**
+   * Props applied on Child Slide Animation.
+   */
+  _slide?: ISlideProps;
+  /**
+   * Prop applied to change Animation.
+   */
+  animationPreset?: 'slide' | 'fade';
 }
 
 export type IAlertDialogComponentType = ((

--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -25,8 +25,7 @@ const Modal = (
     isKeyboardDismissable = true,
     overlayVisible = true,
     backdropVisible = true,
-    //@ts-ignore - internal purpose only
-    animationPreset = 'fade',
+    animationPreset,
     ...rest
   }: IModalProps,
   ref: any
@@ -36,6 +35,9 @@ const Modal = (
     contentSize,
     _backdrop,
     _child,
+    _backdropFade,
+    _fade,
+    _slide,
     ...resolvedProps
   } = usePropsResolution('Modal', rest);
 
@@ -89,6 +91,7 @@ const Modal = (
           entryDuration={200}
           in={visible}
           style={StyleSheet.absoluteFill}
+          {..._backdropFade}
         >
           {overlayVisible && backdropVisible && (
             <Backdrop
@@ -100,7 +103,7 @@ const Modal = (
           )}
         </Fade>
         {animationPreset === 'slide' ? (
-          <Slide in={visible} overlay={false} duration={200}>
+          <Slide in={visible} overlay={false} duration={200} {..._slide}>
             <FocusScope
               contain={visible}
               autoFocus={visible && !initialFocusRef}
@@ -115,6 +118,7 @@ const Modal = (
             entryDuration={200}
             in={visible}
             style={StyleSheet.absoluteFill}
+            {..._fade}
           >
             <FocusScope
               contain={visible}

--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -84,13 +84,7 @@ const Modal = (
       useRNModalOnAndroid
     >
       <ModalContext.Provider value={contextValue}>
-        <Fade
-          exitDuration={150}
-          entryDuration={200}
-          in={visible}
-          style={StyleSheet.absoluteFill}
-          {..._backdropFade}
-        >
+        <Fade in={visible} style={StyleSheet.absoluteFill} {..._backdropFade}>
           {overlayVisible && backdropVisible && (
             <Backdrop
               onPress={() => {
@@ -101,7 +95,7 @@ const Modal = (
           )}
         </Fade>
         {animationPreset === 'slide' ? (
-          <Slide in={visible} overlay={false} duration={200} {..._slide}>
+          <Slide in={visible} {..._slide}>
             <FocusScope
               contain={visible}
               autoFocus={visible && !initialFocusRef}
@@ -111,13 +105,7 @@ const Modal = (
             </FocusScope>
           </Slide>
         ) : (
-          <Fade
-            exitDuration={100}
-            entryDuration={200}
-            in={visible}
-            style={StyleSheet.absoluteFill}
-            {..._fade}
-          >
+          <Fade in={visible} style={StyleSheet.absoluteFill} {..._fade}>
             <FocusScope
               contain={visible}
               autoFocus={visible && !initialFocusRef}

--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -32,10 +32,12 @@ const Modal = (
   ref: any
 ) => {
   const bottomInset = useKeyboardBottomInset();
-  const { contentSize, _backdrop, ...resolvedProps } = usePropsResolution(
-    'Modal',
-    rest
-  );
+  const {
+    contentSize,
+    _backdrop,
+    _child,
+    ...resolvedProps
+  } = usePropsResolution('Modal', rest);
 
   const [visible, setVisible] = useControllableState({
     value: isOpen,
@@ -51,8 +53,8 @@ const Modal = (
     <Box
       bottom={avoidKeyboard ? bottomInset + 'px' : undefined}
       {...resolvedProps}
+      {..._child}
       ref={ref}
-      pointerEvents="box-none"
     >
       {children}
     </Box>

--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -34,7 +34,6 @@ const Modal = (
   const {
     contentSize,
     _backdrop,
-    _child,
     _backdropFade,
     _fade,
     _slide,
@@ -55,7 +54,6 @@ const Modal = (
     <Box
       bottom={avoidKeyboard ? bottomInset + 'px' : undefined}
       {...resolvedProps}
-      {..._child}
       ref={ref}
     >
       {children}

--- a/src/components/composites/Modal/ModalBody.tsx
+++ b/src/components/composites/Modal/ModalBody.tsx
@@ -5,14 +5,13 @@ import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 import { ScrollView, IScrollViewProps } from '../../basic/ScrollView';
 
 const ModalBody = (
-  {
-    children,
-    _scrollview,
-    ...props
-  }: IBoxProps & { _scrollview?: IScrollViewProps },
+  { children, ...props }: IBoxProps & { _scrollview?: IScrollViewProps },
   ref?: any
 ) => {
-  const resolvedProps = usePropsResolution('ModalBody', props);
+  const { _scrollview, ...resolvedProps } = usePropsResolution(
+    'ModalBody',
+    props
+  );
   //TODO: refactor for responsive prop
   if (useHasResponsiveProps(props)) {
     return null;

--- a/src/components/composites/Modal/types.ts
+++ b/src/components/composites/Modal/types.ts
@@ -5,6 +5,7 @@ import type { MutableRefObject } from 'react';
 import type { ResponsiveValue } from '../../../components/types';
 import type { ISizes } from '../../../theme/base/sizes';
 import type { IScrollViewProps } from '../../basic/ScrollView';
+import type { IFadeProps, ISlideProps } from '../Transitions';
 
 export interface IModalProps extends IBoxProps<IModalProps> {
   /**
@@ -65,6 +66,18 @@ export interface IModalProps extends IBoxProps<IModalProps> {
    * @default "fade"
    */
   animationPreset?: 'fade' | 'slide';
+  /**
+   * Props applied on Overlay Animation.
+   */
+  _backdropFade?: IFadeProps;
+  /**
+   * Props applied on Child Fade Animation.
+   */
+  _fade?: IFadeProps;
+  /**
+   * Props applied on Child Slide Animation.
+   */
+  _slide?: ISlideProps;
 }
 
 export type IModalComponentType = ((

--- a/src/theme/components/alert-dialog.ts
+++ b/src/theme/components/alert-dialog.ts
@@ -45,6 +45,7 @@ export const AlertDialog = {
     height: '100%',
     justifyContent: 'center',
     alignItems: 'center',
+    _child: { pointerEvents: 'box-none' },
   },
   sizes,
   defaultProps: {

--- a/src/theme/components/alert-dialog.ts
+++ b/src/theme/components/alert-dialog.ts
@@ -45,7 +45,7 @@ export const AlertDialog = {
     height: '100%',
     justifyContent: 'center',
     alignItems: 'center',
-    _child: { pointerEvents: 'box-none' },
+    _web: { pointerEvents: 'box-none' },
   },
   sizes,
   defaultProps: {

--- a/src/theme/components/alert-dialog.ts
+++ b/src/theme/components/alert-dialog.ts
@@ -46,6 +46,9 @@ export const AlertDialog = {
     justifyContent: 'center',
     alignItems: 'center',
     _web: { pointerEvents: 'box-none' },
+    _backdropFade: { exitDuration: 150, entryDuration: 200 },
+    _fade: { exitDuration: 100, entryDuration: 200 },
+    _slide: { duration: 200, overlay: false },
   },
   sizes,
   defaultProps: {

--- a/src/theme/components/modal.ts
+++ b/src/theme/components/modal.ts
@@ -45,7 +45,7 @@ export const Modal = {
     height: '100%',
     justifyContent: 'center',
     alignItems: 'center',
-    _child: { pointerEvents: 'box-none' },
+    _web: { pointerEvents: 'box-none' },
   },
   sizes,
   defaultProps: {

--- a/src/theme/components/modal.ts
+++ b/src/theme/components/modal.ts
@@ -46,6 +46,9 @@ export const Modal = {
     justifyContent: 'center',
     alignItems: 'center',
     _web: { pointerEvents: 'box-none' },
+    _backdropFade: { exitDuration: 150, entryDuration: 200 },
+    _slide: { overlay: false, duration: 200 },
+    _fade: { exitDuration: 100, entryDuration: 200 },
   },
   sizes,
   defaultProps: {

--- a/src/theme/components/modal.ts
+++ b/src/theme/components/modal.ts
@@ -45,6 +45,7 @@ export const Modal = {
     height: '100%',
     justifyContent: 'center',
     alignItems: 'center',
+    _child: { pointerEvents: 'box-none' },
   },
   sizes,
   defaultProps: {


### PR DESCRIPTION
# Modal
- Theme decoupling
-  Added `_backdropFade`, ` _fade`, `_slide` props for customising animation props

# AlertDialog
- Theme decoupling
- Added `animationPreset` in types
-  Added `_backdropFade`, ` _fade`, `_slide` props for customising animation props