### PR TITLE
fix: icon-button on focus bg color

### DIFF
--- a/src/theme/components/icon-button.ts
+++ b/src/theme/components/icon-button.ts
@@ -111,7 +111,7 @@ function variantOutline({ colorScheme }: Record<string, any>) {
         },
       },
       _focus: {
-        bg: `${colorScheme}.600`,
+        bg: `${colorScheme}.500`,
         _icon: {
           color: 'muted.900',
         },


### PR DESCRIPTION
### Icon Button - outline variant
- fixed bg color on focus for dark mode