### PR TITLE
fix:  content changes in actionsheet types

### DIFF
--- a/src/components/composites/Actionsheet/types.tsx
+++ b/src/components/composites/Actionsheet/types.tsx
@@ -6,11 +6,11 @@ import type { CustomProps } from '../../../components/types';
 export interface InterfaceActionsheetProps
   extends InterfaceBoxProps<IActionsheetProps> {
   /**
-   * If true, the ActionSheet will open. Useful for controllable state behaviour
+   * If true, the ActionSheet will open. Useful for controllable state behavior.
    */
   isOpen?: boolean;
   /**
-   * Callback invoked when the modal is closed
+   * Callback invoked when the modal is closed.
    */
   onClose?: () => any;
   /**
@@ -36,15 +36,15 @@ export interface InterfaceActionsheetProps
 export interface IActionsheetContentProps
   extends InterfaceBoxProps<IActionsheetContentProps> {
   /**
-   * Props applied on area above actionsheet content
+   * Props applied on area above actionsheet content.
    */
   _dragIndicatorWrapperOffSet?: InterfaceBoxProps<IActionsheetContentProps>;
   /**
-   * Props applied on area around drag indicator
+   * Props applied on area around drag indicator.
    */
   _dragIndicatorWrapper?: InterfaceBoxProps<IActionsheetContentProps>;
   /**
-   * Props applied on drag indicator
+   * Props applied on drag indicator.
    */
   _dragIndicator?: InterfaceBoxProps<IActionsheetContentProps>;
 }


### PR DESCRIPTION
Old Content - 
Useful for controllable state behaviour
Callback invoked when the modal is closed
Props applied on area above actionsheet content
Props applied on area around drag indicator
New content - 
Useful for controllable state behavior.
Callback invoked when the modal is closed.
Props applied on area above actionsheet content.
Props applied on area around drag indicator.