### PR TITLE
fix: add icon props in IconButton

### DIFF
--- a/src/components/composites/IconButton/index.tsx
+++ b/src/components/composites/IconButton/index.tsx
@@ -51,6 +51,7 @@ const IconButton = (
   if (icon) {
     clonedIcon = React.cloneElement(icon, {
       ..._icon,
+      ...icon?.props,
     });
   }
 


### PR DESCRIPTION
`Icon` props not getting applied inside `IconButton`

- add `icon.props` while cloning the icon