### PR TITLE
fix: extended time for stale bot and changed auto assign bot

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -7,7 +7,7 @@ addAssignees: false
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
   - surajahmed
-  - MD-REHMAN
+  - rayan1810
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,7 +5,7 @@ daysUntilStale: 60
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 60
+daysUntilClose: 120
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []
@@ -43,7 +43,6 @@ markComment: >
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30
-
 # Limit to only `issues` or `pulls`
 # only: issues
 


### PR DESCRIPTION
- Extended number of days to 6 months for `stale-bot`.
- Replaced `PR` reviewer from `MD-Rehman` to `rayan1810` (Rohit) in `auto-assign-bot`.

