### PR TITLE
fix: icon as prop fixed

### DIFF
--- a/src/components/primitives/Icon/Icon.tsx
+++ b/src/components/primitives/Icon/Icon.tsx
@@ -5,8 +5,8 @@ import SVGIcon from './SVGIcon';
 import { Factory } from '../../../factory';
 import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 
-const Icon = ({ as, ...props }: IIconProps, ref?: any) => {
-  const { size, ...resolvedProps } = usePropsResolution('Icon', props);
+const Icon = (props: IIconProps, ref?: any) => {
+  const { as, size, ...resolvedProps } = usePropsResolution('Icon', props);
   const tokenizedFontSize = useToken('space', size);
   //TODO: refactor for responsive prop
   if (useHasResponsiveProps(props)) {


### PR DESCRIPTION
In Icon component, `as` prop was not working if it is passed from theme.