### PR TITLE
Removes selection prop on select input on safari

### DIFF
--- a/src/components/primitives/Select/Select.tsx
+++ b/src/components/primitives/Select/Select.tsx
@@ -154,6 +154,8 @@ const Select = (
     'shadow',
     'opacity',
   ]);
+  
+  const isSafari = Platform.OS === 'web' && window.safari
 
   const commonInput = (
     <Input
@@ -172,6 +174,7 @@ const Select = (
       isDisabled={isDisabled}
       pointerEvents="none"
       variant={variant}
+      selection={isSafari ? undefined : nonLayoutProps.selection}
     />
   );
 


### PR DESCRIPTION
Fixes #5111

## Summary
When a Select is present on a form rendered on Safari (both iOS and Mac tested), every change in ANY input (even others than the Select) causes the screen to focus on the select input and loses focus on the changing input.

This PR aims to fix #5111 . There's a minimal reproduction of the problem this PR solves in this issue.


