### PR TITLE
fix: shadow fix alert dialogbox

### DIFF
--- a/src/theme/components/alert-dialog.ts
+++ b/src/theme/components/alert-dialog.ts
@@ -59,7 +59,7 @@ export const AlertDialog = {
 export const AlertDialogContent = {
   baseStyle: () => {
     return {
-      shadow: 1,
+      shadow: 6,
       rounded: 'lg',
       maxHeight: `${Dimensions.get('window').height - 150}px`,
       overflow: 'hidden',


### PR DESCRIPTION
- adding `shadow: 6` to `AlertDialogContent` in `theme` as per design changes. 