### PR TITLE
fix: linearGradient props are incorrectly spelled

### DIFF
--- a/src/components/primitives/Box/types.ts
+++ b/src/components/primitives/Box/types.ts
@@ -14,7 +14,7 @@ export interface ILinearGradientProps {
     colors: Array<string>;
     start?: Array<number>;
     end?: Array<number>;
-    location?: Array<number>;
+    locations?: Array<number>;
   };
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The code expects the property to be "locations" with an "s", but the props do not include the "s"

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Corrected types of linearGradient

