### PR TITLE
fix: content changes in scrollview types

### DIFF
--- a/src/components/basic/ScrollView/types.ts
+++ b/src/components/basic/ScrollView/types.ts
@@ -10,7 +10,7 @@ export interface InterfaceScrollViewProps
    * Renders components as Box children. Accepts a JSX.Element or an array of JSX.Element. */
   children?: JSX.Element | JSX.Element[] | string | any;
   /**
-   * pass props to contentContainerStyle, and this also resolved NB tokens.
+   * Pass props to contentContainerStyle, and this also resolves NB tokens.
    */
   _contentContainerStyle?: Partial<IScrollViewProps>;
 }


### PR DESCRIPTION
Old Content - 
pass props to contentContainerStyle, and this also resolved NB tokens.
New Content - 
Pass props to contentContainerStyle, and this also resolves NB tokens.