### PR TITLE
fix: use "base" fontFamily in web

### DIFF
--- a/src/hooks/useResolvedFontFamily.web.ts
+++ b/src/hooks/useResolvedFontFamily.web.ts
@@ -1,0 +1,18 @@
+import type { ITheme } from '../theme';
+/**
+ *
+ * @param props
+ * @returns resolved fontFamily
+ * @description Combination of fontWeight, fontStyle and font family is fully supported on web but on Android we need to pass the exact font family.
+ * for e.g. If we load Roboto-Light-Italic.ttf using css, we can use fontFamily: Roboto, fontWeight: 300, fontStyle: italic on web, but same may not work on all the platforms. Other platform needs to set fontFamily: Roboto-Light-Italic in order to work.
+ * So this function's purpose is to intake styles like fontFamily: Roboto, fontWeight: 300, fontStyle: Italic and return fontFamily: Roboto-Light-Italic depending upon the fontConfig token in typography theme.
+ * This function depends upon fontConfig token in typography for mapping.
+ */
+export function useResolvedFontFamily(props: {
+  fontFamily?: keyof ITheme['fonts'];
+  fontStyle?: string;
+  fontWeight?: keyof ITheme['fontWeights'];
+}) {
+  const { fontFamily, fontStyle, fontWeight } = props;
+  return { fontFamily, fontStyle, fontWeight };
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The fontFamily prop generated currently looks like `FontName-MediumItalic`. This is generally how it's expected by react-native, but not how a browser would expect it. On web, the font family is generally only `FontName` and other props such as `fontWeight` are used in conjunction. This disables the logic to generate this "compound" fontFamily for web.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Web] [Changed] - Use normal fontFamily in web

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I ran the testbed and checked the Text stories to see if something broke.
