### PR TITLE
fix: removing placeholderTextColor from unstyled input theme

### DIFF
--- a/src/theme/components/input.ts
+++ b/src/theme/components/input.ts
@@ -173,12 +173,6 @@ function filledStyle(props: Record<string, any>) {
 function unstyledStyle() {
   return {
     borderWidth: '0',
-    _light: {
-      _focus: { placeholderTextColor: 'text.900' },
-    },
-    _dark: {
-      _focus: { placeholderTextColor: 'text.50' },
-    },
     _focus: {
       bg: 'transparent',
     },


### PR DESCRIPTION
- removing `placeholderTextColor` from unstyled input theme