### PR TITLE
Fix SSRProvider issue on React 18+

### DIFF
--- a/src/core/NativeBaseProvider.tsx
+++ b/src/core/NativeBaseProvider.tsx
@@ -94,7 +94,7 @@ const NativeBaseProvider = (props: NativeBaseProviderProps) => {
             <OverlayProvider isSSR>
               <ToastProvider>
                 <InitializeToastRef />
-                <SSRProvider>{children}</SSRProvider>
+                {React.version >= '18' ? children : <SSRProvider>{children}</SSRProvider>}
               </ToastProvider>
             </OverlayProvider>
           </HybridProvider>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I've just started using React Native and chose NativeBase as UI library, however it seems that it has bug for the version 18+ of React, which couple people mentioned in Issues and even made PRs, however they were closed for some unknown reason and the error is still there, so I've made this pull request in order to solve the SSRProvider bug ( terminal: ` WARN  In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.  ` )
