### PR TITLE
Update types.ts for primitive Input

### DIFF
--- a/src/components/primitives/Input/types.ts
+++ b/src/components/primitives/Input/types.ts
@@ -111,7 +111,7 @@ export interface InterfaceInputProps
   focusOutlineColor?: ColorType;
   /** This prop allow you to change outlineColor when input is in focused state*/
   invalidOutlineColor?: ColorType;
-  ref?: MutableRefObject<any>;
+  ref?: MutableRefObject<any> | RefCallback;
 }
 
 export interface IInputGroupProps extends InterfaceBoxProps<IInputGroupProps> {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This adds 'RefCallback' to ref property for primitive input in order to accommodate for libraries like react-hooks-form which pass a RefCallback type which is not currently accepted.