### PR TITLE
fix: error message overlap

### DIFF
--- a/src/components/composites/FormControl/FormControlErrorMessage.tsx
+++ b/src/components/composites/FormControl/FormControlErrorMessage.tsx
@@ -6,6 +6,7 @@ import { useFormControlContext } from './useFormControl';
 import type { IFormControlErrorMessageProps } from './types';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 import { combineContextAndProps } from '../../../utils';
+import Text from '../../primitives/Text';
 
 const FormControlErrorMessage = (
   props: IFormControlErrorMessageProps,
@@ -73,7 +74,7 @@ const FormControlErrorMessage = (
     <Box nativeID={resolvedProps?.helpTextId} {...resolvedProps} ref={ref}>
       <HStack {..._stack}>
         {startIcon}
-        <Box _text={_text}>{children}</Box>
+        <Text {..._text}>{children}</Text>
         {endIcon}
       </HStack>
     </Box>


### PR DESCRIPTION
Fixed`FormControl.ErrorMessage`  long error message overlap issue #4676 