### PR TITLE
fix: warning on RN v0.65+

### DIFF
--- a/src/core/color-mode/hooks.tsx
+++ b/src/core/color-mode/hooks.tsx
@@ -31,8 +31,18 @@ export const useAppState = () => {
     () => ({
       getCurrentValue: () => AppState.currentState,
       subscribe: (callback: () => void) => {
-        AppState.addEventListener('change', callback);
-        return () => AppState.removeEventListener('change', callback);
+        const subsription = AppState.addEventListener('change', callback);
+        // return () => AppState.removeEventListener('change', callback);
+        return () => {
+          if (AppState.removeEventListener) {
+            // React Native < 0.65
+            AppState.removeEventListener('change', callback);
+          } else {
+            // React Native >= 0.65
+            // @ts-ignore:next-line ignoring ts error as devDependency contains "@types/react-native" < 0.65
+            subsription.remove();
+          }
+        };
       },
     }),
     []

--- a/src/core/color-mode/hooks.tsx
+++ b/src/core/color-mode/hooks.tsx
@@ -32,7 +32,6 @@ export const useAppState = () => {
       getCurrentValue: () => AppState.currentState,
       subscribe: (callback: () => void) => {
         const subsription = AppState.addEventListener('change', callback);
-        // return () => AppState.removeEventListener('change', callback);
         return () => {
           if (AppState.removeEventListener) {
             // React Native < 0.65


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

`removeEventListener` is deprecated for a several years https://reactnative.dev/docs/0.65/appstate#removeeventlistener



## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fix] - Warning on react-native 0.65+

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
