### PR TITLE
fix: content changes in fab types

### DIFF
--- a/src/components/composites/Fab/types.tsx
+++ b/src/components/composites/Fab/types.tsx
@@ -3,21 +3,21 @@ import type { InterfaceButtonProps } from '../../primitives/Button/types';
 
 export interface InterfaceFabProps extends InterfaceButtonProps {
   /**
-   * Placement of the Fab
+   * Placement of the Fab.
    * @default bottom-right
    */
   placement?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
   /**
-   * Text to be displayed in Fab
+   * Text to be displayed in Fab.
    */
   label?: JSX.Element | string;
   /**
-   * Icon to be displayed in Fab
+   * Icon to be displayed in Fab.
    */
   icon?: JSX.Element;
   /**
    * Determines whether the Fab should be rendered in a Portal.
-   * Refer this solution before using this prop
+   * Refer to this solution before using this prop-
    * https://github.com/GeekyAnts/NativeBase/issues/3817
    * @default true
    */


### PR DESCRIPTION
Old Content - 
Placement of the Fab
Text to be displayed in Fab
Icon to be displayed in Fab
Refer this solution before using this prop
New Content - 
Placement of the Fab.
Text to be displayed in Fab.
Icon to be displayed in Fab.
Refer to this solution before using this prop-