### PR TITLE
fix: divider basic example

### DIFF
--- a/example/storybook/stories/components/composites/Divider/Basic.tsx
+++ b/example/storybook/stories/components/composites/Divider/Basic.tsx
@@ -5,7 +5,7 @@ export const Example = () => {
   return (
     <Box alignItems="center">
       <Box w="140">
-        <Heading mx="3" alignItems="center" flexDirection="row">
+        <Heading mx="3" alignItems="center" flexDirection="row" textAlign="center">
           Chrome
         </Heading>
         <Divider
@@ -13,7 +13,7 @@ export const Example = () => {
           _light={{ bg: 'muted.800' }}
           _dark={{ bg: 'muted.50' }}
         />
-        <Heading mx="3" alignItems="center" flexDirection="row">
+        <Heading mx="3" alignItems="center" flexDirection="row" textAlign="center">
           Firefox
         </Heading>
       </Box>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Seeing uncentered text/objects is very unpleasing to the eye. Hence I simply aligned the text in the basic example code of the Divider section.

## Changelog

[General] [Fixed] - Fixed divider basic example code

## Test Plan

I tested the code via the Playground in the docs.



