### PR TITLE
Update hooks.tsx

### DIFF
--- a/src/core/color-mode/hooks.tsx
+++ b/src/core/color-mode/hooks.tsx
@@ -22,7 +22,7 @@ export const useColorMode = (): IColorModeContextProps => {
   return colorModeContext;
 };
 
-export function useColorModeValue(light: any, dark: any) {
+export function useColorModeValue<ValueType>(light: ValueType, dark: ValueType) {
   const { colorMode } = useColorMode();
   return colorMode === 'dark' ? dark : light;
 }


### PR DESCRIPTION
## Summary

Issue:
If use hook `useColorModeValue`, the return type is always `any`.
So, developer need to parse to type they want.
e.g:
```typescript
const textColor = useColorModeValue("dark.900", "light.900"); // type of textColor is any
```
Parse to string
```typescript
const textColor = useColorModeValue("dark.900", "light.900") as string; // type of textColor is string now
```

Solution:
Add generic type for params of hook `useColorModeValue`
This will make the hook return type is specific instead of `any`

## Changelog

Add generic type for params of hook `useColorModeValue`

## Test Plan

Before:
```typescript
const textColor = useColorModeValue("dark.900", "light.900"); // type of textColor is any
```
After:
```typescript
const textColor = useColorModeValue("dark.900", "light.900"); // type of textColor is string
```
