### PR TITLE
fix: input outline color props

### DIFF
--- a/src/components/primitives/Input/Input.tsx
+++ b/src/components/primitives/Input/Input.tsx
@@ -7,7 +7,7 @@ import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 import { useHover } from '@react-native-aria/interactions';
 import { extractInObject, stylingProps } from '../../../theme/tools/utils';
 import { usePropsResolution } from '../../../hooks/useThemeProps';
-import { mergeRefs } from '../../../utils';
+import { mergeRefs, resolveStackStyleInput } from '../../../utils';
 import { Stack } from '../Stack';
 import { makeStyledComponent } from '../../../utils/styled';
 import { useResolvedFontFamily } from '../../../hooks/useResolvedFontFamily';
@@ -35,12 +35,6 @@ const Input = (
     setIsFocused(focusState);
     callback();
   };
-
-  /**Converting into Hash Color Code */
-  //@ts-ignore
-  props.focusOutlineColor = useToken('colors', props.focusOutlineColor);
-  //@ts-ignore
-  props.invalidOutlineColor = useToken('colors', props.invalidOutlineColor);
 
   const _ref = React.useRef(null);
   const { isHovered } = useHover({}, _ref);
@@ -113,9 +107,37 @@ const Input = (
     'colors',
     underlineColorAndroid
   );
+
+  /**Converting into Hash Color Code */
+  //@ts-ignore
+  resolvedProps.focusOutlineColor = useToken(
+    'colors',
+    resolvedProps.focusOutlineColor
+  );
+  //@ts-ignore
+  resolvedProps.invalidOutlineColor = useToken(
+    'colors',
+    resolvedProps.invalidOutlineColor
+  );
   //TODO: refactor for responsive prop
   if (useHasResponsiveProps(props)) {
     return null;
+  }
+
+  if (resolvedProps.focusOutlineColor && isFocused) {
+    layoutProps.borderColor = resolvedProps.focusOutlineColor;
+    _stack.style = resolveStackStyleInput(
+      props.variant,
+      resolvedProps.focusOutlineColor
+    );
+  }
+
+  if (resolvedProps.invalidOutlineColor && props.isInvalid) {
+    layoutProps.borderColor = resolvedProps.invalidOutlineColor;
+    _stack.style = resolveStackStyleInput(
+      props.variant,
+      resolvedProps.invalidOutlineColor
+    );
   }
 
   return (

--- a/src/components/primitives/Input/types.ts
+++ b/src/components/primitives/Input/types.ts
@@ -109,7 +109,7 @@ export interface InterfaceInputProps
   _stack?: Partial<IStackProps>;
   /** This prop allow you to change outlineColor when input is in focused state*/
   focusOutlineColor?: ColorType;
-  /** This prop allow you to change outlineColor when input is in focused state*/
+  /** This prop allow you to change outlineColor when input is in invalid state*/
   invalidOutlineColor?: ColorType;
   ref?: MutableRefObject<any> | RefCallback<any>;
 }

--- a/src/theme/components/input.ts
+++ b/src/theme/components/input.ts
@@ -42,9 +42,8 @@ const baseStyle = (props: InterfaceInputProps & { theme: any }) => {
         _hover: { borderColor: 'primary.600' },
         _stack: {
           style: {
-            outlineWidth: '1px',
-            outlineColor: primary[600],
-            outlineStyle: 'solid',
+            outlineWidth: '0',
+            boxShadow: `0 0 0 1px ${primary[600]}`,
           },
         },
       },
@@ -53,9 +52,8 @@ const baseStyle = (props: InterfaceInputProps & { theme: any }) => {
         _hover: { borderColor: 'error.600' },
         _stack: {
           style: {
-            outlineWidth: '1px',
-            outlineColor: error[600],
-            outlineStyle: 'solid',
+            outlineWidth: '0',
+            boxShadow: `0 0 0 1px ${error[600]}`,
           },
         },
       },
@@ -90,9 +88,8 @@ const baseStyle = (props: InterfaceInputProps & { theme: any }) => {
         _hover: { borderColor: 'primary.500' },
         _stack: {
           style: {
-            outlineWidth: '1px',
-            outlineColor: primary[500],
-            outlineStyle: 'solid',
+            outlineWidth: '0',
+            boxShadow: `0 0 0 1px ${primary[500]}`,
           },
         },
       },
@@ -100,9 +97,8 @@ const baseStyle = (props: InterfaceInputProps & { theme: any }) => {
         borderColor: 'error.500',
         _stack: {
           style: {
-            outlineWidth: '1px',
-            outlineColor: error[500],
-            outlineStyle: 'solid',
+            outlineWidth: '0',
+            boxShadow: `0 0 0 1px ${error[500]}`,
           },
         },
         _hover: { borderColor: 'error.500' },

--- a/src/theme/components/input.ts
+++ b/src/theme/components/input.ts
@@ -43,7 +43,7 @@ const baseStyle = (props: InterfaceInputProps & { theme: any }) => {
         _stack: {
           style: {
             outlineWidth: '1px',
-            outlineColor: `${props.focusOutlineColor || primary[600]}`,
+            outlineColor: primary[600],
             outlineStyle: 'solid',
           },
         },
@@ -54,7 +54,7 @@ const baseStyle = (props: InterfaceInputProps & { theme: any }) => {
         _stack: {
           style: {
             outlineWidth: '1px',
-            outlineColor: `${props.invalidOutlineColor || error[600]}`,
+            outlineColor: error[600],
             outlineStyle: 'solid',
           },
         },
@@ -91,7 +91,7 @@ const baseStyle = (props: InterfaceInputProps & { theme: any }) => {
         _stack: {
           style: {
             outlineWidth: '1px',
-            outlineColor: `${props.focusOutlineColor || primary[500]}`,
+            outlineColor: primary[500],
             outlineStyle: 'solid',
           },
         },
@@ -101,7 +101,7 @@ const baseStyle = (props: InterfaceInputProps & { theme: any }) => {
         _stack: {
           style: {
             outlineWidth: '1px',
-            outlineColor: `${props.invalidOutlineColor || error[500]}`,
+            outlineColor: error[500],
             outlineStyle: 'solid',
           },
         },
@@ -205,7 +205,7 @@ function underlinedStyle(props: InterfaceInputProps & { theme: any }) {
         _stack: {
           style: {
             outlineWidth: '0',
-            boxShadow: `0 1px 0 0 ${props.focusOutlineColor || primary[600]}`,
+            boxShadow: `0 1px 0 0 ${primary[600]}`,
           },
         },
       },
@@ -213,7 +213,7 @@ function underlinedStyle(props: InterfaceInputProps & { theme: any }) {
         _stack: {
           style: {
             outlineWidth: 0,
-            boxShadow: `0 1px 0 0 ${props.invalidOutlineColor || error[600]}`,
+            boxShadow: `0 1px 0 0 ${error[600]}`,
           },
         },
       },
@@ -223,7 +223,7 @@ function underlinedStyle(props: InterfaceInputProps & { theme: any }) {
         _stack: {
           style: {
             outlineWidth: '0',
-            boxShadow: `0 1px 0 0 ${props.focusOutlineColor || primary[500]}`,
+            boxShadow: `0 1px 0 0 ${primary[500]}`,
           },
         },
       },
@@ -231,7 +231,7 @@ function underlinedStyle(props: InterfaceInputProps & { theme: any }) {
         _stack: {
           style: {
             outlineWidth: 0,
-            boxShadow: `0 1px 0 0 ${props.focusOutlineColor || error[500]}`,
+            boxShadow: `0 1px 0 0 ${error[500]}`,
           },
         },
       },

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,3 +19,4 @@ export { ariaAttr } from './accessibilityUtils';
 export { createContext } from './createContext';
 export { useKeyboardBottomInset } from './useKeyboardBottomInset';
 export { isEmptyObj } from './isEmptyObj';
+export { resolveStackStyleInput } from './resolveStackStyleInput';

--- a/src/utils/resolveStackStyleInput.ts
+++ b/src/utils/resolveStackStyleInput.ts
@@ -1,0 +1,18 @@
+export const resolveStackStyleInput = (variant: any, color: any) => {
+  if (variant === 'underlined') {
+    return {
+      outlineWidth: '0',
+      boxShadow: `0 1px 0 0 ${color}`,
+    };
+  } else if (variant === 'unstyled') {
+    return {
+      outlineWidth: 0,
+    };
+  } else {
+    return {
+      outlineWidth: '1px',
+      outlineColor: color,
+      outlineStyle: 'solid',
+    };
+  }
+};

--- a/src/utils/resolveStackStyleInput.ts
+++ b/src/utils/resolveStackStyleInput.ts
@@ -10,9 +10,8 @@ export const resolveStackStyleInput = (variant: any, color: any) => {
     };
   } else {
     return {
-      outlineWidth: '1px',
-      outlineColor: color,
-      outlineStyle: 'solid',
+      outlineWidth: '0',
+      boxShadow: `0 0 0 1px ${color}`,
     };
   }
 };


### PR DESCRIPTION
- `focusOutlineColor` and `invalidOutlineColor` will now change borders and outlineColor when isFocused and isInvalid is true respectively. #3856 