### PR TITLE
added new fab props

### DIFF
--- a/src/components/composites/Fab/types.tsx
+++ b/src/components/composites/Fab/types.tsx
@@ -6,7 +6,8 @@ export interface InterfaceFabProps extends InterfaceButtonProps {
    * Placement of the Fab
    * @default bottom-right
    */
-  placement?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+   placement?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'|'top-center'|'bottom-center'
+   |'center'|'left-center'|'right-center';
   /**
    * Text to be displayed in Fab
    */

--- a/src/theme/components/fab.ts
+++ b/src/theme/components/fab.ts
@@ -3,6 +3,11 @@ const placementProps: any = {
   'top-left': { top: 4, left: 4, position: 'absolute' },
   'bottom-right': { bottom: 4, right: 4, position: 'absolute' },
   'bottom-left': { bottom: 4, left: 4, position: 'absolute' },
+  'top-center':{left:'50%',position:'absolute',},
+  'bottom-center':{left:'50%',bottom:0,position:'absolute',},
+  'center':{left:'50%',top:'50%',position:'absolute',},
+  'left-center':{top:'50%',position:'absolute',}, 
+  'right-center':{top:'50%',right:0,position:'absolute',}
 };
 const baseStyle = {
   shadow: 7,


### PR DESCRIPTION
The fab component only accepts the following values for its placement prop:
"top-right" | "top-left" | "bottom-right" | "bottom-left".
Added new props for fab component-
->”top-center”
->”bottom-center”
->”center”
->”left-center”
->”right-center”