### PR TITLE
Update ImageStatics

### DIFF
--- a/src/components/primitives/Image/index.tsx
+++ b/src/components/primitives/Image/index.tsx
@@ -97,7 +97,7 @@ const Image = memo(
 );
 
 interface ImageStatics {
-  getSize: typeof RNImage.prefetch;
+  getSize: typeof RNImage.getSize;
   prefetch: typeof RNImage.prefetch;
   queryCache: typeof RNImage.queryCache;
 }


### PR DESCRIPTION
fix `getSize` on ImageStatics

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`getSize` for `ImageStatics` was set to `RNImage.prefetch` instead of `RNImage.getSize`

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
