### PR TITLE
fix: remove string from input type

### DIFF
--- a/src/components/primitives/Input/types.ts
+++ b/src/components/primitives/Input/types.ts
@@ -73,7 +73,7 @@ export interface InterfaceInputProps
   /**
    * Using the type password, user can mask the input.
    */
-  type?: 'text' | 'password' | string;
+  type?: 'text' | 'password';
   /**
    * Ref to be passed to Icon's wrapper Box
    */


### PR DESCRIPTION
### Input type
- RN TextInput doesn't have the same support as web Input for types hence we are removing the string typing from type prop for now. 