### PR TITLE
Fix:  content changes in modal types

### DIFF
--- a/src/components/composites/Menu/types.ts
+++ b/src/components/composites/Menu/types.ts
@@ -10,28 +10,28 @@ import type { CustomProps } from '../../../components/types';
 
 export interface InterfaceMenuProps extends InterfaceBoxProps<IMenuProps> {
   /**
-   * Function that returns a React Element. This element will be used as a Trigger for the menu
+   * Function that returns a React Element. This element will be used as a Trigger for the menu.
    */
   trigger: (_props: any, state: { open: boolean }) => JSX.Element;
   /**
-   * This function will be invoked when menu is opened
+   * This function will be invoked when the menu is opened.
    */
   onOpen?: () => void;
   /**
-   * This function will be invoked when menu is closed. It'll also be called when user attempts to close the menu via Escape key or backdrop press.
+   * This function will be invoked when menu is closed.  It will also be called when the user attempts to close the menu via Escape key or backdrop press.
    */
   onClose?: () => void;
   /**
-   * Whether menu should be closed when a menu item is pressed
+   * Whether menu should be closed when a menu item is pressed.
    * @default true
    */
   closeOnSelect?: boolean;
   /**
-   * If true, the menu will be opened by default
+   * If true, the menu will be opened by default.
    */
   defaultIsOpen?: boolean;
   /**
-   * Whether the menu is opened. Useful for conrolling the open state
+   * Whether the menu is opened. Useful for controlling the open state.
    */
   isOpen?: boolean;
   /**
@@ -43,7 +43,7 @@ export interface InterfaceMenuProps extends InterfaceBoxProps<IMenuProps> {
    */
   offset?: number;
   /**
-   * Determines whether menu content should overlap with the trigger
+   * Determines whether menu content should overlap with the trigger.
    * @default false
    */
   shouldOverlapWithTrigger?: boolean;
@@ -85,19 +85,19 @@ export interface InterfaceMenuProps extends InterfaceBoxProps<IMenuProps> {
 
 export interface IMenuItemProps extends IPressableProps {
   /**
-   * Children of Menu Item
+   * Children of Menu Item.
    */
   children: string | JSX.Element | Array<JSX.Element>;
   /**
-   * Whether menu item is disabled
+   * Whether menu item is disabled.
    */
   isDisabled?: boolean;
   /**
-   * Props to be passed to Text
+   * Props to be passed to Text.
    */
   _text?: Partial<ITextProps>;
   /**
-   * This value will be available for the typeahead menu feature
+   * This value will be available for the typeahead menu feature.
    */
   textValue?: string;
 }
@@ -122,11 +122,11 @@ export interface IMenuItemOptionProps extends IMenuItemProps {
 }
 export interface IMenuGroupProps {
   /**
-   *  The title of the menu group
+   *  The title of the menu group.
    */
   title: string;
   /**
-   * The children of Menu group
+   * The children of the Menu group.
    */
   children: JSX.Element | Array<JSX.Element>;
   /**
@@ -141,15 +141,15 @@ export interface IMenuOptionGroupProps extends IMenuGroupProps {
    */
   type: 'radio' | 'checkbox';
   /**
-   * The initial value of the option group
+   * The initial value of the option group.
    */
   defaultValue?: string | number | string[] | number[];
   /**
-   * The value of the option group
+   * The value of the option group.
    */
   value?: string | number | Array<string> | Array<number>;
   /**
-   * Function called when selection changes
+   * Function called when selection changes.
    */
   onChange?: (val: any) => void;
 }

--- a/src/components/composites/Modal/types.ts
+++ b/src/components/composites/Modal/types.ts
@@ -8,19 +8,19 @@ import type { ThemeComponentSizeType } from '../../../components/types/utils';
 import type { IOverlayProps } from '../../primitives/Overlay';
 export interface InterfaceModalProps extends InterfaceBoxProps<IModalProps> {
   /**
-   * If true, the modal will open. Useful for controllable state behaviour
+   * If true, the modal will open. Useful for controllable state behavior.
    */
   isOpen?: boolean;
   /**
-   * Callback invoked when the modal is closed
+   * Callback invoked when the modal is closed.
    */
   onClose?: any;
   /**
-   * If true, the modal will be opened by default
+   * If true, the modal will be opened by default.
    */
   defaultIsOpen?: boolean;
   /**
-   * The size of the modal
+   * The size of the modal.
    */
   size?: ThemeComponentSizeType<'Modal'>;
   /**
@@ -37,22 +37,22 @@ export interface InterfaceModalProps extends InterfaceBoxProps<IModalProps> {
    */
   avoidKeyboard?: boolean;
   /**
-   * If true, the modal will close when the overlay is clicked
+   * If true, the modal will close when the overlay is clicked.
    * @default true
    */
   closeOnOverlayClick?: boolean;
   /**
-   * If true, the modal will close when Escape key is pressed
+   * If true, the modal will close when Escape key is pressed.
    * @default true
    */
   isKeyboardDismissable?: boolean;
   /**
-   * If true, a backdrop element is visible
+   * If true, a backdrop element is visible.
    * @default true
    */
   overlayVisible?: boolean;
   /**
-   * If true, a backdrop element is visible
+   * If true, a backdrop element is visible.
    * @default true
    */
   backdropVisible?: boolean;
@@ -61,7 +61,7 @@ export interface InterfaceModalProps extends InterfaceBoxProps<IModalProps> {
    */
   _backdrop?: any;
   /**
-   * Sets the animation type
+   * Sets the animation type.
    * @default "fade"
    */
   animationPreset?: 'fade' | 'slide';


### PR DESCRIPTION
**Old Content -** 
Useful for controllable state behaviour
Callback invoked when the modal is closed
If true, the modal will be opened by default
The size of the modal
If true, the modal will close when the overlay is clicked
If true, the modal will close when Escape key is pressed
If true, a backdrop element is visible
Sets the animation type
**New Content -**
Useful for controllable state behavior. 
Callback invoked when the modal is closed.
If true, the modal will be opened by default.
The size of the modal.
If true, the modal will close when the overlay is clicked.
If true, the modal will close when Escape key is pressed.
If true, a backdrop element is visible.
Sets the animation type.