### PR TITLE
Saeed

### DIFF
--- a/src/components/composites/Actionsheet/Actionsheet.tsx
+++ b/src/components/composites/Actionsheet/Actionsheet.tsx
@@ -30,7 +30,7 @@ const Actionsheet = (
       onClose={onClose}
       {...resolvedProps}
       overlayVisible={disableOverlay ? false : true}
-      closeOnOverlayClick={disableOverlay ? false : true}
+      closeOnOverlayClick={true}
       ref={ref}
       _overlay={{ style: overlayStyle }}
     >


### PR DESCRIPTION
## Summary
on `Actionsheet` when user disable overlay by adding `disableOverlay` it is impossible to close with click outside of modal. 
With this change you can disable overlay and prevent from dimming screen and close action menu easily.



