### PR TITLE
fix | android overlay component does not cover statusbar

### DIFF
--- a/src/components/primitives/Overlay/Overlay.tsx
+++ b/src/components/primitives/Overlay/Overlay.tsx
@@ -51,6 +51,7 @@ export function Overlay({
     return (
       <ExitAnimationContext.Provider value={{ exited, setExited }}>
         <Modal
+          statusBarTranslucent
           transparent
           visible={isOpen}
           onRequestClose={onRequestClose}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
When the modal and the overlay component were shown, the background did not cover the status bar. Suppose the status bar color is white. It looks a little ugly.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Fix android overlay component does not cover statusbar

## Test Plan
![Screenshot_20220715_164807](https://user-images.githubusercontent.com/14011323/179192990-b1995483-67d2-4641-8e92-774af1164c1b.png)
![Screenshot_20220715_164749](https://user-images.githubusercontent.com/14011323/179193004-1d75ddde-5bbc-4c72-9752-48f7622df61b.png)

