### PR TITLE
fix: Select container pressable functionality fixed.

### DIFF
--- a/src/components/primitives/Select/Select.tsx
+++ b/src/components/primitives/Select/Select.tsx
@@ -165,6 +165,15 @@ const Select = (
       editable={false}
       focusable={false}
       isDisabled={isDisabled}
+      onPressIn={
+        Platform.OS !== 'web'
+          ? () => {
+              Keyboard.dismiss();
+              setIsOpen(true);
+              onOpen && onOpen();
+            }
+          : undefined
+      }
     />
   );
 


### PR DESCRIPTION
## Summary

The action sheet does not open when the current select container is pressed. The only button that could be pressed was the dropdown icon. I fixed it by adding the `onPressIn` prop to its input to be able to open the action sheet.

## Changelog

[General] [Fixed] - Pressable function added to Select's input as onPressIn.

## Test Plan

It does not change the user interface.
