### PR TITLE
fix: content changes in avatar-types

### DIFF
--- a/src/components/composites/Avatar/types.tsx
+++ b/src/components/composites/Avatar/types.tsx
@@ -10,16 +10,16 @@ export interface InterfaceAvatarProps extends InterfaceBoxProps<IAvatarProps> {
    */
   source?: ImageSourcePropType;
   /**
-   * The size of the avatar
+   * The size of the avatar.
    * @default md
    */
   size?: ThemeComponentSizeType<'Avatar'>;
   /**
-   * For providing props to Image component inside Avatar
+   * For providing props to Image component inside the Avatar.
    */
   _image?: Partial<IImageProps>;
   /**
-   * ref to be attached to Avatar wrapper
+   * ref to be attached to the Avatar wrapper.
    */
   wrapperRef?: MutableRefObject<any>;
 }


### PR DESCRIPTION
Old Content - 
The size of the avatar
For providing props to Image component inside Avatar.
ref to be attached to Avatar wrapper
New Content - 
The size of the avatar.
For providing props to Image component inside the Avatar.
ref to be attached to the Avatar wrapper.