### PR TITLE
fix: content changes in text types

### DIFF
--- a/src/components/primitives/Text/types.tsx
+++ b/src/components/primitives/Text/types.tsx
@@ -51,23 +51,23 @@ export interface InterfaceTextProps<T = ITextProps>
    */
   noOfLines?: number;
   /**
-   * Make the text bold.
+   * Used to make the text bold.
    */
   bold?: boolean;
   /**
-   * If true, it'll render an ellipsis when the text exceeds the width of the viewport or maxWidth set.
+   * If true, it will render an ellipsis when the text exceeds the width of the viewport or maxWidth set.
    */
   isTruncated?: boolean;
   /**
-   * Make the text italic.
+   * Used to make the text italic.
    */
   italic?: boolean;
   /**
-   * Underline the text.
+   * Used to underline the text.
    */
   underline?: boolean;
   /**
-   * A horizontal line through its center.
+   * A horizontal line through the center of the text.
    */
   strikeThrough?: boolean;
   /**
@@ -75,7 +75,7 @@ export interface InterfaceTextProps<T = ITextProps>
    */
   sub?: boolean;
   /**
-   * Highlight the text with a yellow background.
+   * Used to highlight the text with a yellow background.
    */
   highlight?: boolean;
   /**


### PR DESCRIPTION
**Old Content -**
Make the text bold.
If true, it'll render an ellipsis when the text exceeds the width of the viewport or maxWidth set.
Make the text italic.
Underline the text.
A horizontal line through its center.
Highlight the text with a yellow background.
**New Content -**
Used to make the text bold.
If true, it will render an ellipsis when the text exceeds the width of the viewport or maxWidth set.
Used to make the text italic.
A horizontal line through the center of the text.