### PR TITLE
extract accessibilityLabel from nonLayoutProps

### DIFF
--- a/src/components/primitives/Checkbox/Checkbox.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.tsx
@@ -154,6 +154,7 @@ const CheckboxComponent = React.memo(
     ] = extractInObject(nonLayoutProps, [
       'accessibilityRole',
       'accessibilityState',
+      'accessibilityLabel',
     ]);
 
     //TODO: refactor for responsive prop


### PR DESCRIPTION
## Summary

When extract _accessibilityProps_ from _nonLayoutProps_  we missing _accessibilityLabel_ key; so that lead to inconsistent accessibility announcement between **Radio** and **Checkbox**

Ex: with accessibilityLabel="This is example label"
Then accessibility announcement on components will be :
- Radio:  not checked, This is example label, Radio button.
- Checkbox: not checked, Checkbox, This is example label.


## Changelog

[General] - [Fixed] - fix checkbox a11y announcement inconsistent with Radio component

## Test Plan

It is not a breaking change.