### PR TITLE
fix: addons example in  input component

### DIFF
--- a/example/storybook/stories/components/primitives/Input/Addons.tsx
+++ b/example/storybook/stories/components/primitives/Input/Addons.tsx
@@ -10,8 +10,8 @@ import {
 
 export const Example = () => {
   return (
-    <Stack alignItems="center">
-      <InputGroup w={{ base: '70%', md: '285' }}>
+    <Stack>
+      <InputGroup w={{ base: '70%', md: '285' }} justifyContent="center">
         <InputLeftAddon children={'https://'} />
         <Input w={{ base: '70%', md: '100%' }} placeholder="nativebase" />
         <InputRightAddon children={'.io'} />


### PR DESCRIPTION
Fix: Addons example in input component placed in the center.