### PR TITLE
fix: replacing rehman to rohit for PR review auto-assign-bot

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -7,7 +7,7 @@ addAssignees: false
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
   - surajahmed
-  - MD-REHMAN
+  - rayan1810
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)


### PR DESCRIPTION
- replacing Rehman with Rohit for PR review auto-assign-bot.