### PR TITLE
Fix/select label value

### DIFF
--- a/example/storybook/stories/components/primitives/Select/Basic.tsx
+++ b/example/storybook/stories/components/primitives/Select/Basic.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Select, Box, CheckIcon, Center } from 'native-base';
 
 export const Example = () => {
-  let [service, setService] = React.useState('');
+  const [service, setService] = React.useState('');
 
   return (
     <Center>

--- a/src/components/primitives/Select/Select.tsx
+++ b/src/components/primitives/Select/Select.tsx
@@ -92,18 +92,18 @@ const Select = (
     },
   });
 
-  const itemsList: Array<{ label: string; value: string }> = React.Children.map(
-    children ?? [],
-    (child: any) => {
-      return {
-        label: child.props.label,
-        value: child.props.value,
-      };
-    }
-  );
+  const itemsList: Array<{
+    label: string;
+    value: string;
+  }> = React.Children.toArray(children).map((child: any) => {
+    return {
+      label: child?.props?.label,
+      value: child?.props?.value,
+    };
+  });
 
   const selectedItemArray = itemsList.filter(
-    (item: any) => item.value === value
+    (item: any) => item?.value === value
   );
 
   const selectedItem =
@@ -140,7 +140,7 @@ const Select = (
   };
 
   if (optimized) {
-    React.Children.map(children, (child: any) => {
+    React.Children.toArray(children).map((child: any) => {
       flatListData.push(child.props);
     });
   }
@@ -232,12 +232,12 @@ const Select = (
               // eslint-disable-next-line no-shadow
               keyExtractor={(_item, index) => index.toString()}
               renderItem={({ item }: any) => {
-                const isSelected = selectedValue === item.value;
+                const isSelected = selectedValue === item?.value;
                 return (
                   <Actionsheet.Item
                     onPress={() => {
                       if (!isDisabled) {
-                        setValue(item.value);
+                        setValue(item?.value);
                       }
                     }}
                     accessibilityState={{ selected: isSelected }}
@@ -245,7 +245,7 @@ const Select = (
                     {..._item}
                     {...(isSelected && _selectedItem)}
                   >
-                    {item.label}
+                    {item?.label}
                   </Actionsheet.Item>
                 );
               }}


### PR DESCRIPTION
### Select
Select was breaking for below example,
```
<Select
  selectedValue={service}
  minWidth="200"
  accessibilityLabel="Choose Service"
  placeholder="Choose Service"
  _selectedItem={{
    bg: 'teal.600',
    endIcon: <CheckIcon size="5" />,
  }}
  mt={1}
  onValueChange={(itemValue) => setService(itemValue)}
  >
  Hello World
  {null}
  <Select.Item label="UX Research" value="ux" />
  <Select.Item label="Web Development" value="web" />
  <Select.Item label="Cross Platform Development" value="cross" />
  <Select.Item label="UI Designing" value="ui" />
  <Select.Item label="Backend Development" value="backend" />
</Select>
```

Here I've passed null value and string in between the `SelectItem`