### PR TITLE
fix: linear gradient locations typing

### DIFF
--- a/src/components/primitives/Box/types.ts
+++ b/src/components/primitives/Box/types.ts
@@ -14,7 +14,7 @@ export interface ILinearGradientProps {
     colors: Array<string>;
     start?: Array<number>;
     end?: Array<number>;
-    location?: Array<number>;
+    locations?: Array<number>;
   };
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

LinearGradient `locations` props was wrongly typed. In js code it was working fine.

(this is reopening of https://github.com/GeekyAnts/NativeBase/pull/5025 which was closed by mistake)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Linear gradient `locations` TypeScript typing

## Test Plan

This should work in tsx
```
        <Box
          bg={{
            linearGradient: {
              colors: ["coral", "#2D3D4DFF"],
              locations: [0.9, 1],
            },
          }}>
```
