### PR TITLE
fix: accept string value for Slider

### DIFF
--- a/src/components/primitives/Slider/Slider.tsx
+++ b/src/components/primitives/Slider/Slider.tsx
@@ -14,7 +14,7 @@ function Slider({ isDisabled, isReadOnly, ...props }: ISliderProps, ref?: any) {
     'aria-label': props.accessibilityLabel ?? 'Slider',
   };
 
-  if (typeof props.value === 'number') {
+  if (typeof props.value === 'number' || typeof props.value === 'string') {
     //@ts-ignore - React Native Aria slider accepts array of values
     newProps.value = [props.value];
   }


### PR DESCRIPTION
When using a library like react-hook-form the value might be a string
rather than a number

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
