### PR TITLE
fix: stop actionsheet preventing interaction with content behind

### DIFF
--- a/src/components/composites/Actionsheet/Actionsheet.tsx
+++ b/src/components/composites/Actionsheet/Actionsheet.tsx
@@ -31,6 +31,7 @@ const Actionsheet = (
       {...resolvedProps}
       overlayVisible={disableOverlay ? false : true}
       closeOnOverlayClick={disableOverlay ? false : true}
+      useRNModalOnAndroid={disableOverlay ? false : true}
       ref={ref}
       _overlay={{ style: overlayStyle }}
     >

--- a/src/components/composites/Modal/Modal.tsx
+++ b/src/components/composites/Modal/Modal.tsx
@@ -39,6 +39,7 @@ const Modal = (
     _slide,
     _overlay,
     useRNModal,
+    useRNModalOnAndroid = true,
     ...resolvedProps
   } = usePropsResolution('Modal', rest);
 
@@ -84,7 +85,7 @@ const Modal = (
       onRequestClose={handleClose}
       isKeyboardDismissable={isKeyboardDismissable}
       animationPreset={animationPreset}
-      useRNModalOnAndroid
+      useRNModalOnAndroid={useRNModalOnAndroid}
       useRNModal={useRNModal}
       {..._overlay}
     >

--- a/src/components/composites/Modal/types.ts
+++ b/src/components/composites/Modal/types.ts
@@ -86,6 +86,12 @@ export interface InterfaceModalProps extends InterfaceBoxProps<IModalProps> {
    * @default false
    */
   useRNModal?: boolean;
+  /**
+   * If true, renders react-native native modal (android only)
+   * We use RN modal on android if needed as it supports shifting accessiblity focus to the opened view. IOS automatically shifts focus if an absolutely placed view appears in front.
+   * @default true
+   */
+  useRNModalOnAndroid?: boolean;
 }
 
 export type IModalComponentType = ((


### PR DESCRIPTION
Modal - add optional prop useRNModalOnAndroid
Actionsheet - if disableOverlay, pass useRNModalOnAndroid=false to Modal

## Summary

https://github.com/GeekyAnts/NativeBase/issues/5734

## Changelog

Android Fixed - Allow click through from Actionsheet when disableOverlay set
General Changed - Modal: Added optional property useRNModalOnAndroid (defaults to true)

## Test Plan
![Peek 2023-07-27 16-22](https://github.com/GeekyAnts/NativeBase/assets/7941695/8260828e-02d5-413e-91b9-d7315877018e)

