### PR TITLE
chore: replaced deprecated Clipboard to @react-native-clipboard/clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
     "@react-native-aria/slider": "^0.2.5-alpha.1",
     "@react-native-aria/tabs": "^0.2.7",
     "@react-native-aria/utils": "^0.2.8",
+    "@react-native-clipboard/clipboard": "^1.14.1",
     "@react-stately/checkbox": "3.0.3",
     "@react-stately/collections": "3.3.0",
     "@react-stately/combobox": "3.0.0-alpha.1",

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -1,12 +1,13 @@
 import React from 'react';
-import { Clipboard } from 'react-native';
+// import { Clipboard } from 'react-native'; 'Clipboard' is deprecated.
+import Clipboard from '@react-native-clipboard/clipboard';
 
 export function useClipboard() {
   const [hasCopied, setHasCopied] = React.useState(false);
   const [value, setValue] = React.useState<string>('');
-  const onCopy = async (copiedValue: string) => {
+  const onCopy = (copiedValue: string) => {
     if (Clipboard) {
-      await Clipboard.setString(copiedValue);
+      Clipboard.setString(copiedValue);
     }
     setValue(copiedValue);
     setHasCopied(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2415,6 +2415,11 @@
     "@react-aria/ssr" "^3.0.1"
     "@react-aria/utils" "^3.3.0"
 
+"@react-native-clipboard/clipboard@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.14.1.tgz#835f82fc86881a0808a8405f2576617bb5383554"
+  integrity sha512-SM3el0A28SwoeJljVNhF217o0nI4E7RfalLmuRQcT1/7tGcxUjgFa3jyrEndYUct8/uxxK5EUNGUu1YEDqzxqw==
+
 "@react-native-community/bob@^0.16.2":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@react-native-community/bob/-/bob-0.16.2.tgz#9102b0160e70084fa1b75403a80dec332647c950"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The Clipboard from 'react-native' is deprecated

<img width="943" alt="react native clipboard removed" src="https://github.com/GeekyAnts/NativeBase/assets/140485131/f7e68075-76fa-4d86-808c-61776905f633">

I added the [@react-native-clipboard/clipboard](https://www.npmjs.com/package/@react-native-clipboard/clipboard) library and updated the code in src\hooks\useClipboard.ts.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

Internal Deprecated - Replaced the deprecated Clipboard

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

```
yarn test

Test Suites: 7 failed, 7 passed, 14 total
Tests:       29 passed, 29 total
Snapshots:   0 total
Time:        7.396s, estimated 13s
Ran all test suites.

```