### PR TITLE
fix: content changes in menu types

### DIFF
--- a/src/components/composites/Menu/types.ts
+++ b/src/components/composites/Menu/types.ts
@@ -10,28 +10,28 @@ import type { CustomProps } from '../../../components/types';
 
 export interface InterfaceMenuProps extends InterfaceBoxProps<IMenuProps> {
   /**
-   * Function that returns a React Element. This element will be used as a Trigger for the menu
+   * Function that returns a React Element. This element will be used as a Trigger for the menu.
    */
   trigger: (_props: any, state: { open: boolean }) => JSX.Element;
   /**
-   * This function will be invoked when menu is opened
+   * This function will be invoked when the menu is opened.
    */
   onOpen?: () => void;
   /**
-   * This function will be invoked when menu is closed. It'll also be called when user attempts to close the menu via Escape key or backdrop press.
+   * This function will be invoked when menu is closed.  It will also be called when the user attempts to close the menu via Escape key or backdrop press.
    */
   onClose?: () => void;
   /**
-   * Whether menu should be closed when a menu item is pressed
+   * Whether menu should be closed when a menu item is pressed.
    * @default true
    */
   closeOnSelect?: boolean;
   /**
-   * If true, the menu will be opened by default
+   * If true, the menu will be opened by default.
    */
   defaultIsOpen?: boolean;
   /**
-   * Whether the menu is opened. Useful for conrolling the open state
+   * Whether the menu is opened. Useful for controlling the open state.
    */
   isOpen?: boolean;
   /**
@@ -43,7 +43,7 @@ export interface InterfaceMenuProps extends InterfaceBoxProps<IMenuProps> {
    */
   offset?: number;
   /**
-   * Determines whether menu content should overlap with the trigger
+   * Determines whether menu content should overlap with the trigger.
    * @default false
    */
   shouldOverlapWithTrigger?: boolean;
@@ -85,19 +85,19 @@ export interface InterfaceMenuProps extends InterfaceBoxProps<IMenuProps> {
 
 export interface IMenuItemProps extends IPressableProps {
   /**
-   * Children of Menu Item
+   * Children of Menu Item.
    */
   children: string | JSX.Element | Array<JSX.Element>;
   /**
-   * Whether menu item is disabled
+   * Whether menu item is disabled.
    */
   isDisabled?: boolean;
   /**
-   * Props to be passed to Text
+   * Props to be passed to Text.
    */
   _text?: Partial<ITextProps>;
   /**
-   * This value will be available for the typeahead menu feature
+   * This value will be available for the typeahead menu feature.
    */
   textValue?: string;
 }
@@ -122,11 +122,11 @@ export interface IMenuItemOptionProps extends IMenuItemProps {
 }
 export interface IMenuGroupProps {
   /**
-   *  The title of the menu group
+   *  The title of the menu group.
    */
   title: string;
   /**
-   * The children of Menu group
+   * The children of the Menu group.
    */
   children: JSX.Element | Array<JSX.Element>;
   /**
@@ -141,15 +141,15 @@ export interface IMenuOptionGroupProps extends IMenuGroupProps {
    */
   type: 'radio' | 'checkbox';
   /**
-   * The initial value of the option group
+   * The initial value of the option group.
    */
   defaultValue?: string | number | string[] | number[];
   /**
-   * The value of the option group
+   * The value of the option group.
    */
   value?: string | number | Array<string> | Array<number>;
   /**
-   * Function called when selection changes
+   * Function called when selection changes.
    */
   onChange?: (val: any) => void;
 }


### PR DESCRIPTION
**Old Content -** 
It'll also be called when user attempts to close the menu via Escape key or backdrop press.
This element will be used as a Trigger for the menu
This function will be invoked when menu is opened
Whether menu should be closed when a menu item is pressed
If true, the menu will be opened by default
Useful for conrolling the open state
menu content should overlap with the trigger
Children of Menu Item
Whether menu item is disabled
Props to be passed to Text
typeahead menu feature
The title of the menu group
The children of Menu group
The initial value of the option group
The value of the option group
Function called when selection changes
**New Content -**
It will also be called when the user attempts to close the menu via Escape key or backdrop press.
This element will be used as a Trigger for the menu.
This function will be invoked when the menu is opened.
Whether menu should be closed when a menu item is pressed.
If true, the menu will be opened by default.
Useful for controlling the open state.
menu content should overlap with the trigger.
Children of Menu Item.
Whether menu item is disabled.
Props to be passed to Text.
 typeahead menu feature.
The title of the menu group.
The children of the Menu group.
The initial value of the option group.
The value of the option group.
Function called when selection changes.