### PR TITLE
fix: stack will automatically remove null component

### DIFF
--- a/src/utils/getSpacedChildren.tsx
+++ b/src/utils/getSpacedChildren.tsx
@@ -58,12 +58,22 @@ const getSpacedChildren = (
       ...spacingProp,
     });
 
+    // childrenArray = childrenArray.map((child: any, index: number) => {
+    //   return (
+    //     <React.Fragment key={child.key ?? `spaced-child-${index}`}>
+    //       {child}
+    //       {index < childrenArray.length - 1 && divider}
+    //     </React.Fragment>
+    //   );
+
     childrenArray = childrenArray.map((child: any, index: number) => {
-      return (
+      return Object.keys(child?.props).length ? (
         <React.Fragment key={child.key ?? `spaced-child-${index}`}>
           {child}
           {index < childrenArray.length - 1 && divider}
         </React.Fragment>
+      ) : (
+        <></>
       );
     });
   } else {


### PR DESCRIPTION
The stack will automatically remove a null component, but only if there are no props in them.