### PR TITLE
:hammer: Fix add generics support for useTheme

### DIFF
--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,6 +1,6 @@
 import { useNativeBaseConfig } from './../core/NativeBaseContext';
 
-export function useTheme() {
+export function useTheme<T = any>(): T {
   const theme = useNativeBaseConfig('useTheme').theme;
   if (!theme) {
     throw Error(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Using a custom theme, I always write `const theme = useTheme() as ThemeType`. But If we incorporate the generics, we can easily use custom types as `const theme = useTheme<ThemeType>()`.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

1d45a48 - 🔨 Fix add generics support for useTheme