### PR TITLE
fix: popover break on falsy children value

### DIFF
--- a/src/components/composites/Popover/PopoverContent.tsx
+++ b/src/components/composites/Popover/PopoverContent.tsx
@@ -53,10 +53,7 @@ export const PopoverContent = React.forwardRef(
     let arrowElement = null;
     const restChildren: any = [];
     React.Children.toArray(props.children).forEach((child: any) => {
-      if (
-        typeof child === 'object' &&
-        child.type.displayName === 'PopperArrow'
-      ) {
+      if (child?.type?.displayName === 'PopperArrow') {
         arrowElement = React.cloneElement(child, {
           backgroundColor: child.props.color ?? color,
         });

--- a/src/components/composites/Popover/PopoverContent.tsx
+++ b/src/components/composites/Popover/PopoverContent.tsx
@@ -52,8 +52,11 @@ export const PopoverContent = React.forwardRef(
 
     let arrowElement = null;
     const restChildren: any = [];
-    React.Children.forEach(props.children, (child) => {
-      if (child.type.displayName === 'PopperArrow') {
+    React.Children.toArray(props.children).forEach((child: any) => {
+      if (
+        typeof child === 'object' &&
+        child.type.displayName === 'PopperArrow'
+      ) {
         arrowElement = React.cloneElement(child, {
           backgroundColor: child.props.color ?? color,
         });


### PR DESCRIPTION
`PopoverContent`  was breaking over the `falsy`, `null` or `string` value of children