### PR TITLE
refactor: replaces use-subscription with use-sync-external-store

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      # If you wish to fail your job when the Quality Gate is red, uncomment the
+      # following lines. This would typically be used to fail a deployment.
+      # - uses: sonarsource/sonarqube-quality-gate-action@master
+      #   timeout-minutes: 5
+      #   env:
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ NativeBase 3.0 is a rich component library with nearly 40 components.
 
 JavaScript, React Native, Styled System
 
+### Made with :heart: at [GeekyAnts](https://geekyants.com/?utm_source=nb-github&utm_medium=landing+page&utm_campaign=nativebase-github-cta)
+NativeBase is an open-source project made by the tech-savvy geeks at GeekyAnts.
+GeekyAnts is a group of React Native experts. Do [get in touch with us](https://geekyants.com/hire/?utm_source=nb-github&utm_medium=landing+page&utm_campaign=nativebase-github-hire-cta) for any help with your React Native project. Always happy to help!
+
+
 ## 10. Compatible Versions
 
 | NativeBase                       | React Native                                               |
@@ -187,3 +192,4 @@ Support this project with your organization. Your logo will show up here with a 
 ## 14. License
 
 Licensed under the MIT License, Copyright © 2021 GeekyAnts. See [LICENSE](https://github.com/GeekyAnts/NativeBase/blob/master/LICENSE) for more information.
+

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@types/react": "^16.9.19",
     "@types/react-native": "~0.63.2",
     "@types/tinycolor2": "^1.4.2",
-    "@types/use-subscription": "^1.0.0",
+    "@types/use-sync-external-store": "^0.0.3",
     "babel-plugin-transform-remove-console": "^6.9.4",
     "commitlint": "^8.3.5",
     "eslint": "^7.10.0",
@@ -209,7 +209,7 @@
     "lodash.pick": "^4.4.0",
     "stable-hash": "^0.0.2",
     "tinycolor2": "^1.4.2",
-    "use-subscription": "^1.8.0"
+    "use-sync-external-store": "^1.2.0"
   },
   "directories": {
     "example": "example",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.projectKey=GeekyAnts_NativeBase_AYYLs_jd-qOzU22UD5wX

--- a/src/core/color-mode/hooks.tsx
+++ b/src/core/color-mode/hooks.tsx
@@ -7,7 +7,8 @@ import type {
 import { HybridContext } from './../hybrid-overlay/Context';
 import type { IHybridContextProps } from './../hybrid-overlay/types';
 import { AppState, useColorScheme as _useColorScheme } from 'react-native';
-import { useSubscription } from 'use-subscription';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
+
 import { useNativeBaseConfig } from '../NativeBaseContext';
 
 export const useColorMode = (): IColorModeContextProps => {
@@ -56,7 +57,11 @@ export const useAppState = () => {
     // This if statement technically breaks the rules of hooks, but is safe
     // because the condition never changes after mounting.
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useSubscription(subscription);
+    return useSyncExternalStore(
+      subscription.subscribe,
+      subscription.getCurrentValue,
+      subscription.getCurrentValue
+    );
   }
 };
 
@@ -100,7 +105,7 @@ export function useModeManager(
   useEffect(() => {
     if (colorModeManager) {
       (async function getMode() {
-        let value = await colorModeManager.get(initialColorMode);
+        const value = await colorModeManager.get(initialColorMode);
         if (value && value !== colorMode) {
           setRawMode(value);
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3356,6 +3356,11 @@
   resolved "https://registry.yarnpkg.com/@types/use-subscription/-/use-subscription-1.0.0.tgz#d146f8d834f70f50d48bd8246a481d096f11db19"
   integrity sha512-0WWZ5GUDKMXUY/1zy4Ur5/zsC0s/B+JjXfHdkvx6JgDNZzZV5eW+KKhDqsTGyqX56uh99gwGwbsKbVwkcVIKQA==
 
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"


### PR DESCRIPTION
migrates to use-sync-external-store to support react 18 and nextjs

## Summary

React 18.x and nextjs 13.x raises the error 
```
Error: Missing getServerSnapshot, which is required for server-rendered content. Will revert to client rendering.
This error happened while generating the page. Any console logs will be displayed in the terminal window.
```
Applying the same upgrade that nextjs applied to native-base fixes the error
https://github.com/vercel/next.js/pull/36733/files

## Changelog

[refactor] [Changed] - Migrate to use-sync-external-store from use-subscription

## Test Plan

Upgrading a project to react 18 and nextjs 13 resolves the error
