### PR TITLE
fix: added 'animating' prop to spinner component

### DIFF
--- a/src/components/primitives/Spinner/index.tsx
+++ b/src/components/primitives/Spinner/index.tsx
@@ -10,10 +10,14 @@ import { useHasResponsiveProps } from '../../../hooks/useHasResponsiveProps';
 import { useTheme } from '../../../hooks';
 
 const Spinner = (props: ISpinnerProps, ref: any) => {
-  const { color, size, style, testID, ...resolvedProps } = usePropsResolution(
-    'Spinner',
-    props
-  );
+  const {
+    color,
+    size,
+    style,
+    testID,
+    animating,
+    ...resolvedProps
+  } = usePropsResolution('Spinner', props);
   const resolvedColor = getColor(color, useTheme().colors, useTheme());
   const resolvedStyle = useStyledSystemPropsResolver(resolvedProps);
   //TODO: refactor for responsive prop
@@ -30,6 +34,7 @@ const Spinner = (props: ISpinnerProps, ref: any) => {
       ref={ref}
       size={size}
       style={[resolvedStyle, style]}
+      animating={animating}
     />
   );
 };

--- a/src/components/primitives/Spinner/types.tsx
+++ b/src/components/primitives/Spinner/types.tsx
@@ -11,6 +11,7 @@ export interface InterfaceSpinnerProps
    * Size of Spinner
    */
   size?: ThemeComponentSizeType<'Spinner'>;
+  animating?: boolean;
 
   // variant?:
   //   | 'custom'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Added animating prop to activity indicator of the spinner component as mentioned in the issue [#5642](https://github.com/GeekyAnts/NativeBase/issues/5642)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->
[General] [Added] - Added 'animating' prop to spinner component.

## Test Plan
set the animating prop to false in the spinner component and it will disappear.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
