### PR TITLE
Fix: tooltip's prop offset is rewritten by default value

### DIFF
--- a/src/components/composites/Tooltip/Tooltip.tsx
+++ b/src/components/composites/Tooltip/Tooltip.tsx
@@ -32,9 +32,7 @@ export const Tooltip = ({
 }: ITooltipProps) => {
   if (hasArrow && offset === undefined) {
     offset = 0;
-  } else {
-    offset = 6;
-  }
+  } 
 
   const resolvedProps = usePropsResolution('Tooltip', props);
   const [isOpen, setIsOpen] = useControllableState({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I tried to set up the tooltip prop offset and this was rewritten by default value 6

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
