### PR TITLE
Make cbs returned from useDisclose referentially stable

### DIFF
--- a/src/hooks/useDisclose.ts
+++ b/src/hooks/useDisclose.ts
@@ -1,16 +1,16 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 export function useDisclose(initState?: boolean) {
   const [isOpen, setIsOpen] = React.useState(initState || false);
-  const onOpen = () => {
+  const onOpen = useCallback(() => {
     setIsOpen(true);
-  };
-  const onClose = () => {
+  }, []);
+  const onClose = useCallback(() => {
     setIsOpen(false);
-  };
-  const onToggle = () => {
-    setIsOpen(!isOpen);
-  };
+  },[]);
+  const onToggle = useCallback(() => {
+    setIsOpen(prevIsOpen => !prevIsOpen);
+  }, []);
   return {
     isOpen,
     onOpen,


### PR DESCRIPTION
So that we can omit onOpen, onClose, onToggle from dependency arrays and optimize performance

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
onOpen, onClose, and onToggle are changing with every render. Exhaustive hooks linter tells me to put it in the dependency array of a useCallback, but since it changes every render, the callback is recreated every render, breaking memoization of the FlatList (since I'm passing this callback to one of the FlatList's items).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Change] - useDisclose returns callbacks that are referentially stable

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
