### PR TITLE
fix: Tooltip may get null targetRef on Android

### DIFF
--- a/src/components/composites/Tooltip/Tooltip.tsx
+++ b/src/components/composites/Tooltip/Tooltip.tsx
@@ -120,6 +120,9 @@ export const Tooltip = ({
     'ref': mergeRefs([newChildren.ref, targetRef]),
 
     'aria-describedby': isOpen ? tooltipID : undefined,
+    
+    // to avoid null targetRef on android
+    'collapsable': false,
   });
 
   useKeyboardDismissable({


### PR DESCRIPTION
Tooltip should override the children view with `collapsable={false}`, otherwise it may never get a valid `targetRef`, which breaks the tooltip component and leads to a measuring dead loop 