### PR TITLE
fix: prevent unnecessary AppState listener warning on some react-native versions

### DIFF
--- a/src/core/color-mode/hooks.tsx
+++ b/src/core/color-mode/hooks.tsx
@@ -33,15 +33,16 @@ export const useAppState = () => {
     () => ({
       getCurrentValue: () => AppState.currentState,
       subscribe: (callback: () => void) => {
-        const subsription = AppState.addEventListener('change', callback);
+        const subscription = AppState.addEventListener('change', callback);
+
         return () => {
-          if (AppState.removeEventListener) {
+          if (Object.prototype.hasOwnProperty.call(subscription, 'remove')) {
+            // React Native >= 0.65
+            /* @ts-ignore ignoring ts error as devDependency contains "@types/react-native" < 0.65 */
+            subscription.remove();
+          } else {
             // React Native < 0.65
             AppState.removeEventListener('change', callback);
-          } else {
-            // React Native >= 0.65
-            // @ts-ignore:next-line ignoring ts error as devDependency contains "@types/react-native" < 0.65
-            subsription.remove();
           }
         };
       },


### PR DESCRIPTION
## Summary

On older React Native versions (between 0.65 and 0.69), the AppState.removeEventListener method exists.
The previous query is `true` and the method is called, but issues a warning that this method is deprecated.
This code change prioritizes checking whether subscription.remove exists.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fix] - prevent unnecessary AppState listener warning on some react-native versions