### PR TITLE
feat: avoid spaces on Icon only button

### DIFF
--- a/src/components/primitives/Button/Button.tsx
+++ b/src/components/primitives/Button/Button.tsx
@@ -136,8 +136,9 @@ const Button = (
           ? isLoadingText
             ? boxChildren(isLoadingText)
             : null
-          : boxChildren(children)}
-
+          : children
+          ? boxChildren(children)
+          : null}
         {endIcon && !isLoading ? endIcon : null}
         {isLoading && spinnerPlacement === 'end' ? spinnerElement : null}
       </HStack>


### PR DESCRIPTION
## Summary

Since V3.3.8 a space has been added to the right of an icon (if it's icon start position). If there is no text in the button, the icon `appear` not correctly centered.
The fix test if children is `undefined`. If so it return null so there is no more spaces added.
