### PR TITLE
feat: added optional support for angle

### DIFF
--- a/example/storybook/stories/components/primitives/Box/LinearGrad.tsx
+++ b/example/storybook/stories/components/primitives/Box/LinearGrad.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Box } from 'native-base';
+import React from 'react';
 export const Example = () => {
   return (
     <Box
@@ -24,3 +24,28 @@ export const Example = () => {
     </Box>
   );
 };
+
+export const ExampleWithAngle = () => {
+  return (
+    <Box
+      bg={{
+        linearGradient: {
+          colors: ['lightBlue.300', 'violet.800'],
+          angle: 45,
+          angleCenter: { x: 0.5, y: 0.5},
+        },
+      }}
+      p="12"
+      w="72"
+      rounded="xl"
+      _text={{
+        fontSize: 'md',
+        fontWeight: 'medium',
+        color: 'warmGray.50',
+        textAlign: 'center',
+      }}
+    >
+      This is a Box with Linear Gradient using angle props
+    </Box>
+  );
+}

--- a/example/storybook/stories/components/primitives/Box/index.tsx
+++ b/example/storybook/stories/components/primitives/Box/index.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { withKnobs } from '@storybook/addon-knobs';
 import { Example as Basic } from './basic';
-import { Example as LinearGrad } from './LinearGrad';
+import {
+   Example as LinearGrad,
+   ExampleWithAngle as LinearGradWithAngle 
+} from './LinearGrad';
 import { Example as WithRef } from './WithRef';
 import { Example as Composition } from './composition';
 // import { Example as CompositionCard } from './composition-card';
@@ -17,6 +20,7 @@ storiesOf('Box', module)
   .addDecorator((getStory: any) => <Wrapper>{getStory()}</Wrapper>)
   .add('Basic Box', () => <Basic />)
   .add('LinearGradient Box', () => <LinearGrad />)
+  .add('LinearGradient Box Angle', () => <LinearGradWithAngle />)
   .add('Composition', () => <Composition />)
   .add('With Ref', () => <WithRef />);
 // .add('Composition Card', () => <CompositionCard />)

--- a/src/components/primitives/Box/index.tsx
+++ b/src/components/primitives/Box/index.tsx
@@ -1,14 +1,14 @@
-import React, { memo, forwardRef } from 'react';
+import React, { forwardRef, memo } from 'react';
 import { View } from 'react-native';
+import { useNativeBaseConfig } from '../../../core/NativeBaseContext';
+import { useTheme } from '../../../hooks';
+import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
+import { useSafeArea } from '../../../hooks/useSafeArea';
 import { usePropsResolution } from '../../../hooks/useThemeProps';
 import { getColor } from '../../../theme';
-import { useTheme } from '../../../hooks';
 import { makeStyledComponent } from '../../../utils/styled';
 import { wrapStringChild } from '../../../utils/wrapStringChild';
-import type { IBoxProps, InterfaceBoxProps } from './types';
-import { useSafeArea } from '../../../hooks/useSafeArea';
-import { useNativeBaseConfig } from '../../../core/NativeBaseContext';
-import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
+import type { IBoxProps, InterfaceBoxProps, LinearGradientBaseProps, LinearGradientProps } from './types';
 
 const StyledBox = makeStyledComponent(View);
 
@@ -50,20 +50,43 @@ const Box = ({ children, ...props }: IBoxProps, ref: any) => {
       lgrad.colors = lgrad.colors?.map((color: string) => {
         return getColor(color, theme.colors, theme);
       });
-      let startObj = { x: 0, y: 0 };
-      let endObj = { x: 0, y: 1 };
-      if (lgrad.start && lgrad.start.length === 2) {
-        startObj = {
-          x: lgrad.start[0],
-          y: lgrad.start[1],
-        };
+
+      let linearGradientBaseProps: LinearGradientBaseProps = {
+        colors: lgrad.colors,
+        locations: lgrad.locations,
+      };
+
+      let linearGradientProps: LinearGradientProps;
+
+      if(lgrad.useAngle) {
+        linearGradientProps = {
+          ...linearGradientBaseProps,
+          useAngle: lgrad.useAngle,
+          angle: lgrad.angle,
+          angleCenter: lgrad.angleCenter,
+        }
+      } else {
+        let startObj = { x: 0, y: 0 };
+        let endObj = { x: 0, y: 1 };
+        if (lgrad.start && lgrad.start.length === 2) {
+          startObj = {
+            x: lgrad.start[0],
+            y: lgrad.start[1],
+          };
+        }
+        if (lgrad.end && lgrad.end.length === 2) {
+          endObj = {
+            x: lgrad.end[0],
+            y: lgrad.end[1],
+          };
+        }
+        linearGradientProps = {
+          ...linearGradientBaseProps,
+          start: startObj,
+          end: endObj,
+        }
       }
-      if (lgrad.end && lgrad.end.length === 2) {
-        endObj = {
-          x: lgrad.end[0],
-          y: lgrad.end[1],
-        };
-      }
+      
       const backgroundColorProps = [
         'bg',
         'bgColor',
@@ -79,10 +102,7 @@ const Box = ({ children, ...props }: IBoxProps, ref: any) => {
         <Gradient
           ref={ref}
           {...safeAreaProps}
-          colors={lgrad.colors}
-          start={startObj}
-          end={endObj}
-          locations={lgrad.locations}
+          {...linearGradientProps}
         >
           {/* {React.Children.map(children, (child) =>
             typeof child === 'string' || typeof child === 'number' ? (

--- a/src/components/primitives/Box/types.ts
+++ b/src/components/primitives/Box/types.ts
@@ -1,11 +1,9 @@
 import type { ViewProps } from 'react-native';
 import type { StyledProps } from '../../../theme/types';
 import type {
-  SafeAreaProps,
-  PlatformProps,
-  ResponsiveValue,
   ColorType,
-  CustomProps,
+  CustomProps, PlatformProps,
+  ResponsiveValue, SafeAreaProps
 } from '../../types';
 import type { ITextProps } from './../Text/types';
 
@@ -47,3 +45,32 @@ export interface InterfaceBoxProps<T = null>
 }
 
 export type IBoxProps<T = null> = InterfaceBoxProps<T> & CustomProps<'Box'>;
+
+export type LinearGradientProps = LinearGradientBaseProps & (
+  LinearGradientPropsStartEnd | LinearGradientPropsAngle
+);
+
+export type LinearGradientBaseProps = {
+  colors: string[];
+  locations: number[];
+}
+
+export type LinearGradientPropsStartEnd = {
+  start: {
+    x: number;
+    y: number;
+  };
+  end: {
+    x: number;
+    y: number;
+  };
+};
+
+export type LinearGradientPropsAngle = {
+  useAngle: boolean;
+  angle: number;
+  angleCenter: {
+    x: number;
+    y: number;
+  };
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Adds (optional) support for `useAngle` `angle` and `angleCenter` props for `LinearGradient`.

closes #5538 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->
[General] [Added] - Add support for angle props in `LinearGradient`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I've added a storybook example

```jsx
export const ExampleWithAngle = () => {
  return (
    <Box
      bg={{
        linearGradient: {
          colors: ['lightBlue.300', 'violet.800'],
          angle: 45,
          angleCenter: { x: 0.5, y: 0.5},
        },
      }}
      p="12"
      w="72"
      rounded="xl"
      _text={{
        fontSize: 'md',
        fontWeight: 'medium',
        color: 'warmGray.50',
        textAlign: 'center',
      }}
    >
      This is a Box with Linear Gradient using angle props
    </Box>
  );
}
```