### PR TITLE
fix `Image.getSize` typing

### DIFF
--- a/src/components/primitives/Image/index.tsx
+++ b/src/components/primitives/Image/index.tsx
@@ -97,7 +97,7 @@ const Image = memo(
 );
 
 interface ImageStatics {
-  getSize: typeof RNImage.prefetch;
+  getSize: typeof RNImage.getSize;
   prefetch: typeof RNImage.prefetch;
   queryCache: typeof RNImage.queryCache;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fixes typing for `Image.getSize`.

## Changelog

[fix] [types] - Fix `Image.getSize` typing

## Test Plan

No tests written due to the nature of the fix.
