### PR TITLE
fix: content changes in transitions types

### DIFF
--- a/src/components/composites/Transitions/types.tsx
+++ b/src/components/composites/Transitions/types.tsx
@@ -74,7 +74,7 @@ export interface ITransitionStyleProps extends ISupportedTransitions {
 }
 export interface ITransitionProps extends ViewProps {
   /**
-   * Callback invoked when transition is completed
+   * Callback invoked when the transition is completed.
    */
   onTransitionComplete?: (s: 'entered' | 'exited') => any;
   /**
@@ -101,28 +101,28 @@ export interface ITransitionProps extends ViewProps {
 
 export interface IPresenceTransitionProps extends ViewProps {
   /**
-   * Callback invoked when transition is completed
+   * Callback invoked when the transition is completed.
    */
   onTransitionComplete?: (s: 'entered' | 'exited') => any;
   /**
-   * Styles before the transition starts
+   * Styles before the transition starts.
    */
   initial?: ISupportedTransitions;
   /**
-   * Entry animation styles
+   * Entry animation styles.
    */
   animate?: ITransitionStyleProps;
   /**
-   * Exit animation styles
+   * Exit animation styles.
    */
   exit?: ITransitionStyleProps;
   /**
-   * Determines whether to start the animation
+   * Determines whether to start the animation.
    */
   visible?: boolean;
   children?: ReactNode;
   /**
-   * Accepts a Component to be rendered as Wrapper. Defaults to `View`
+   * Accepts a Component to be rendered as Wrapper. Defaults to `View`.
    */
   as?: ReactNode;
 }


### PR DESCRIPTION
Old Content - 
Callback invoked when transition is completed
Styles before the transition starts
Entry animation styles
Exit animation styles
Determines whether to start the animation
Defaults to `View`
New Content - 
Callback invoked when the transition is completed.
Styles before the transition starts.
Entry animation styles.
Exit animation styles.
Determines whether to start the animation.
Defaults to `View`.