### PR TITLE
fix/progress-design-changes

### DIFF
--- a/src/theme/components/progress.ts
+++ b/src/theme/components/progress.ts
@@ -1,5 +1,3 @@
-import { mode, getColorScheme } from '../tools';
-
 const defaultProps = {
   colorScheme: 'primary',
   size: 'sm',
@@ -11,13 +9,11 @@ const defaultProps = {
 };
 
 function baseStyle(props: Record<string, any>) {
-  const colorScheme = getColorScheme(props);
+  const { colorScheme: c } = props;
 
   return {
-    bg: `${colorScheme}.200`,
     overflow: 'hidden',
     _filledTrack: {
-      bg: mode(`${colorScheme}.600`, `${colorScheme}.500`)(props),
       shadow: 0,
       height: '100%',
       display: 'flex',
@@ -26,6 +22,18 @@ function baseStyle(props: Record<string, any>) {
       _text: {
         color: 'white',
         fontWeight: 'bold',
+      },
+    },
+    _light: {
+      bg: 'muted.200',
+      _filledTrack: {
+        bg: `${c}.600`,
+      },
+    },
+    _dark: {
+      bg: 'muted.700',
+      _filledTrack: {
+        bg: `${c}.400`,
       },
     },
   };


### PR DESCRIPTION
### Progress

- Track Color:
     - light mode:  `primary.200` to `muted.200`
     - dark mode: `primary.200` to `muted.700` 
- Filled Track
    - dark mode: `primary.500` to `primary.400`