### PR TITLE
fix: fixed same key for multiple children error due to stack flattening

### DIFF
--- a/src/utils/getSpacedChildren.tsx
+++ b/src/utils/getSpacedChildren.tsx
@@ -17,15 +17,29 @@ type SpaceType =
 // Thanks @gregberge for code and @nandorojo for suggestion.
 // Original source: https://github.com/gregberge/react-flatten-children
 type ReactChildArray = ReturnType<typeof React.Children.toArray>;
-function flattenChildren(children: React.ReactNode): ReactChildArray {
+function flattenChildren(
+  children: React.ReactNode,
+  keys: (string | number)[] = []
+): ReactChildArray {
   const childrenArray = React.Children.toArray(children);
-  return childrenArray.reduce((flatChildren: ReactChildArray, child) => {
+  return childrenArray.reduce((flatChildren: ReactChildArray, child, index: number) => {
     if ((child as React.ReactElement<any>).type === React.Fragment) {
       return flatChildren.concat(
-        flattenChildren((child as React.ReactElement<any>).props.children)
+        flattenChildren(
+          (child as React.ReactElement<any>).props.children,
+          keys.concat(child.key || index)
+        )
       );
     }
-    flatChildren.push(child);
+    if (React.isValidElement(child)) {
+      flatChildren.push(
+        React.cloneElement(child, {
+          key: keys.concat(String(child.key || index)).join('.')
+        })
+      );
+    } else {
+      flatChildren.push(child);
+    }
     return flatChildren;
   }, []);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
The way stack flattening is implemented right now leads to multiple children having the same key, resulting in these errors:
```
Encountered two children with the same key, .$.$.1
```
This PR fixes the issue by using the child's key or the index as prefix to generate unique keys.
Inspired from this repository: [grrowl/react-keyed-flatten-children](https://github.com/grrowl/react-keyed-flatten-children/blob/master/index.ts)
Linked issue: #4653 

## Changelog

fix: fixed same key for multiple children error due to stack flattening

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
