### PR TITLE
fix: make useResolvedFonts consistent with documentation

### DIFF
--- a/src/hooks/useResolvedFontFamily.ts
+++ b/src/hooks/useResolvedFontFamily.ts
@@ -20,7 +20,7 @@ export function useResolvedFontFamily(props: {
   let newFontWeight = fontWeight;
 
   const { fontConfig, fontWeights, fonts } = useTheme();
-  if (fontWeight && fontStyle && fontFamily && fontFamily in fonts) {
+  if (fontWeight && fontStyle && fontFamily && fontFamily in fontConfig) {
     // TODO: Fix typing remove any.
     const fontToken: any = fonts[fontFamily];
     if (fontConfig && fontConfig[fontToken]) {


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency between `useResolvedFontFamily` and the documentation & examples.

To use a custom font, the documentation suggests that a property needs to be added to `theme.fontConfig` mapping all the font weights and styles to specific font files.

The `useResolvedFontFamily` implementation, however, [on line 23](https://github.com/GeekyAnts/NativeBase/blob/master/src/hooks/useResolvedFontFamily.ts#L23), suggests that a property also needs to be added to `theme.fonts` which is inconsistent with the documentation.

As documented, if I wanted to add `SF Pro Display` as a custom font, I would do:

```
const fonts = {
  heading: 'SF Pro Display',
  body: 'SF Pro Display',
  monospace: undefined,
}

const fontConfig = {
  'SF Pro Display': {
    400: {
      normal: 'SF Pro Display Regular',
      itallc: 'SF Pro Display Regular Italic',
    },
    ....
  }
}

const theme = extendTheme({
  fonts,
  fontConfig,
});
```

But nowhere does it suggest I need to update `fonts`, adding a property with `SF Pro Display` as a key.  Unless I were to do that, line 23 of `useResolvedFontFamily` always evaluates to `false` and this hook never properly does its job to map fonts to the correct value for Android and iOS.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

General Fixed - Correct an inconsistency between useResolvedFontFamily and the documentation for using custom fonts

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
